### PR TITLE
refactor: clarify dictionary parsing and normalization boundaries

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content.css", "dictionary/parser.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/dictionary/normalizer.mjs
+++ b/src/dictionary/normalizer.mjs
@@ -1,0 +1,129 @@
+/**
+ * Values coming from the dictionary API are JSON data, not trusted model
+ * instances. These helpers keep the presentation contract small and stable:
+ * scalar text is always a trimmed string, unsupported values become an empty
+ * string, and collections always become arrays.
+ */
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function normalizeString(value) {
+  if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+    return ''
+  }
+
+  return String(value).trim()
+}
+
+export function normalizeStringList(value) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(normalizeString)
+    .filter(Boolean)
+}
+
+export function normalizeHttpUrl(value) {
+  const candidate = normalizeString(value)
+  if (!candidate) {
+    return ''
+  }
+
+  try {
+    const parsed = new URL(candidate)
+    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
+      return candidate
+    }
+  } catch {
+    // Invalid or unsupported URLs are represented by the empty string.
+  }
+
+  return ''
+}
+
+export function normalizeMeaning(value) {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  return {
+    order: normalizeString(value.order),
+    value: normalizeString(value.value)
+  }
+}
+
+export function normalizeMeanings(value) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(normalizeMeaning)
+    .filter(Boolean)
+}
+
+export function normalizePhoneticEntry(value) {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const audioUrl = normalizeHttpUrl(value.audioUrl)
+  if (!audioUrl) {
+    return null
+  }
+
+  return {
+    phoneticSymbol: normalizeString(value.phoneticSymbol),
+    audioUrl
+  }
+}
+
+export function normalizePhoneticEntries(value) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(normalizePhoneticEntry)
+    .filter(Boolean)
+}
+
+/**
+ * Input contract:
+ *   { word, partOfSpeech, meanings, phonetics }
+ *
+ * Output contract:
+ *   { word, partOfSpeech, phoneticSymbol, audioUrl, meanings }
+ *
+ * `phonetics` contains candidates in API order. The first candidate with a
+ * valid HTTP(S) audio URL wins, matching the existing one-audio UI contract.
+ */
+export function normalizeDictionaryEntry(value) {
+  if (!isRecord(value)) {
+    return null
+  }
+
+  const phoneticEntry = normalizePhoneticEntries(value.phonetics)[0]
+
+  return {
+    word: normalizeString(value.word),
+    partOfSpeech: normalizeString(value.partOfSpeech),
+    phoneticSymbol: phoneticEntry?.phoneticSymbol || '',
+    audioUrl: phoneticEntry?.audioUrl || '',
+    meanings: normalizeMeanings(value.meanings)
+  }
+}
+
+export function normalizeDictionaryEntries(value) {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .map(normalizeDictionaryEntry)
+    .filter(Boolean)
+}

--- a/src/dictionary/parser.mjs
+++ b/src/dictionary/parser.mjs
@@ -1,103 +1,127 @@
+import {
+  normalizeDictionaryEntries,
+  normalizeString
+} from './normalizer.mjs'
+
 const NAVER_API_URL = 'https://en.dict.naver.com/api3/enko/search?m=mobile&lang=ko&query='
 const NAVER_DICTIONARY_URL = 'https://en.dict.naver.com/#/search?query='
 
