### PR TITLE
refactor: centralize settings schema and storage

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "settings.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -1,23 +1,14 @@
 <script setup>
 import { ref, reactive, onMounted } from 'vue'
 import { getText } from '/src/text.js'
-import { DEFAULT_OPTIONS } from '/src/content.js'
+import {
+  createOptionForm,
+  optionFormFromSettings,
+  settingsFromOptionForm
+} from '/src/settings.mjs'
+import { loadSettings, saveSettings } from '/src/settings-storage.mjs'
 
-const options = reactive({
-  dClick: DEFAULT_OPTIONS.DCLICK,
-  dClickTrigger: DEFAULT_OPTIONS.DCLICK_TRIGGER,
-  dClickSpeed: DEFAULT_OPTIONS.DCLICK_SPEED,
-  drag: DEFAULT_OPTIONS.DRAG,
-  dragTrigger: DEFAULT_OPTIONS.DRAG_TRIGGER,
-  translate: DEFAULT_OPTIONS.TRANSLATE,
-  translateTrigger: DEFAULT_OPTIONS.TRANSLATE_TRIGGER,
-  deeplAuthKey: DEFAULT_OPTIONS.DEEPL_AUTH_KEY,
-  popupBGColor: DEFAULT_OPTIONS.POPUP_BG_COLOR,
-  popupFontColor: DEFAULT_OPTIONS.POPUP_FONT_COLOR,
-  popupFontSize: DEFAULT_OPTIONS.POPUP_FONT_SIZE,
-  useDenyList: DEFAULT_OPTIONS.USE_DENY_LIST,
-  safeURLs: DEFAULT_OPTIONS.SAFE_URLS
-})
+const options = reactive(createOptionForm())
 const version = chrome.runtime.getManifest().version
 let statusText = ref('')
 
@@ -36,21 +27,7 @@ function saveOptions() {
     options.safeURLs = options.safeURLs.replace(/\s/g, '')
   }
 
