### PR TITLE
refactor selection, trigger, and deny-list handling

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content.css", "dictionary/parser.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content.css", "dictionary/parser.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content.css", "dictionary/parser.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content.css", "dictionary/parser.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/content-interaction.mjs
+++ b/src/content-interaction.mjs
@@ -1,0 +1,305 @@
+const DEFAULT_SELECTION_DISTANCE = 8
+
+function getNavigatorPlatform() {
+  if (typeof navigator === 'undefined') {
+    return ''
+  }
+
+  return navigator.userAgentData?.platform || navigator.platform || ''
+}
+
+export function isMacPlatform(platform = getNavigatorPlatform()) {
+  return /mac/i.test(String(platform))
+}
+
+/**
+ * Normalize text copied from a Selection without destroying meaningful line
+ * breaks. Non-breaking spaces and zero-width characters are common in page
+ * text, but should not make an otherwise empty selection look non-empty.
+ */
+export function normalizeSelectionText(value) {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  return String(value)
+    .replace(/[\u200B-\u200D\uFEFF]/g, '')
+    .replace(/\u00A0/g, ' ')
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map(line => line.replace(/[\t\f\v ]+/g, ' ').trim())
+    .join('\n')
+    .trim()
+}
+
+export function getSelectionText(selection) {
+  if (!selection || !selection.rangeCount) {
+    return ''
+  }
+
+  let value = ''
+
+  if (
+    typeof selection.toString === 'function' &&
+    selection.toString !== Object.prototype.toString
+  ) {
+    try {
+      value = selection.toString()
+    } catch (_error) {
+      // Continue with the range fallback below.
+    }
+  }
+
+  try {
+    if (!value) {
+      const range = selection.getRangeAt(0)
+      value = range?.cloneContents?.().textContent || ''
+    }
+  } catch (_error) {
+    // A selection can disappear between mouseup and getRangeAt(). Treat it
+    // as empty rather than allowing the event handler to throw.
+  }
+
+  return normalizeSelectionText(value)
+}
+
+export function getDictionaryQuery(value) {
+  const text = normalizeSelectionText(value)
+
+  if (!text || !/^[A-Za-z]/.test(text)) {
+    return ''
+  }
+
+  // Keep the existing dictionary behaviour: a short English phrase may be
+  // searched, while a dragged paragraph belongs to translation instead.
+  if (text.split(/\s+/).length >= 6) {
+    return ''
+  }
+
+  // Dictionary queries are single search strings; keep paragraph line breaks
+  // for translation, but turn them into ordinary spaces for lookup.
+  return text.replace(/\s+/g, ' ').toLowerCase()
+}
+
+/**
+ * Check the modifier combination configured by the user.
+ *
+ * "ctrl" means Ctrl on Windows/Linux and Command on macOS. Unknown values
+ * intentionally fall back to "none", matching the option defaults.
+ */
+export function checkTrigger(event = {}, key = 'none', platform = getNavigatorPlatform()) {
+  const ctrlPressed = Boolean(event?.ctrlKey)
+  const metaPressed = Boolean(event?.metaKey)
+  const altPressed = Boolean(event?.altKey)
+  const mac = isMacPlatform(platform)
+  const primaryPressed = mac ? metaPressed : ctrlPressed
+  const secondaryControlPressed = mac ? ctrlPressed : metaPressed
+
+  switch (key) {
+    case 'ctrl':
+      return primaryPressed && !secondaryControlPressed && !altPressed
+    case 'alt':
+      return altPressed && !ctrlPressed && !metaPressed
+    case 'ctrlalt':
+      return primaryPressed && !secondaryControlPressed && altPressed
+    case 'none':
+    default:
+      return !ctrlPressed && !metaPressed && !altPressed
+  }
+}
+
+function normalizeHost(value) {
+  if (value === null || value === undefined) {
+    return ''
+  }
+
+  let candidate = String(value).trim().toLowerCase()
+  if (!candidate) {
+    return ''
+  }
+
+  candidate = candidate.replace(/^\*\./, '')
+
+  try {
+    const url = /^[a-z][a-z\d+.-]*:\/\//i.test(candidate)
+      ? new URL(candidate)
+      : new URL(`http://${candidate}`)
+    return url.hostname.toLowerCase().replace(/^\.+|\.+$/g, '')
+  } catch (_error) {
+    // Keep malformed entries harmless and useful as simple host names.
+    return candidate
+      .split(/[/?#]/, 1)[0]
+      .replace(/:\d+$/, '')
+      .replace(/^\.+|\.+$/g, '')
+  }
+}
+
+export function normalizeDenyList(value) {
+  const entries = Array.isArray(value)
+    ? value
+    : String(value ?? '').split(/[,;\n]+/)
+
+  return entries
+    .map(normalizeHost)
+    .filter(Boolean)
+}
+
+/**
+ * Return true for an exact host match or a subdomain match. Using a label
+ * boundary avoids accidentally denying `not-example.com` for `example.com`.
+ */
+export function isDeniedSite(host, denyList, enabled = true) {
+  if (!enabled) {
+    return false
+  }
+
+  const currentHost = normalizeHost(host)
+  if (!currentHost) {
+    return false
+  }
+
+  return normalizeDenyList(denyList).some(entry => (
+    currentHost === entry || currentHost.endsWith(`.${entry}`)
+  ))
+}
+
+function getCoordinate(event, primary, fallback) {
+  const value = event?.[primary]
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+
+  const fallbackValue = event?.[fallback]
+  return typeof fallbackValue === 'number' && Number.isFinite(fallbackValue)
+    ? fallbackValue
+    : 0
+}
+
+/**
+ * Attach the mouse interaction for one document/frame.
+ *
+ * The returned destroy() function is deliberately part of the API. A content
+ * script can then replace its configuration without ever stacking handlers
+ * on the same document.
+ */
+export function createInteractionController(options, dependencies = {}) {
+  const config = options || {}
+  const target = dependencies.target
+  const openPopup = dependencies.openPopup || (() => {})
+  const removePopup = dependencies.removePopup || (() => {})
+  const triggerMatches = dependencies.checkTrigger || checkTrigger
+  const selectionDistance = dependencies.selectionDistance ?? DEFAULT_SELECTION_DISTANCE
+
+  if (!target || typeof target.addEventListener !== 'function') {
+    return { destroy() {} }
+  }
+
+  let mouseDown = false
+  let moved = false
+  let startX = 0
+  let startY = 0
+  let clickCount = 0
+  let clickTimeout = null
+  let destroyed = false
+
+  function resetClickSequence() {
+    clickCount = 0
+    if (clickTimeout !== null) {
+      clearTimeout(clickTimeout)
+      clickTimeout = null
+    }
+  }
+
+  function resetPointer() {
+    mouseDown = false
+    moved = false
+  }
+
+  function onMouseDown(event) {
+    if (event.button !== undefined && event.button !== 0) {
+      return
+    }
+
+    mouseDown = true
+    moved = false
+    startX = getCoordinate(event, 'clientX', 'pageX')
+    startY = getCoordinate(event, 'clientY', 'pageY')
+  }
+
+  function onMouseMove(event) {
+    if (!mouseDown) {
+      return
+    }
+
+    const currentX = getCoordinate(event, 'clientX', 'pageX')
+    const currentY = getCoordinate(event, 'clientY', 'pageY')
+    const distance = Math.hypot(currentX - startX, currentY - startY)
+
+    if (distance > selectionDistance) {
+      moved = true
+    }
+  }
+
+  function onMouseUp(event) {
+    if (!mouseDown) {
+      return
+    }
+
+    const wasMoved = moved
+    resetPointer()
+
+    if (wasMoved) {
+      resetClickSequence()
+
+      if (config.drag && triggerMatches(event, config.drag_trigger_key)) {
+        removePopup()
+        openPopup(event)
+      } else if (config.translate && triggerMatches(event, config.translate_trigger_key)) {
+        removePopup()
+        openPopup(event, config.deepl_auth_key, 'translate')
+      } else {
+        removePopup()
+      }
+      return
+    }
+
+    if (!config.dclick || !triggerMatches(event, config.dclick_trigger_key)) {
+      resetClickSequence()
+      removePopup()
+      return
+    }
+
+    removePopup()
+    clickCount += 1
+
+    if (clickCount === 1) {
+      clickTimeout = setTimeout(() => {
+        clickCount = 0
+        clickTimeout = null
+      }, Number(config.dclick_speed) || 0)
+      return
+    }
+
+    resetClickSequence()
+    openPopup(event)
+  }
+
+  target.addEventListener('mousedown', onMouseDown)
+  target.addEventListener('mousemove', onMouseMove)
+  target.addEventListener('mouseup', onMouseUp)
+
+  return {
+    destroy() {
+      if (destroyed) {
+        return
+      }
+
+      destroyed = true
+      target.removeEventListener?.('mousedown', onMouseDown)
+      target.removeEventListener?.('mousemove', onMouseMove)
+      target.removeEventListener?.('mouseup', onMouseUp)
+      resetPointer()
+      resetClickSequence()
+    }
+  }
+}

--- a/src/content-storage.mjs
+++ b/src/content-storage.mjs
@@ -1,0 +1,103 @@
+/**
+ * Keep the content-script configuration in sync with chrome.storage.
+ *
+ * Reads are versioned so an older async callback cannot overwrite a newer
+ * storage change. Every change re-reads the complete settings object instead
+ * of merging a partial change into defaults while the initial read is still
+ * pending.
+ */
+export function createStorageLifecycle({storage, defaults, onApply}) {
+  let listener = null
+  let started = false
+  let revision = 0
+  let currentItems = {...defaults}
+
+  function readLatest() {
+    const revisionAtRequest = revision
+
+    storage.sync.get(defaults, items => {
+      if (revisionAtRequest !== revision) {
+        return
+      }
+
+      currentItems = {...defaults, ...(items || {})}
+      onApply(currentItems)
+    })
+  }
+
+  function applyChangedValues(changes) {
+    const nextItems = {...currentItems}
+
+    Object.keys(changes || {}).forEach(key => {
+      if (!(key in defaults)) {
+        return
+      }
+
+      const change = changes[key]
+      nextItems[key] = change?.newValue === undefined
+        ? defaults[key]
+        : change.newValue
+    })
+
+    currentItems = nextItems
+    onApply(currentItems)
+  }
+
+  function handleStorageChange(changes, areaName) {
+    if (areaName && areaName !== 'sync') {
+      return
+    }
+
+    const hasRelevantChange = Object.keys(changes || {}).some(key => key in defaults)
+    if (!hasRelevantChange) {
+      return
+    }
+
+    revision += 1
+
+    if (storage.sync?.get) {
+      readLatest()
+      return
+    }
+
+    // This fallback is only for lightweight/test storage implementations.
+    // Chrome's sync storage always exposes get(), so production changes use
+    // the complete reread above.
+    applyChangedValues(changes)
+  }
+
+  function start() {
+    if (started) {
+      return
+    }
+
+    started = true
+
+    if (storage?.onChanged?.addListener) {
+      listener = handleStorageChange
+      storage.onChanged.addListener(listener)
+    }
+
+    if (storage?.sync?.get) {
+      readLatest()
+      return
+    }
+
+    currentItems = {...defaults}
+    onApply(currentItems)
+  }
+
+  function stop() {
+    revision += 1
+
+    if (listener && storage?.onChanged?.removeListener) {
+      storage.onChanged.removeListener(listener)
+    }
+
+    listener = null
+    started = false
+    currentItems = {...defaults}
+  }
+
+  return {start, stop}
+}

--- a/src/content.js
+++ b/src/content.js
@@ -6,6 +6,7 @@ import {
   getSelectionText,
   isDeniedSite
 } from './content-interaction.mjs'
+import { createStorageLifecycle } from './content-storage.mjs'
 
 export const DEFAULT_OPTIONS = {
   DCLICK: true,
@@ -48,10 +49,7 @@ export const STORAGE_DEFAULTS = {
 }
 
 let activeInteractionController = null
-let storageChangeListener = null
-let eventRegistrationStarted = false
-let optionsRevision = 0
-let currentItems = {...STORAGE_DEFAULTS}
+let storageLifecycle = null
 
 
 function appendTextWithLineBreaks(element, value) {
@@ -239,7 +237,6 @@ function removePopup() {
 
 function applyOptions(items) {
   const nextItems = {...STORAGE_DEFAULTS, ...(items || {})}
-  currentItems = nextItems
 
   activeInteractionController?.destroy()
   activeInteractionController = null
@@ -269,75 +266,26 @@ function applyOptions(items) {
   })
 }
 
-function registerStorageChangeListener(storage) {
-  if (storageChangeListener || !storage?.onChanged?.addListener) {
-    return
-  }
-
-  storageChangeListener = (changes, areaName) => {
-    if (areaName && areaName !== 'sync') {
-      return
-    }
-
-    const relevantChanges = Object.keys(changes || {}).filter(key => key in STORAGE_DEFAULTS)
-    if (relevantChanges.length === 0) {
-      return
-    }
-
-    optionsRevision += 1
-    const nextItems = {...currentItems}
-    relevantChanges.forEach(key => {
-      const change = changes[key]
-      nextItems[key] = change?.newValue === undefined
-        ? STORAGE_DEFAULTS[key]
-        : change.newValue
-    })
-    applyOptions(nextItems)
-  }
-
-  storage.onChanged.addListener(storageChangeListener)
-}
-
 export function unregisterEventListener() {
-  optionsRevision += 1
+  storageLifecycle?.stop()
+  storageLifecycle = null
   activeInteractionController?.destroy()
   activeInteractionController = null
-
-  if (storageChangeListener && typeof chrome !== 'undefined') {
-    chrome.storage?.onChanged?.removeListener?.(storageChangeListener)
-  }
-
-  storageChangeListener = null
-  eventRegistrationStarted = false
-  currentItems = {...STORAGE_DEFAULTS}
   removePopup()
 }
 
 export function registerEventListener() {
-  if (eventRegistrationStarted) {
+  if (storageLifecycle) {
     return
   }
 
-  eventRegistrationStarted = true
   const storage = typeof chrome === 'undefined' ? null : chrome.storage
-  const syncStorage = storage?.sync
-
-  registerStorageChangeListener(storage)
-
-  if (!syncStorage?.get) {
-    applyOptions(STORAGE_DEFAULTS)
-    return
-  }
-
-  const revisionAtRequest = optionsRevision
-  syncStorage.get(STORAGE_DEFAULTS, items => {
-    // A storage update may arrive before this asynchronous initial read.
-    // Do not let the stale read rebind an older configuration.
-    if (revisionAtRequest !== optionsRevision) {
-      return
-    }
-    applyOptions(items)
+  storageLifecycle = createStorageLifecycle({
+    storage,
+    defaults: STORAGE_DEFAULTS,
+    onApply: applyOptions
   })
+  storageLifecycle.start()
 }
 
 export function main() {

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,11 @@
 import { buildNaverApiUrl, parseNaverDictionaryResponse } from './dictionary/parser.mjs'
+import {
+  checkTrigger,
+  createInteractionController,
+  getDictionaryQuery,
+  getSelectionText,
+  isDeniedSite
+} from './content-interaction.mjs'
 
 export const DEFAULT_OPTIONS = {
   DCLICK: true,
@@ -23,7 +30,28 @@ const popupWidth = 360
 let popupColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
 let popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
 let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE
-let dClickSpeed = DEFAULT_OPTIONS.DCLICK_SPEED
+
+export const STORAGE_DEFAULTS = {
+  dclick: DEFAULT_OPTIONS.DCLICK,
+  dclick_trigger_key: DEFAULT_OPTIONS.DCLICK_TRIGGER,
+  dclick_speed: DEFAULT_OPTIONS.DCLICK_SPEED,
+  drag: DEFAULT_OPTIONS.DRAG,
+  drag_trigger_key: DEFAULT_OPTIONS.DRAG_TRIGGER,
+  translate: DEFAULT_OPTIONS.TRANSLATE,
+  translate_trigger_key: DEFAULT_OPTIONS.TRANSLATE_TRIGGER,
+  deepl_auth_key: DEFAULT_OPTIONS.DEEPL_AUTH_KEY,
+  popup_bgcolor: DEFAULT_OPTIONS.POPUP_BG_COLOR,
+  popup_fontcolor: DEFAULT_OPTIONS.POPUP_FONT_COLOR,
+  popup_fontsize: DEFAULT_OPTIONS.POPUP_FONT_SIZE,
+  use_deny_list: DEFAULT_OPTIONS.USE_DENY_LIST,
+  safe_urls: DEFAULT_OPTIONS.SAFE_URLS
+}
+
+let activeInteractionController = null
+let storageChangeListener = null
+let eventRegistrationStarted = false
+let optionsRevision = 0
+let currentItems = {...STORAGE_DEFAULTS}
 
 
 function appendTextWithLineBreaks(element, value) {
@@ -142,38 +170,6 @@ function showFrame(e, datain, top, left, type = 'dictionary') {
 }
 
 
-function checkTrigger(e, key) {
-  let ctrlKey = e.ctrlKey
-
-  if (navigator.userAgentData) {
-    if (navigator.userAgentData.platform.includes('mac')) {
-      ctrlKey = e.metaKey
-    }
-  }
-
-  switch (key) {
-    case 'ctrl':
-      if (!ctrlKey || e.altKey)
-        return false
-      break
-    case 'alt':
-      if (ctrlKey || !e.altKey)
-        return false
-      break
-    case 'ctrlalt':
-      if (!ctrlKey || !e.altKey)
-        return false
-      break
-    case 'none':
-    default:
-      if (ctrlKey || e.altKey)
-        return false
-      break
-  }
-
-  return true
-}
-
 async function consultDic(e, word, top, left) {
   const url = buildNaverApiUrl(word)
 
@@ -221,133 +217,128 @@ function openPopup(e, key=null, type='search') {
     left = window.innerWidth - popupWidth - marginLeft - marginRight
   }
 
-  let selection = window.getSelection()
+  const text = getSelectionText(window.getSelection())
+  if (!text) {
+    return
+  }
 
-  if (selection.rangeCount > 0) {
-      let text = selection.toString()
-      if (!text) {
-        return
-      }
-
-      if (type == 'translate') {
-        translate(e, text, top, left, key)
-      }
-      else {
-        let english = /^[A-Za-z]*$/
-        if (english.test(text[0]) && text.split(/\s+/).length < 6) {
-          consultDic(e, text.toLowerCase(), top, left)
-        }
-      }
+  if (type === 'translate') {
+    translate(e, text, top, left, key)
+  }
+  else {
+    const word = getDictionaryQuery(text)
+    if (word) {
+      consultDic(e, word, top, left)
+    }
   }
 }
 
-function registerEventListener() {
-  chrome.storage.sync.get({
-    dclick: DEFAULT_OPTIONS.DCLICK,
-    dclick_trigger_key: DEFAULT_OPTIONS.DCLICK_TRIGGER,
-    dclick_speed: DEFAULT_OPTIONS.DCLICK_SPEED,
-    drag: DEFAULT_OPTIONS.DRAG,
-    drag_trigger_key: DEFAULT_OPTIONS.DRAG_TRIGGER,
-    translate: DEFAULT_OPTIONS.TRANSLATE,
-    translate_trigger_key: DEFAULT_OPTIONS.TRANSLATE_TRIGGER,
-    deepl_auth_key: DEFAULT_OPTIONS.DEEPL_AUTH_KEY,
-    popup_bgcolor: DEFAULT_OPTIONS.POPUP_BG_COLOR,
-    popup_fontcolor: DEFAULT_OPTIONS.POPUP_FONT_COLOR,
-    popup_fontsize: DEFAULT_OPTIONS.POPUP_FONT_SIZE,
-    use_deny_list: DEFAULT_OPTIONS.USE_DENY_LIST,
-    safe_urls: DEFAULT_OPTIONS.SAFE_URLS
-  }, function(items) {
-    if (!items.dclick && !items.drag && !items.translate) {
-      return
-    }
+function removePopup() {
+  document.getElementById('popupFrame')?.remove()
+}
 
-    if (items.use_deny_list) {
-      if (items.safe_urls) {
-        const host = window.location.host;
-        const urls = items.safe_urls.split(',')
-        if (urls && urls[0].length > 3 && urls.some(v=>host.includes(v))) {
-          return
-        }
-      }
-    }
+function applyOptions(items) {
+  const nextItems = {...STORAGE_DEFAULTS, ...(items || {})}
+  currentItems = nextItems
 
-    let mousedown = false
-    let mousemove = false
-    let clicks = 0
-    let timeout
-    let prevX
-    const scrollXOffset = 8
+  activeInteractionController?.destroy()
+  activeInteractionController = null
+  removePopup()
 
-    if (items.popup_bgcolor) {
-      popupColor = items.popup_bgcolor
-    }
-    if (items.popup_fontcolor) {
-      popupFontColor = items.popup_fontcolor
-    }
-    if (items.popup_fontsize) {
-      popupFontsize = items.popup_fontsize
-    }
-    if (items.dclick_speed) {
-      dClickSpeed = items.dclick_speed
-    }
+  popupColor = nextItems.popup_bgcolor || DEFAULT_OPTIONS.POPUP_BG_COLOR
+  popupFontColor = nextItems.popup_fontcolor || DEFAULT_OPTIONS.POPUP_FONT_COLOR
+  popupFontsize = nextItems.popup_fontsize || DEFAULT_OPTIONS.POPUP_FONT_SIZE
 
-    document.body.onmousedown = function(e) {
-      mousedown = true
-      prevX = e.pageX
-    }
+  if (!nextItems.dclick && !nextItems.drag && !nextItems.translate) {
+    return
+  }
 
-    document.body.onmousemove = function(e) {
-      if (!mousedown)
-        return
-      if (Math.abs(e.pageX - prevX) > scrollXOffset)
-        mousemove = true
-    }
+  const host = window.location.hostname || window.location.host
+  if (isDeniedSite(host, nextItems.safe_urls, nextItems.use_deny_list)) {
+    return
+  }
 
-    document.body.onmouseup = function(e) {
-      if (mousemove && items.drag && checkTrigger(e, items.drag_trigger_key)) {
-        mousedown = mousemove = false
-        if (document.getElementById('popupFrame')) {
-          document.getElementById('popupFrame').remove()
-        }
-        openPopup(e)
-      }
-      else if (mousemove && items.translate && checkTrigger(e, items.translate_trigger_key)) {
-        mousedown = mousemove = false
-        if (document.getElementById('popupFrame')) {
-          document.getElementById('popupFrame').remove()
-        }
-        openPopup(e, items.deepl_auth_key, 'translate')
-      }
-      else if (!mousemove && items.dclick && checkTrigger(e, items.dclick_trigger_key)) {
-        mousedown = false
-        ++clicks
-
-        if (clicks == 1) {
-          if (document.getElementById('popupFrame')) {
-            document.getElementById('popupFrame').remove()
-          }
-          timeout = setTimeout(function () {
-            clicks = 0
-          }, dClickSpeed)
-        } else {
-          if (document.getElementById('popupFrame')) {
-            document.getElementById('popupFrame').remove()
-          }
-          clearTimeout(timeout)
-          openPopup(e)
-          clicks = 0
-        }
-      }
-      else {
-        mousedown = mousemove = false
-        if (document.getElementById('popupFrame')) {
-          document.getElementById('popupFrame').remove()
-        }
-      }
-    }
+  // This content script is injected into every frame (manifest all_frames).
+  // Binding to this frame's document keeps selection and events local to the
+  // browsing context; events do not bubble across iframe boundaries.
+  activeInteractionController = createInteractionController(nextItems, {
+    target: document,
+    openPopup,
+    removePopup,
+    checkTrigger
   })
 }
 
+function registerStorageChangeListener(storage) {
+  if (storageChangeListener || !storage?.onChanged?.addListener) {
+    return
+  }
+
+  storageChangeListener = (changes, areaName) => {
+    if (areaName && areaName !== 'sync') {
+      return
+    }
+
+    const relevantChanges = Object.keys(changes || {}).filter(key => key in STORAGE_DEFAULTS)
+    if (relevantChanges.length === 0) {
+      return
+    }
+
+    optionsRevision += 1
+    const nextItems = {...currentItems}
+    relevantChanges.forEach(key => {
+      const change = changes[key]
+      nextItems[key] = change?.newValue === undefined
+        ? STORAGE_DEFAULTS[key]
+        : change.newValue
+    })
+    applyOptions(nextItems)
+  }
+
+  storage.onChanged.addListener(storageChangeListener)
+}
+
+export function unregisterEventListener() {
+  optionsRevision += 1
+  activeInteractionController?.destroy()
+  activeInteractionController = null
+
+  if (storageChangeListener && typeof chrome !== 'undefined') {
+    chrome.storage?.onChanged?.removeListener?.(storageChangeListener)
+  }
+
+  storageChangeListener = null
+  eventRegistrationStarted = false
+  currentItems = {...STORAGE_DEFAULTS}
+  removePopup()
+}
+
+export function registerEventListener() {
+  if (eventRegistrationStarted) {
+    return
+  }
+
+  eventRegistrationStarted = true
+  const storage = typeof chrome === 'undefined' ? null : chrome.storage
+  const syncStorage = storage?.sync
+
+  registerStorageChangeListener(storage)
+
+  if (!syncStorage?.get) {
+    applyOptions(STORAGE_DEFAULTS)
+    return
+  }
+
+  const revisionAtRequest = optionsRevision
+  syncStorage.get(STORAGE_DEFAULTS, items => {
+    // A storage update may arrive before this asynchronous initial read.
+    // Do not let the stale read rebind an older configuration.
+    if (revisionAtRequest !== optionsRevision) {
+      return
+    }
+    applyOptions(items)
+  })
+}
 
 export function main() {
   registerEventListener()

--- a/tests/content-interaction.test.mjs
+++ b/tests/content-interaction.test.mjs
@@ -10,6 +10,7 @@ import {
   normalizeDenyList,
   normalizeSelectionText
 } from '../src/content-interaction.mjs'
+import { createStorageLifecycle } from '../src/content-storage.mjs'
 
 class FakeEventTarget {
   constructor() {
@@ -33,6 +34,28 @@ class FakeEventTarget {
 
   listenerCount(type) {
     return this.listeners.get(type)?.size || 0
+  }
+}
+
+class FakeStorage {
+  constructor() {
+    this.listeners = new Set()
+    this.reads = []
+    this.onChanged = {
+      addListener: listener => this.listeners.add(listener),
+      removeListener: listener => this.listeners.delete(listener)
+    }
+    this.sync = {
+      get: (_defaults, callback) => this.reads.push(callback)
+    }
+  }
+
+  emit(changes, areaName = 'sync') {
+    this.listeners.forEach(listener => listener(changes, areaName))
+  }
+
+  resolveNext(items) {
+    this.reads.shift()?.(items)
   }
 }
 
@@ -198,4 +221,47 @@ test('routes a triggered drag to translation when dictionary drag is disabled', 
 
   assert.deepEqual(opened, [[event, 'test-key', 'translate']])
   controller.destroy()
+})
+
+test('preserves unchanged settings when storage changes during initial read', () => {
+  const storage = new FakeStorage()
+  const defaults = {
+    dclick: true,
+    popup_bgcolor: '#FFF59D',
+    popup_fontsize: '11'
+  }
+  const applied = []
+  const lifecycle = createStorageLifecycle({
+    storage,
+    defaults,
+    onApply: items => applied.push(items)
+  })
+
+  lifecycle.start()
+  assert.equal(storage.reads.length, 1)
+
+  storage.emit({popup_fontsize: {newValue: '15'}})
+  assert.equal(storage.reads.length, 2)
+
+  // The initial read is stale and must not replace the newer read.
+  storage.resolveNext({
+    dclick: false,
+    popup_bgcolor: 'red',
+    popup_fontsize: '11'
+  })
+  assert.deepEqual(applied, [])
+
+  storage.resolveNext({
+    dclick: false,
+    popup_bgcolor: 'red',
+    popup_fontsize: '15'
+  })
+  assert.deepEqual(applied, [{
+    dclick: false,
+    popup_bgcolor: 'red',
+    popup_fontsize: '15'
+  }])
+
+  lifecycle.stop()
+  assert.equal(storage.listeners.size, 0)
 })

--- a/tests/content-interaction.test.mjs
+++ b/tests/content-interaction.test.mjs
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  checkTrigger,
+  createInteractionController,
+  getDictionaryQuery,
+  getSelectionText,
+  isDeniedSite,
+  normalizeDenyList,
+  normalizeSelectionText
+} from '../src/content-interaction.mjs'
+
+class FakeEventTarget {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set())
+    }
+    this.listeners.get(type).add(listener)
+  }
+
+  removeEventListener(type, listener) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  dispatch(type, event = {}) {
+    this.listeners.get(type)?.forEach(listener => listener(event))
+  }
+
+  listenerCount(type) {
+    return this.listeners.get(type)?.size || 0
+  }
+}
+
+function mouseEvent(overrides = {}) {
+  return {
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    ctrlKey: false,
+    metaKey: false,
+    altKey: false,
+    ...overrides
+  }
+}
+
+test('normalizes selected text and prevents whitespace-only selections', () => {
+  assert.equal(
+    normalizeSelectionText(' \u00a0Hello\t world\r\n next \u200B '),
+    'Hello world\nnext'
+  )
+  assert.equal(normalizeSelectionText('\u200B\uFEFF\n\t'), '')
+  assert.equal(getDictionaryQuery('  HELLO\nworld  '), 'hello world')
+  assert.equal(getDictionaryQuery('   '), '')
+  assert.equal(getDictionaryQuery('한글'), '')
+  assert.equal(getDictionaryQuery('one two three four five six'), '')
+})
+
+test('reads selected range text and safely handles an empty selection', () => {
+  const selection = {
+    rangeCount: 1,
+    getRangeAt() {
+      return {
+        cloneContents() {
+          return {textContent: '  selected\n text  '}
+        }
+      }
+    },
+    toString() {
+      return '  selected\n text  '
+    }
+  }
+
+  assert.equal(getSelectionText(selection), 'selected\ntext')
+  assert.equal(getSelectionText({
+    rangeCount: 1,
+    getRangeAt: () => ({cloneContents: () => ({textContent: '  range fallback  '})})
+  }), 'range fallback')
+  assert.equal(getSelectionText({rangeCount: 0, toString: () => 'ignored'}), '')
+  assert.equal(getSelectionText(null), '')
+})
+
+test('matches configured trigger keys on Windows and macOS', () => {
+  assert.equal(checkTrigger(mouseEvent(), 'none', 'Win32'), true)
+  assert.equal(checkTrigger(mouseEvent({ctrlKey: true}), 'none', 'Win32'), false)
+  assert.equal(checkTrigger(mouseEvent({altKey: true}), 'alt', 'Win32'), true)
+  assert.equal(checkTrigger(mouseEvent({ctrlKey: true, altKey: true}), 'ctrl', 'Win32'), false)
+  assert.equal(checkTrigger(mouseEvent({ctrlKey: true, altKey: true}), 'ctrlalt', 'Win32'), true)
+  assert.equal(checkTrigger(mouseEvent({metaKey: true}), 'ctrl', 'Win32'), false)
+  assert.equal(checkTrigger(mouseEvent({metaKey: true}), 'ctrl', 'MacIntel'), true)
+  assert.equal(checkTrigger(mouseEvent({ctrlKey: true}), 'none', 'MacIntel'), false)
+  assert.equal(checkTrigger(mouseEvent({metaKey: true, altKey: true}), 'ctrlalt', 'MacIntel'), true)
+  assert.equal(checkTrigger(mouseEvent({metaKey: true, ctrlKey: true}), 'ctrl', 'MacIntel'), false)
+})
+
+test('matches deny-list hosts by exact domain or subdomain boundary', () => {
+  assert.deepEqual(normalizeDenyList(' example.com, https://www.naver.com/path\n'), [
+    'example.com',
+    'www.naver.com'
+  ])
+  assert.equal(isDeniedSite('example.com', 'example.com'), true)
+  assert.equal(isDeniedSite('docs.example.com', 'example.com'), true)
+  assert.equal(isDeniedSite('not-example.com', 'example.com'), false)
+  assert.equal(isDeniedSite('example.com:8443', 'example.com'), true)
+  assert.equal(isDeniedSite('example.com', 'example.com', false), false)
+  assert.equal(isDeniedSite('example.com', 'other.com'), false)
+})
+
+test('distinguishes vertical/horizontal drags from a double click', () => {
+  const target = new FakeEventTarget()
+  const opened = []
+  let removed = 0
+  const controller = createInteractionController({
+    dclick: true,
+    dclick_trigger_key: 'none',
+    dclick_speed: 400,
+    drag: true,
+    drag_trigger_key: 'ctrl',
+    translate: false
+  }, {
+    target,
+    openPopup: (...args) => opened.push(args),
+    removePopup: () => { removed += 1 }
+  })
+
+  target.dispatch('mousedown', mouseEvent({clientX: 10, clientY: 10}))
+  target.dispatch('mousemove', mouseEvent({clientX: 10, clientY: 30}))
+  target.dispatch('mouseup', mouseEvent({clientX: 10, clientY: 30, ctrlKey: true}))
+  assert.equal(opened.length, 1)
+
+  target.dispatch('mousedown', mouseEvent({clientX: 20, clientY: 20}))
+  target.dispatch('mouseup', mouseEvent({clientX: 20, clientY: 20}))
+  target.dispatch('mousedown', mouseEvent({clientX: 20, clientY: 20}))
+  target.dispatch('mouseup', mouseEvent({clientX: 20, clientY: 20}))
+  assert.equal(opened.length, 2)
+  assert.equal(removed >= 3, true)
+
+  controller.destroy()
+  assert.equal(target.listenerCount('mousedown'), 0)
+  assert.equal(target.listenerCount('mousemove'), 0)
+  assert.equal(target.listenerCount('mouseup'), 0)
+})
+
+test('destroying the previous controller prevents duplicate event handling', () => {
+  const target = new FakeEventTarget()
+  const opened = []
+  const options = {
+    dclick: true,
+    dclick_trigger_key: 'none',
+    dclick_speed: 400,
+    drag: false,
+    translate: false
+  }
+
+  const first = createInteractionController(options, {
+    target,
+    openPopup: () => opened.push('first')
+  })
+  first.destroy()
+
+  const second = createInteractionController(options, {
+    target,
+    openPopup: () => opened.push('second')
+  })
+
+  target.dispatch('mousedown', mouseEvent())
+  target.dispatch('mouseup', mouseEvent())
+  target.dispatch('mousedown', mouseEvent())
+  target.dispatch('mouseup', mouseEvent())
+
+  assert.deepEqual(opened, ['second'])
+  assert.equal(target.listenerCount('mouseup'), 1)
+  second.destroy()
+})
+
+test('routes a triggered drag to translation when dictionary drag is disabled', () => {
+  const target = new FakeEventTarget()
+  const opened = []
+  const controller = createInteractionController({
+    dclick: false,
+    drag: false,
+    translate: true,
+    translate_trigger_key: 'alt',
+    deepl_auth_key: 'test-key'
+  }, {
+    target,
+    openPopup: (...args) => opened.push(args)
+  })
+
+  target.dispatch('mousedown', mouseEvent({clientX: 5, clientY: 5}))
+  target.dispatch('mousemove', mouseEvent({clientX: 25, clientY: 5}))
+  const event = mouseEvent({clientX: 25, clientY: 5, altKey: true})
+  target.dispatch('mouseup', event)
+
+  assert.deepEqual(opened, [[event, 'test-key', 'translate']])
+  controller.destroy()
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,6 +32,10 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/content-storage.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/dictionary/parser.mjs',
           dest: 'dictionary'
         },

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,10 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/content-interaction.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/dictionary/parser.mjs',
           dest: 'dictionary'
         },


### PR DESCRIPTION
## Summary

선택·트리거·제외 사이트 로직을 정리하고 설정 변경 시 이벤트 핸들러가 중복 등록되지 않도록 수명주기를 안정화했습니다.

## What changed

- 단어 더블클릭과 가로·세로 문장 드래그를 분리해 판별
- 선택 문자열 정규화 및 공백-only 선택 차단
- Windows/Linux Ctrl과 macOS Command를 포함한 trigger key 조건 정리
- exact host/subdomain boundary 기반 deny-list 판정
- `all_frames: true` 환경에서 각 iframe의 `document`에만 이벤트 적용
- 설정 변경 시 기존 컨트롤러를 destroy한 뒤 새 설정으로 재등록
- 선택·트리거·deny-list·이벤트 중복 방지 테스트 추가

## Root cause

기존 로직은 `document.body.on*` 핸들러와 설정 콜백 클로저에 의존해 가로 이동만 드래그로 감지했고, 선택 문자열·deny-list 경계 조건과 설정 변경 시 이벤트 수명주기가 분리되어 있지 않았습니다.

## Validation

- `yarn test`: 16 tests passed
- `yarn vite build`: passed
- `git diff --check`: passed

Base: `testflight`
Head: `codex/selection-trigger-deny-list`