-function toText(value) {
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return String(value)
-  }
-
-  return ''
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
-function toHttpUrl(value) {
-  const candidate = toText(value).trim()
-  if (!candidate) {
-    return ''
+function getWordItems(data) {
+  if (!isRecord(data)) {
+    return []
   }
 
-  try {
-    const parsed = new URL(candidate)
-    if (parsed.protocol === 'http:' || parsed.protocol === 'https:') {
-      return candidate
-    }
-  } catch {
-    // Ignore malformed external URLs.
-  }
+  const searchResultMap = data.searchResultMap
+  const listMap = isRecord(searchResultMap)
+    ? searchResultMap.searchResultListMap
+    : null
+  const wordResults = isRecord(listMap) ? listMap.WORD : null
 
-  return ''
+  return isRecord(wordResults) && Array.isArray(wordResults.items)
+    ? wordResults.items
+    : []
 }
 
-function getFirstAudioEntry(item) {
-  if (!Array.isArray(item.searchPhoneticSymbolList)) {
+function getFirstRecord(value) {
+  if (!Array.isArray(value)) {
     return null
   }
 
-  for (const phoneticEntry of item.searchPhoneticSymbolList) {
-    if (!phoneticEntry || typeof phoneticEntry !== 'object') {
-      continue
-    }
-
-    const audioUrl = toHttpUrl(phoneticEntry.symbolFile)
-    if (audioUrl) {
-      return {
-        phoneticSymbol: toText(phoneticEntry.symbolValue),
-        audioUrl
-      }
+  for (const item of value) {
+    if (isRecord(item)) {
+      return item
     }
   }
 
   return null
 }
 
-function getFirstCollector(item) {
-  if (!Array.isArray(item.meansCollector)) {
-    return null
-  }
-
-  return item.meansCollector.find(collector => collector && typeof collector === 'object') || null
-}
-
-function getMeanings(collector) {
-  if (!collector || !Array.isArray(collector.means)) {
+function parsePhoneticEntries(value) {
+  if (!Array.isArray(value)) {
     return []
   }
 
-  return collector.means
-    .filter(meaning => meaning && typeof meaning === 'object')
-    .map(meaning => ({
-      order: toText(meaning.order),
-      value: toText(meaning.value)
+  return value
+    .filter(isRecord)
+    .map(item => ({
+      phoneticSymbol: item.symbolValue,
+      audioUrl: item.symbolFile
     }))
 }
 
-export function buildNaverApiUrl(query) {
-  return NAVER_API_URL + encodeURIComponent(toText(query))
+/**
+ * Parse one API item into the raw dictionary-entry shape consumed by the
+ * normalizer. No trimming, URL validation, or presentation URL generation is
+ * performed here.
+ */
+export function parseNaverDictionaryItem(item) {
+  if (!isRecord(item)) {
+    return null
+  }
+
+  const collector = getFirstRecord(item.meansCollector)
+
+  return {
+    word: item.handleEntry,
+    partOfSpeech: collector?.partOfSpeech,
+    meanings: Array.isArray(collector?.means) ? collector.means : [],
+    phonetics: parsePhoneticEntries(item.searchPhoneticSymbolList)
+  }
 }
 
-export function buildDictionaryUrl(word) {
-  return NAVER_DICTIONARY_URL + encodeURIComponent(toText(word))
-}
+/**
+ * Parse only the known Naver response envelope and preserve the API values.
+ * The returned records are deliberately not renderer-ready; callers should
+ * pass them through normalizeNaverDictionaryEntries.
+ */
+export function parseNaverDictionaryItems(data) {
+  let items
 
-export function parseNaverDictionaryResponse(data) {
-  const items = data?.searchResultMap?.searchResultListMap?.WORD?.items
-  if (!Array.isArray(items)) {
+  try {
+    items = getWordItems(data)
+  } catch {
     return []
   }
 
-  return items
-    .filter(item => item && typeof item === 'object')
-    .map(item => {
-      const word = toText(item.handleEntry)
-      const collector = getFirstCollector(item)
-      const audioEntry = getFirstAudioEntry(item)
-
-      return {
-        word,
-        dictionaryUrl: buildDictionaryUrl(word),
-        partOfSpeech: toText(collector?.partOfSpeech),
-        phoneticSymbol: audioEntry?.phoneticSymbol || '',
-        audioUrl: audioEntry?.audioUrl || '',
-        meanings: getMeanings(collector)
+  const parsedItems = []
+  for (const item of items) {
+    try {
+      const parsedItem = parseNaverDictionaryItem(item)
+      if (parsedItem) {
+        parsedItems.push(parsedItem)
       }
-    })
+    } catch {
+      // Ignore one malformed item without discarding valid sibling entries.
+    }
+  }
+
+  return parsedItems
+}
+
+/**
+ * Convert parsed entries to the stable renderer contract used by Popup.vue
+ * and content.js. The dictionary URL is derived only after the headword has
+ * been normalized.
+ */
+export function normalizeNaverDictionaryEntries(entries) {
+  return normalizeDictionaryEntries(entries).map(entry => ({
+    ...entry,
+    dictionaryUrl: buildDictionaryUrl(entry.word)
+  }))
+}
+
+export function buildNaverApiUrl(query) {
+  return NAVER_API_URL + encodeURIComponent(normalizeString(query))
+}
+
+export function buildDictionaryUrl(word) {
+  return NAVER_DICTIONARY_URL + encodeURIComponent(normalizeString(word))
+}
+
+export function parseNaverDictionaryResponse(data) {
+  return normalizeNaverDictionaryEntries(parseNaverDictionaryItems(data))
 }

--- a/tests/naver-parser.test.mjs
+++ b/tests/naver-parser.test.mjs
@@ -4,8 +4,17 @@ import test from 'node:test'
 import {
   buildDictionaryUrl,
   buildNaverApiUrl,
+  normalizeNaverDictionaryEntries,
+  parseNaverDictionaryItems,
   parseNaverDictionaryResponse
 } from '../src/dictionary/parser.mjs'
+import {
+  normalizeDictionaryEntry,
+  normalizeHttpUrl,
+  normalizeMeanings,
+  normalizeString,
+  normalizeStringList
+} from '../src/dictionary/normalizer.mjs'
 
 function response(items) {
   return {
@@ -43,6 +52,39 @@ test('parses a normal single dictionary result', () => {
       { order: '1', value: '안녕하세요' },
       { order: '2', value: '여보세요' }
     ]
+  }])
+})
+
+test('keeps parsing and normalization as separate contracts', () => {
+  const rawEntries = parseNaverDictionaryItems(response([{
+    handleEntry: '  hello  ',
+    meansCollector: [{
+      partOfSpeech: ' 명사 ',
+      means: [{ order: 1, value: ' 안녕하세요 ' }]
+    }],
+    searchPhoneticSymbolList: [{
+      symbolValue: ' həˈloʊ ',
+      symbolFile: ' https://audio.example/hello.mp3 '
+    }]
+  }]))
+
+  assert.deepEqual(rawEntries, [{
+    word: '  hello  ',
+    partOfSpeech: ' 명사 ',
+    meanings: [{ order: 1, value: ' 안녕하세요 ' }],
+    phonetics: [{
+      phoneticSymbol: ' həˈloʊ ',
+      audioUrl: ' https://audio.example/hello.mp3 '
+    }]
+  }])
+
+  assert.deepEqual(normalizeNaverDictionaryEntries(rawEntries), [{
+    word: 'hello',
+    dictionaryUrl: 'https://en.dict.naver.com/#/search?query=hello',
+    partOfSpeech: '명사',
+    phoneticSymbol: 'həˈloʊ',
+    audioUrl: 'https://audio.example/hello.mp3',
+    meanings: [{ order: '1', value: '안녕하세요' }]
   }])
 })
 
@@ -140,6 +182,68 @@ test('does not let missing meanings or invalid audio URLs throw', () => {
   assert.deepEqual(result[0].meanings, [])
   assert.equal(result[0].phoneticSymbol, '')
   assert.equal(result[0].audioUrl, '')
+})
+
+test('normalizes scalar and array values consistently', () => {
+  assert.equal(normalizeString(null), '')
+  assert.equal(normalizeString(undefined), '')
+  assert.equal(normalizeString('  text  '), 'text')
+  assert.equal(normalizeString(12), '12')
+  assert.equal(normalizeString(false), 'false')
+  assert.equal(normalizeString({value: 'text'}), '')
+
+  assert.deepEqual(normalizeStringList(null), [])
+  assert.deepEqual(normalizeStringList('text'), [])
+  assert.deepEqual(normalizeStringList([' text ', '', null, 12, false, ['nested']]), [
+    'text',
+    '12',
+    'false'
+  ])
+})
+
+test('normalizes missing and invalid entry fields to the stable contract', () => {
+  assert.deepEqual(normalizeDictionaryEntry({
+    word: '  partial ',
+    partOfSpeech: null,
+    meanings: [
+      null,
+      { order: 1, value: ' first ' },
+      'invalid',
+      { order: undefined, value: undefined }
+    ],
+    phonetics: [
+      { phoneticSymbol: 'bad', audioUrl: 'javascript:alert(1)' },
+      { phoneticSymbol: 'good', audioUrl: ' https://audio.example/good.mp3 ' }
+    ]
+  }), {
+    word: 'partial',
+    partOfSpeech: '',
+    phoneticSymbol: 'good',
+    audioUrl: 'https://audio.example/good.mp3',
+    meanings: [
+      { order: '1', value: 'first' },
+      { order: '', value: '' }
+    ]
+  })
+
+  assert.equal(normalizeDictionaryEntry(null), null)
+  assert.deepEqual(normalizeMeanings(null), [])
+  assert.deepEqual(normalizeMeanings([]), [])
+  assert.equal(normalizeHttpUrl(null), '')
+  assert.equal(normalizeHttpUrl('data:audio/wav;base64,abc'), '')
+})
+
+test('ignores invalid sibling entries while preserving valid response order', () => {
+  const result = parseNaverDictionaryResponse(response([
+    null,
+    'invalid',
+    { handleEntry: ' first ', meansCollector: [{ means: [] }] },
+    { handleEntry: 'second', meansCollector: undefined }
+  ]))
+
+  assert.deepEqual(result.map(entry => entry.word), ['first', 'second'])
+  assert.equal(result[0].dictionaryUrl, 'https://en.dict.naver.com/#/search?query=first')
+  assert.deepEqual(result[1].meanings, [])
 })
 
 test('keeps HTML-looking response values as plain data', () => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -40,6 +40,10 @@ export default defineConfig({
           dest: 'dictionary'
         },
         {
+          src: 'src/dictionary/normalizer.mjs',
+          dest: 'dictionary'
+        },
+        {
           src: 'src/content.css',
           dest: '.'
         },


### PR DESCRIPTION
## Summary

- Separate Naver response envelope parsing from dictionary-entry normalization.
- Normalize scalar text, collections, meanings, phonetic symbols, and HTTP(S) audio URLs into a stable renderer contract.
- Keep invalid or partial API entries from propagating exceptions while preserving valid entry order.
- Register the normalization module in Vite static copies and web-accessible extension resources.
- Add parser and normalizer boundary tests for normal, partial, invalid, and empty inputs.

No search UX, result ordering, wording, API provider, or request URL was changed.

## Validation

- `yarn test` — 20 tests passed
- `yarn vite build` — passed
- esbuild content-script bundle — passed
- `git diff --check` — passed