-  chrome.storage.sync.set({
-    dclick: options.dClick,
-    dclick_trigger_key: options.dClickTrigger,
-    dclick_speed: options.dClickSpeed,
-    drag: options.drag,
-    drag_trigger_key: options.dragTrigger,
-    translate: options.translate,
-    translate_trigger_key: options.translateTrigger,
-    deepl_auth_key: options.deeplAuthKey,
-    popup_bgcolor: options.popupBGColor,
-    popup_fontcolor: options.popupFontColor,
-    popup_fontsize: options.popupFontSize,
-    use_deny_list: options.useDenyList,
-    safe_urls: options.safeURLs
-  }, function() {
+  saveSettings(chrome.storage, settingsFromOptionForm(options), function() {
     statusText.value = getText('SAVE_STATUS');
     setTimeout(function() {
       statusText.value = ''
@@ -59,67 +36,15 @@ function saveOptions() {
 }
 
 function loadOptions() {
-  chrome.storage.sync.get({
-    dclick: DEFAULT_OPTIONS.DCLICK,
-    dclick_trigger_key: DEFAULT_OPTIONS.DCLICK_TRIGGER,
-    dclick_speed: DEFAULT_OPTIONS.DCLICK_SPEED,
-    drag: DEFAULT_OPTIONS.DRAG,
-    drag_trigger_key: DEFAULT_OPTIONS.DRAG_TRIGGER,
-    translate: DEFAULT_OPTIONS.TRANSLATE,
-    translate_trigger_key: DEFAULT_OPTIONS.TRANSLATE_TRIGGER,
-    deepl_auth_key: DEFAULT_OPTIONS.DEEPL_AUTH_KEY,
-    popup_bgcolor: DEFAULT_OPTIONS.POPUP_BG_COLOR,
-    popup_fontcolor: DEFAULT_OPTIONS.POPUP_FONT_COLOR,
-    popup_fontsize: DEFAULT_OPTIONS.POPUP_FONT_SIZE,
-    use_deny_list: DEFAULT_OPTIONS.USE_DENY_LIST,
-    safe_urls: DEFAULT_OPTIONS.SAFE_URLS
-  }, function(items) {
-    options.dClick = items.dclick
-    options.dClickTrigger = items.dclick_trigger_key
-    options.dClickSpeed = items.dclick_speed
-    options.drag = items.drag
-    options.dragTrigger = items.drag_trigger_key
-    options.translate = items.translate
-    options.translateTrigger = items.translate_trigger_key
-    options.deeplAuthKey = items.deepl_auth_key
-    options.popupBGColor = items.popup_bgcolor
-    options.popupFontColor = items.popup_fontcolor
-    options.popupFontSize = items.popup_fontsize
-    options.useDenyList = items.use_deny_list
-    options.safeURLs = items.safe_urls
+  loadSettings(chrome.storage, function(items) {
+    Object.assign(options, optionFormFromSettings(items))
   })
 }
 
 function resetOptions() {
-  options.dClick = DEFAULT_OPTIONS.DCLICK
-  options.dClickTrigger = DEFAULT_OPTIONS.DCLICK_TRIGGER
-  options.dClickSpeed = DEFAULT_OPTIONS.DCLICK_SPEED
-  options.drag = DEFAULT_OPTIONS.DRAG
-  options.dragTrigger = DEFAULT_OPTIONS.DRAG_TRIGGER
-  options.translate = DEFAULT_OPTIONS.TRANSLATE
-  options.translateTrigger = DEFAULT_OPTIONS.TRANSLATE_TRIGGER
-  options.deeplAuthKey = DEFAULT_OPTIONS.DEEPL_AUTH_KEY
-  options.popupBGColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
-  options.popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
-  options.popupFontSize = DEFAULT_OPTIONS.POPUP_FONT_SIZE
-  options.useDenyList = DEFAULT_OPTIONS.USE_DENY_LIST
-  options.safeURLs = DEFAULT_OPTIONS.SAFE_URLS
+  Object.assign(options, createOptionForm())
 
-  chrome.storage.sync.set({
-    dclick: options.dClick,
-    dclick_trigger_key: options.dClickTrigger,
-    dclick_speed: options.dClickSpeed,
-    drag: options.drag,
-    drag_trigger_key: options.dragTrigger,
-    translate: options.translate,
-    translate_trigger_key: options.translateTrigger,
-    deepl_auth_key: options.deeplAuthKey,
-    popup_bgcolor: options.popupBGColor,
-    popup_fontcolor: options.popupFontColor,
-    popup_fontsize: options.popupFontSize,
-    use_deny_list: options.useDenyList,
-    safe_urls: options.safeURLs
-  }, function() {
+  saveSettings(chrome.storage, settingsFromOptionForm(options), function() {
     statusText.value = getText('RESET_STATUS');
     setTimeout(function() {
       statusText.value = ''

--- a/src/content-storage.mjs
+++ b/src/content-storage.mjs
@@ -1,3 +1,5 @@
+import { getDefaultSettings, normalizeSettings } from './settings.mjs'
+
 /**
  * Keep the content-script configuration in sync with chrome.storage.
  *
@@ -6,22 +8,26 @@
  * of merging a partial change into defaults while the initial read is still
  * pending.
  */
-export function createStorageLifecycle({storage, defaults, onApply}) {
+export function createStorageLifecycle({storage, defaults, normalize, onApply}) {
+  const storageDefaults = defaults || getDefaultSettings()
+  const normalizeItems = normalize || (defaults
+    ? items => ({...storageDefaults, ...(items || {})})
+    : normalizeSettings)
   let listener = null
   let started = false
   let revision = 0
-  let currentItems = {...defaults}
+  let currentItems = normalizeItems(storageDefaults)
 
   function readLatest() {
     const revisionAtRequest = revision
 
-    storage.sync.get(defaults, items => {
+    storage.sync.get(storageDefaults, items => {
       if (revisionAtRequest !== revision) {
         return
       }
 
-      currentItems = {...defaults, ...(items || {})}
-      onApply(currentItems)
+      currentItems = normalizeItems(items)
+      onApply?.(currentItems)
     })
   }
 
@@ -29,18 +35,18 @@ export function createStorageLifecycle({storage, defaults, onApply}) {
     const nextItems = {...currentItems}
 
     Object.keys(changes || {}).forEach(key => {
-      if (!(key in defaults)) {
+      if (!(key in storageDefaults)) {
         return
       }
 
       const change = changes[key]
       nextItems[key] = change?.newValue === undefined
-        ? defaults[key]
+        ? storageDefaults[key]
         : change.newValue
     })
 
-    currentItems = nextItems
-    onApply(currentItems)
+    currentItems = normalizeItems(nextItems)
+    onApply?.(currentItems)
   }
 
   function handleStorageChange(changes, areaName) {
@@ -48,7 +54,7 @@ export function createStorageLifecycle({storage, defaults, onApply}) {
       return
     }
 
-    const hasRelevantChange = Object.keys(changes || {}).some(key => key in defaults)
+    const hasRelevantChange = Object.keys(changes || {}).some(key => key in storageDefaults)
     if (!hasRelevantChange) {
       return
     }
@@ -83,8 +89,8 @@ export function createStorageLifecycle({storage, defaults, onApply}) {
       return
     }
 
-    currentItems = {...defaults}
-    onApply(currentItems)
+    currentItems = normalizeItems(storageDefaults)
+    onApply?.(currentItems)
   }
 
   function stop() {
@@ -96,7 +102,7 @@ export function createStorageLifecycle({storage, defaults, onApply}) {
 
     listener = null
     started = false
-    currentItems = {...defaults}
+    currentItems = normalizeItems(storageDefaults)
   }
 
   return {start, stop}

--- a/src/content.js
+++ b/src/content.js
@@ -7,22 +7,13 @@ import {
   isDeniedSite
 } from './content-interaction.mjs'
 import { createStorageLifecycle } from './content-storage.mjs'
+import {
+  DEFAULT_OPTIONS,
+  normalizeSettings,
+  STORAGE_DEFAULTS
+} from './settings.mjs'
 
-export const DEFAULT_OPTIONS = {
-  DCLICK: true,
-  DCLICK_TRIGGER: 'none',
-  DCLICK_SPEED: 400,
-  DRAG: true,
-  DRAG_TRIGGER: 'ctrl',
-  TRANSLATE: false,
-  TRANSLATE_TRIGGER: 'ctrlalt',
-  DEEPL_AUTH_KEY: '',
-  POPUP_BG_COLOR: '#FFF59D',
-  POPUP_FONT_COLOR: '#000000',
-  POPUP_FONT_SIZE: '11',
-  USE_DENY_LIST: false,
-  SAFE_URLS: null
-}
+export { DEFAULT_OPTIONS, STORAGE_DEFAULTS }
 
 const marginLeft = 10
 const marginRight = 30
@@ -31,22 +22,6 @@ const popupWidth = 360
 let popupColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
 let popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
 let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE
-
-export const STORAGE_DEFAULTS = {
-  dclick: DEFAULT_OPTIONS.DCLICK,
-  dclick_trigger_key: DEFAULT_OPTIONS.DCLICK_TRIGGER,
-  dclick_speed: DEFAULT_OPTIONS.DCLICK_SPEED,
-  drag: DEFAULT_OPTIONS.DRAG,
-  drag_trigger_key: DEFAULT_OPTIONS.DRAG_TRIGGER,
-  translate: DEFAULT_OPTIONS.TRANSLATE,
-  translate_trigger_key: DEFAULT_OPTIONS.TRANSLATE_TRIGGER,
-  deepl_auth_key: DEFAULT_OPTIONS.DEEPL_AUTH_KEY,
-  popup_bgcolor: DEFAULT_OPTIONS.POPUP_BG_COLOR,
-  popup_fontcolor: DEFAULT_OPTIONS.POPUP_FONT_COLOR,
-  popup_fontsize: DEFAULT_OPTIONS.POPUP_FONT_SIZE,
-  use_deny_list: DEFAULT_OPTIONS.USE_DENY_LIST,
-  safe_urls: DEFAULT_OPTIONS.SAFE_URLS
-}
 
 let activeInteractionController = null
 let storageLifecycle = null
@@ -236,15 +211,15 @@ function removePopup() {
 }
 
 function applyOptions(items) {
-  const nextItems = {...STORAGE_DEFAULTS, ...(items || {})}
+  const nextItems = normalizeSettings(items)
 
   activeInteractionController?.destroy()
   activeInteractionController = null
   removePopup()
 
-  popupColor = nextItems.popup_bgcolor || DEFAULT_OPTIONS.POPUP_BG_COLOR
-  popupFontColor = nextItems.popup_fontcolor || DEFAULT_OPTIONS.POPUP_FONT_COLOR
-  popupFontsize = nextItems.popup_fontsize || DEFAULT_OPTIONS.POPUP_FONT_SIZE
+  popupColor = nextItems.popup_bgcolor
+  popupFontColor = nextItems.popup_fontcolor
+  popupFontsize = nextItems.popup_fontsize
 
   if (!nextItems.dclick && !nextItems.drag && !nextItems.translate) {
     return
@@ -282,7 +257,6 @@ export function registerEventListener() {
   const storage = typeof chrome === 'undefined' ? null : chrome.storage
   storageLifecycle = createStorageLifecycle({
     storage,
-    defaults: STORAGE_DEFAULTS,
     onApply: applyOptions
   })
   storageLifecycle.start()

--- a/src/settings-storage.mjs
+++ b/src/settings-storage.mjs
@@ -1,0 +1,45 @@
+import {
+  getDefaultSettings,
+  normalizeSettings,
+  STORAGE_DEFAULTS
+} from './settings.mjs'
+
+function getSyncStorage(storage) {
+  return storage?.sync || storage || null
+}
+
+/**
+ * Load the complete settings contract. Missing or malformed values are
+ * normalized before the callback sees them; the read itself never writes
+ * defaults back, so existing users are not migrated or reset on load.
+ */
+export function loadSettings(storage, onLoad) {
+  const syncStorage = getSyncStorage(storage)
+
+  if (!syncStorage?.get) {
+    onLoad?.(getDefaultSettings())
+    return
+  }
+
+  syncStorage.get(STORAGE_DEFAULTS, items => {
+    onLoad?.(normalizeSettings(items))
+  })
+}
+
+/**
+ * Save only the known settings using the same normalization contract as
+ * loadSettings. Chrome storage.set merges this payload, preserving unrelated
+ * keys owned by other extension features or older versions.
+ */
+export function saveSettings(storage, values, onSaved) {
+  const syncStorage = getSyncStorage(storage)
+  const normalized = normalizeSettings(values)
+
+  if (!syncStorage?.set) {
+    onSaved?.()
+    return normalized
+  }
+
+  syncStorage.set(normalized, onSaved)
+  return normalized
+}

--- a/src/settings.mjs
+++ b/src/settings.mjs
@@ -1,0 +1,158 @@
+const TRIGGER_KEYS = ['none', 'ctrl', 'alt', 'ctrlalt']
+
+/**
+ * This table is the only source of truth for setting keys, defaults, storage
+ * value kinds, and the form field names used by Options.vue.
+ */
+const SETTING_DEFINITIONS = [
+  {key: 'dclick', optionKey: 'DCLICK', formKey: 'dClick', kind: 'boolean', defaultValue: true},
+  {key: 'dclick_trigger_key', optionKey: 'DCLICK_TRIGGER', formKey: 'dClickTrigger', kind: 'trigger', defaultValue: 'none'},
+  {key: 'dclick_speed', optionKey: 'DCLICK_SPEED', formKey: 'dClickSpeed', kind: 'number', defaultValue: 400},
+  {key: 'drag', optionKey: 'DRAG', formKey: 'drag', kind: 'boolean', defaultValue: true},
+  {key: 'drag_trigger_key', optionKey: 'DRAG_TRIGGER', formKey: 'dragTrigger', kind: 'trigger', defaultValue: 'ctrl'},
+  {key: 'translate', optionKey: 'TRANSLATE', formKey: 'translate', kind: 'boolean', defaultValue: false},
+  {key: 'translate_trigger_key', optionKey: 'TRANSLATE_TRIGGER', formKey: 'translateTrigger', kind: 'trigger', defaultValue: 'ctrlalt'},
+  {key: 'deepl_auth_key', optionKey: 'DEEPL_AUTH_KEY', formKey: 'deeplAuthKey', kind: 'string', defaultValue: ''},
+  {key: 'popup_bgcolor', optionKey: 'POPUP_BG_COLOR', formKey: 'popupBGColor', kind: 'string', defaultValue: '#FFF59D'},
+  {key: 'popup_fontcolor', optionKey: 'POPUP_FONT_COLOR', formKey: 'popupFontColor', kind: 'string', defaultValue: '#000000'},
+  {key: 'popup_fontsize', optionKey: 'POPUP_FONT_SIZE', formKey: 'popupFontSize', kind: 'string', defaultValue: '11'},
+  {key: 'use_deny_list', optionKey: 'USE_DENY_LIST', formKey: 'useDenyList', kind: 'boolean', defaultValue: false},
+  {key: 'safe_urls', optionKey: 'SAFE_URLS', formKey: 'safeURLs', kind: 'nullable-string', defaultValue: null}
+]
+
+export const SETTINGS_SCHEMA = Object.freeze(
+  SETTING_DEFINITIONS.map(definition => Object.freeze({...definition}))
+)
+
+export const STORAGE_DEFAULTS = Object.freeze(
+  Object.fromEntries(SETTING_DEFINITIONS.map(({key, defaultValue}) => [key, defaultValue]))
+)
+
+// Keep the legacy option names available for callers that used content.js.
+// Their values are derived from the same definition table above.
+export const DEFAULT_OPTIONS = Object.freeze(
+  Object.fromEntries(SETTING_DEFINITIONS.map(({optionKey, defaultValue}) => [optionKey, defaultValue]))
+)
+
+function getDefinition(key) {
+  return SETTING_DEFINITIONS.find(definition => definition.key === key) || null
+}
+
+function normalizeBoolean(value, fallback) {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (value === true || value === 1 || value === '1' || value === 'true') {
+    return true
+  }
+
+  if (value === false || value === 0 || value === '0' || value === 'false') {
+    return false
+  }
+
+  return fallback
+}
+
+function normalizeNumber(value, fallback) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : fallback
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    // dclick_speed has historically been stored both as 400 and as '400'.
+    // Validate numeric strings without migrating their existing representation.
+    return Number.isFinite(parsed) ? value.trim() : fallback
+  }
+
+  return fallback
+}
+
+function normalizeString(value, fallback) {
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  const normalized = value.trim()
+  return normalized || fallback
+}
+
+function normalizeNullableString(value, fallback) {
+  if (value === null) {
+    return null
+  }
+
+  if (typeof value !== 'string') {
+    return fallback
+  }
+
+  return value.trim()
+}
+
+function normalizeTrigger(value, fallback) {
+  const normalized = normalizeString(value, '')
+  return TRIGGER_KEYS.includes(normalized) ? normalized : fallback
+}
+
+function normalizeValue(definition, value) {
+  switch (definition.kind) {
+    case 'boolean':
+      return normalizeBoolean(value, definition.defaultValue)
+    case 'number':
+      return normalizeNumber(value, definition.defaultValue)
+    case 'trigger':
+      return normalizeTrigger(value, definition.defaultValue)
+    case 'nullable-string':
+      return normalizeNullableString(value, definition.defaultValue)
+    case 'string':
+    default:
+      return normalizeString(value, definition.defaultValue)
+  }
+}
+
+export function getDefaultSettings() {
+  return {...STORAGE_DEFAULTS}
+}
+
+export function normalizeSetting(key, value) {
+  const definition = getDefinition(key)
+  return definition ? normalizeValue(definition, value) : undefined
+}
+
+/**
+ * Normalize only known settings and always return every known storage key.
+ * Unknown keys are intentionally ignored so unrelated sync storage data is
+ * neither interpreted nor overwritten by this contract.
+ */
+export function normalizeSettings(values) {
+  const source = values && typeof values === 'object' ? values : {}
+
+  return Object.fromEntries(SETTING_DEFINITIONS.map(definition => [
+    definition.key,
+    normalizeValue(definition, source[definition.key])
+  ]))
+}
+
+export function createOptionForm(values = STORAGE_DEFAULTS) {
+  const normalized = normalizeSettings(values)
+
+  return Object.fromEntries(SETTING_DEFINITIONS.map(definition => [
+    definition.formKey,
+    normalized[definition.key]
+  ]))
+}
+
+export function optionFormFromSettings(values) {
+  return createOptionForm(values)
+}
+
+export function settingsFromOptionForm(form) {
+  const source = form && typeof form === 'object' ? form : {}
+  const values = Object.fromEntries(SETTING_DEFINITIONS.map(definition => [
+    definition.key,
+    source[definition.formKey]
+  ]))
+
+  return normalizeSettings(values)
+}

--- a/tests/content-interaction.test.mjs
+++ b/tests/content-interaction.test.mjs
@@ -265,3 +265,36 @@ test('preserves unchanged settings when storage changes during initial read', ()
   lifecycle.stop()
   assert.equal(storage.listeners.size, 0)
 })
+
+test('normalizes shared settings and keeps the storage lifecycle single-registration', () => {
+  const storage = new FakeStorage()
+  const applied = []
+  const lifecycle = createStorageLifecycle({
+    storage,
+    onApply: items => applied.push(items)
+  })
+
+  lifecycle.start()
+  lifecycle.start()
+  assert.equal(storage.reads.length, 1)
+  assert.equal(storage.listeners.size, 1)
+
+  storage.resolveNext({
+    dclick: 'damaged',
+    dclick_speed: 'damaged',
+    popup_fontsize: ' 15 '
+  })
+  assert.equal(applied.length, 1)
+  assert.equal(applied[0].dclick, true)
+  assert.equal(applied[0].dclick_speed, 400)
+  assert.equal(applied[0].popup_fontsize, '15')
+
+  storage.emit({dclick: {newValue: 'false'}})
+  assert.equal(storage.reads.length, 1)
+  storage.resolveNext({dclick: 'false'})
+  assert.equal(applied.length, 2)
+  assert.equal(applied[1].dclick, false)
+
+  lifecycle.stop()
+  assert.equal(storage.listeners.size, 0)
+})

--- a/tests/settings.test.mjs
+++ b/tests/settings.test.mjs
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_OPTIONS,
+  createOptionForm,
+  getDefaultSettings,
+  normalizeSetting,
+  normalizeSettings,
+  optionFormFromSettings,
+  SETTINGS_SCHEMA,
+  settingsFromOptionForm,
+  STORAGE_DEFAULTS
+} from '../src/settings.mjs'
+import { loadSettings, saveSettings } from '../src/settings-storage.mjs'
+
+class FakeSyncStorage {
+  constructor(items = {}) {
+    this.items = {...items}
+    this.getCalls = []
+    this.setCalls = []
+  }
+
+  get(defaults, callback) {
+    this.getCalls.push({...defaults})
+    callback({...defaults, ...this.items})
+  }
+
+  set(values, callback) {
+    this.setCalls.push({...values})
+    this.items = {...this.items, ...values}
+    callback?.()
+  }
+}
+
+function settingDefaultsFromSchema(field) {
+  return Object.fromEntries(SETTINGS_SCHEMA.map(definition => [
+    definition[field],
+    definition.defaultValue
+  ]))
+}
+
+test('derives storage and legacy defaults from one settings schema', () => {
+  assert.deepEqual(STORAGE_DEFAULTS, settingDefaultsFromSchema('key'))
+  assert.deepEqual(DEFAULT_OPTIONS, settingDefaultsFromSchema('optionKey'))
+  assert.deepEqual(getDefaultSettings(), STORAGE_DEFAULTS)
+})
+
+test('normalizes setting types and falls back damaged values', () => {
+  assert.deepEqual(normalizeSettings({
+    dclick: 'false',
+    dclick_trigger_key: ' alt ',
+    dclick_speed: '300',
+    drag: 'damaged',
+    drag_trigger_key: 'unsupported',
+    translate: 1,
+    translate_trigger_key: null,
+    deepl_auth_key: '  secret  ',
+    popup_bgcolor: '  red  ',
+    popup_fontcolor: '',
+    popup_fontsize: 15,
+    use_deny_list: '0',
+    safe_urls: ' example.com, naver.com '
+  }), {
+    dclick: false,
+    dclick_trigger_key: 'alt',
+    dclick_speed: '300',
+    drag: true,
+    drag_trigger_key: 'ctrl',
+    translate: true,
+    translate_trigger_key: 'ctrlalt',
+    deepl_auth_key: 'secret',
+    popup_bgcolor: 'red',
+    popup_fontcolor: '#000000',
+    popup_fontsize: '11',
+    use_deny_list: false,
+    safe_urls: 'example.com, naver.com'
+  })
+
+  assert.equal(normalizeSetting('dclick_speed', 'not-a-number'), 400)
+  assert.equal(normalizeSetting('dclick', 'not-a-boolean'), true)
+  assert.equal(normalizeSetting('safe_urls', ''), '')
+  assert.equal(normalizeSetting('unknown_key', 'value'), undefined)
+})
+
+test('keeps existing valid storage values compatible', () => {
+  const existing = {
+    ...STORAGE_DEFAULTS,
+    dclick: false,
+    dclick_speed: '500',
+    popup_fontsize: '13',
+    safe_urls: null
+  }
+
+  const normalized = normalizeSettings(existing)
+  assert.equal(normalized.dclick, false)
+  assert.equal(normalized.dclick_speed, '500')
+  assert.equal(normalized.popup_fontsize, '13')
+  assert.equal(normalized.safe_urls, null)
+})
+
+test('maps the shared storage contract to the existing Options form shape', () => {
+  const defaults = createOptionForm()
+  assert.equal(defaults.dClick, true)
+  assert.equal(defaults.dClickSpeed, 400)
+  assert.equal(defaults.safeURLs, null)
+
+  const form = optionFormFromSettings({
+    ...STORAGE_DEFAULTS,
+    dclick: false,
+    dclick_speed: '300',
+    popup_bgcolor: 'red'
+  })
+  assert.equal(form.dClick, false)
+  assert.equal(form.dClickSpeed, '300')
+  assert.equal(form.popupBGColor, 'red')
+
+  const storageValues = settingsFromOptionForm({
+    ...defaults,
+    dClick: false,
+    dClickSpeed: '200',
+    useDenyList: true,
+    safeURLs: 'example.com'
+  })
+  assert.equal(storageValues.dclick, false)
+  assert.equal(storageValues.dclick_speed, '200')
+  assert.equal(storageValues.use_deny_list, true)
+  assert.equal(storageValues.safe_urls, 'example.com')
+})
+
+test('loads normalized settings without writing defaults back', () => {
+  const syncStorage = new FakeSyncStorage({
+    dclick: 'invalid',
+    dclick_speed: '300',
+    popup_fontsize: ' 15 '
+  })
+  const loaded = []
+
+  loadSettings({sync: syncStorage}, items => loaded.push(items))
+
+  assert.equal(syncStorage.getCalls.length, 1)
+  assert.deepEqual(syncStorage.getCalls[0], STORAGE_DEFAULTS)
+  assert.equal(loaded.length, 1)
+  assert.equal(loaded[0].dclick, true)
+  assert.equal(loaded[0].dclick_speed, '300')
+  assert.equal(loaded[0].popup_fontsize, '15')
+  assert.equal(syncStorage.setCalls.length, 0)
+})
+
+test('saves only known normalized settings and preserves unrelated storage keys', () => {
+  const syncStorage = new FakeSyncStorage({legacy_key: 'keep-me'})
+  let callbackCalled = false
+
+  const normalized = saveSettings({sync: syncStorage}, {
+    ...STORAGE_DEFAULTS,
+    dclick: 'false',
+    dclick_speed: 'not-a-number',
+    unknown_key: 'ignore-me'
+  }, () => {
+    callbackCalled = true
+  })
+
+  assert.equal(callbackCalled, true)
+  assert.equal(normalized.dclick, false)
+  assert.equal(normalized.dclick_speed, 400)
+  assert.equal(syncStorage.setCalls.length, 1)
+  assert.deepEqual(syncStorage.setCalls[0], normalized)
+  assert.equal(syncStorage.items.legacy_key, 'keep-me')
+  assert.equal(syncStorage.setCalls[0].unknown_key, undefined)
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,10 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/settings.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/dictionary/parser.mjs',
           dest: 'dictionary'
         },


### PR DESCRIPTION
## Summary

- Define setting keys, defaults, types, and Options form mappings in one shared schema.
- Normalize boolean, trigger, numeric, string, and nullable URL-list settings with consistent fallbacks.
- Route Options load/save/reset through shared storage helpers without writing defaults during load.
- Apply the same normalized contract in the content-script storage lifecycle.
- Preserve existing storage keys and valid legacy representations, including numeric/string dclick_speed values and empty safe_urls.
- Add lifecycle, compatibility, normalization, and storage helper tests.
- Rebase the branch onto the latest `testflight`, retaining TASK3's dictionary normalizer resource registration.

The background service worker does not read settings directly, so no duplicate background defaults existed to remove. The settings UI layout and wording are unchanged.

## Validation

- `yarn test` — 27 tests passed
- `yarn vite build` — passed
- esbuild content-script bundle — passed
- `git diff --check` — passed