### PR TITLE
refactor: formalize background messaging contract

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "settings.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "messaging.mjs", "settings.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/background-handler.mjs
+++ b/src/background-handler.mjs
@@ -1,0 +1,347 @@
+import {
+  DEFAULT_MESSAGE_TIMEOUT_MS,
+  MESSAGE_ACTIONS,
+  MESSAGE_ERROR_CODES,
+  createErrorResponse,
+  createSuccessResponse,
+  respondOnce
+} from './messaging.mjs'
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isHttpUrl(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return false
+  }
+
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch (_error) {
+    return false
+  }
+}
+
+function hasMessageAction(action) {
+  return Object.values(MESSAGE_ACTIONS).includes(action)
+}
+
+function expectedMethod(action) {
+  return action === MESSAGE_ACTIONS.DICTIONARY ? 'GET' : 'POST'
+}
+
+/**
+ * Validate the two existing message request shapes before touching fetch.
+ * Returning a response instead of throwing makes malformed messages safe at
+ * the service-worker boundary.
+ */
+export function validateMessageRequest(request) {
+  if (!isRecord(request)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The message request must be an object.'
+    )
+  }
+
+  if (typeof request.action !== 'string' || !request.action.trim()) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The message action is required.'
+    )
+  }
+
+  if (!hasMessageAction(request.action)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.UNKNOWN_ACTION,
+      `Unsupported message action: ${request.action}`
+    )
+  }
+
+  if (request.url === undefined || request.url === null || request.url === '') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The message URL is required.'
+    )
+  }
+
+  if (!isHttpUrl(request.url)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The message URL must be an HTTP or HTTPS URL.'
+    )
+  }
+
+  if (request.method === undefined || request.method === null || request.method === '') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The message method is required.'
+    )
+  }
+
+  if (typeof request.method !== 'string') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The message method must be a string.'
+    )
+  }
+
+  if (request.method.toUpperCase() !== expectedMethod(request.action)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      `The ${request.action} action requires ${expectedMethod(request.action)}.`
+    )
+  }
+
+  if (request.action === MESSAGE_ACTIONS.DICTIONARY) {
+    return null
+  }
+
+  if (request.key === undefined || request.key === null || request.key === '') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation API key is required.'
+    )
+  }
+
+  if (typeof request.key !== 'string') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The translation API key must be a string.'
+    )
+  }
+
+  if (!request.key.trim()) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation API key is required.'
+    )
+  }
+
+  if (request.data === undefined || request.data === null) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation payload is required.'
+    )
+  }
+
+  if (!isRecord(request.data)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'The translation payload must be an object.'
+    )
+  }
+
+  if (!Array.isArray(request.data.text) || request.data.text.length === 0) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation payload must include a non-empty text array.'
+    )
+  }
+
+  if (request.data.text.some(text => typeof text !== 'string')) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      'Every translation text value must be a string.'
+    )
+  }
+
+  if (typeof request.data.target_lang !== 'string' || !request.data.target_lang.trim()) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation target language is required.'
+    )
+  }
+
+  return null
+}
+
+function timeoutError() {
+  const error = new Error('The network request timed out.')
+  error.code = MESSAGE_ERROR_CODES.TIMEOUT
+  return error
+}
+
+/**
+ * Race a background fetch against a bounded timeout. AbortController is used
+ * when available, while the race also protects test and older runtimes whose
+ * fetch implementation does not support abort signals.
+ */
+export async function fetchWithTimeout(fetchFn, url, options, timeoutMs) {
+  const normalizedTimeout = Number(timeoutMs)
+  const effectiveTimeout = Number.isFinite(normalizedTimeout) && normalizedTimeout > 0
+    ? normalizedTimeout
+    : DEFAULT_MESSAGE_TIMEOUT_MS
+  const controller = typeof AbortController === 'function'
+    ? new AbortController()
+    : null
+  const fetchOptions = {...options}
+
+  if (controller) {
+    fetchOptions.signal = controller.signal
+  }
+
+  let timeoutId = null
+  const fetchPromise = Promise.resolve().then(() => fetchFn(url, fetchOptions))
+  const timeoutPromise = new Promise((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      controller?.abort()
+      reject(timeoutError())
+    }, effectiveTimeout)
+  })
+
+  try {
+    return await Promise.race([fetchPromise, timeoutPromise])
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+function responsePayloadError(action, data) {
+  if (!isRecord(data)) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+      `The ${action} response must be a JSON object.`
+    )
+  }
+
+  if (action === MESSAGE_ACTIONS.TRANSLATION) {
+    const firstTranslation = data.translations?.[0]
+    if (!Array.isArray(data.translations) ||
+        !isRecord(firstTranslation) ||
+        typeof firstTranslation.text !== 'string') {
+      return createErrorResponse(
+        MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+        'The translation response did not include translated text.'
+      )
+    }
+  }
+
+  return null
+}
+
+function httpErrorResponse(response) {
+  const status = Number.isFinite(response?.status) ? response.status : undefined
+  const suffix = status === undefined ? '' : ` (${status})`
+  return createErrorResponse(
+    MESSAGE_ERROR_CODES.HTTP_ERROR,
+    `The network request failed${suffix}.`,
+    {status}
+  )
+}
+
+function networkErrorResponse(error) {
+  if (error?.code === MESSAGE_ERROR_CODES.TIMEOUT || error?.name === 'AbortError') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.TIMEOUT,
+      'The network request timed out.'
+    )
+  }
+
+  return createErrorResponse(
+    MESSAGE_ERROR_CODES.NETWORK_ERROR,
+    error?.message || 'The network request failed.'
+  )
+}
+
+function requestOptions(request) {
+  if (request.action === MESSAGE_ACTIONS.DICTIONARY) {
+    return {method: request.method}
+  }
+
+  return {
+    method: request.method,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `DeepL-Auth-Key ${request.key}`
+    },
+    body: JSON.stringify(request.data)
+  }
+}
+
+/**
+ * Handle one message independently of chrome.* so all boundary cases can be
+ * tested without loading a service-worker global in Node.
+ */
+export async function handleBackgroundMessage(
+  request,
+  {fetchFn = globalThis.fetch, timeoutMs = DEFAULT_MESSAGE_TIMEOUT_MS} = {}
+) {
+  const validationError = validateMessageRequest(request)
+  if (validationError) {
+    return validationError
+  }
+
+  if (typeof fetchFn !== 'function') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INTERNAL_ERROR,
+      'The background fetch implementation is unavailable.'
+    )
+  }
+
+  let response
+  try {
+    response = await fetchWithTimeout(
+      fetchFn,
+      request.url,
+      requestOptions(request),
+      timeoutMs
+    )
+  } catch (error) {
+    return networkErrorResponse(error)
+  }
+
+  if (!response || typeof response.json !== 'function') {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+      'The network response did not provide a JSON body.'
+    )
+  }
+
+  if (response.ok === false || response.status >= 400) {
+    return httpErrorResponse(response)
+  }
+
+  let data
+  try {
+    data = await response.json()
+  } catch (_error) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+      'The network response was not valid JSON.'
+    )
+  }
+
+  return responsePayloadError(request.action, data) || createSuccessResponse(data)
+}
+
+/**
+ * Register the Chrome listener separately from the fetch logic so the
+ * sendResponse/return-true lifecycle can be tested without a Chrome global.
+ */
+export function registerBackgroundListener(runtime, handler = handleBackgroundMessage) {
+  if (!runtime?.onMessage?.addListener) {
+    return null
+  }
+
+  const listener = (request, _sender, sendResponse) => {
+    const respond = respondOnce(sendResponse)
+
+    Promise.resolve()
+      .then(() => handler(request))
+      .then(respond)
+      .catch(() => respond(createErrorResponse(
+        MESSAGE_ERROR_CODES.INTERNAL_ERROR,
+        'The background message handler failed.'
+      )))
+
+    // Keep the channel open for the asynchronous handler response.
+    return true
+  }
+
+  runtime.onMessage.addListener(listener)
+  return listener
+}

--- a/src/background-handler.mjs
+++ b/src/background-handler.mjs
@@ -163,16 +163,34 @@ function timeoutError() {
   return error
 }
 
-/**
- * Race a background fetch against a bounded timeout. AbortController is used
- * when available, while the race also protects test and older runtimes whose
- * fetch implementation does not support abort signals.
- */
-export async function fetchWithTimeout(fetchFn, url, options, timeoutMs) {
+function invalidJsonError() {
+  const error = new Error('The network response was not valid JSON.')
+  error.code = MESSAGE_ERROR_CODES.INVALID_RESPONSE
+  return error
+}
+
+function effectiveTimeout(timeoutMs) {
   const normalizedTimeout = Number(timeoutMs)
-  const effectiveTimeout = Number.isFinite(normalizedTimeout) && normalizedTimeout > 0
+  return Number.isFinite(normalizedTimeout) && normalizedTimeout > 0
     ? normalizedTimeout
     : DEFAULT_MESSAGE_TIMEOUT_MS
+}
+
+/**
+ * Race a background fetch and response processing against one bounded
+ * deadline. The optional responseHandler is used to parse the body while the
+ * same timer is still active. AbortController is used when available, while
+ * the race also protects test and older runtimes whose fetch implementation
+ * does not support abort signals.
+ */
+export async function fetchWithTimeout(
+  fetchFn,
+  url,
+  options,
+  timeoutMs,
+  responseHandler = response => response
+) {
+  const timeout = effectiveTimeout(timeoutMs)
   const controller = typeof AbortController === 'function'
     ? new AbortController()
     : null
@@ -183,16 +201,22 @@ export async function fetchWithTimeout(fetchFn, url, options, timeoutMs) {
   }
 
   let timeoutId = null
-  const fetchPromise = Promise.resolve().then(() => fetchFn(url, fetchOptions))
+  let rejectTimeout
   const timeoutPromise = new Promise((_resolve, reject) => {
+    rejectTimeout = reject
     timeoutId = setTimeout(() => {
       controller?.abort()
-      reject(timeoutError())
-    }, effectiveTimeout)
+      rejectTimeout(timeoutError())
+    }, timeout)
   })
+  const fetchPromise = Promise.resolve().then(() => fetchFn(url, fetchOptions))
 
   try {
-    return await Promise.race([fetchPromise, timeoutPromise])
+    const response = await Promise.race([fetchPromise, timeoutPromise])
+    return await Promise.race([
+      Promise.resolve().then(() => responseHandler(response)),
+      timeoutPromise
+    ])
   } finally {
     if (timeoutId !== null) {
       clearTimeout(timeoutId)
@@ -241,6 +265,13 @@ function networkErrorResponse(error) {
     )
   }
 
+  if (error?.code === MESSAGE_ERROR_CODES.INVALID_RESPONSE) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+      error.message
+    )
+  }
+
   return createErrorResponse(
     MESSAGE_ERROR_CODES.NETWORK_ERROR,
     error?.message || 'The network request failed.'
@@ -282,18 +313,37 @@ export async function handleBackgroundMessage(
     )
   }
 
-  let response
+  let result
   try {
-    response = await fetchWithTimeout(
+    result = await fetchWithTimeout(
       fetchFn,
       request.url,
       requestOptions(request),
-      timeoutMs
+      timeoutMs,
+      async response => {
+        if (!response || typeof response.json !== 'function') {
+          return {response}
+        }
+
+        if (response.ok === false || response.status >= 400) {
+          return {response}
+        }
+
+        let data
+        try {
+          data = await response.json()
+        } catch (_error) {
+          throw invalidJsonError()
+        }
+
+        return {response, data}
+      }
     )
   } catch (error) {
     return networkErrorResponse(error)
   }
 
+  const response = result?.response
   if (!response || typeof response.json !== 'function') {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.INVALID_RESPONSE,
@@ -305,17 +355,7 @@ export async function handleBackgroundMessage(
     return httpErrorResponse(response)
   }
 
-  let data
-  try {
-    data = await response.json()
-  } catch (_error) {
-    return createErrorResponse(
-      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
-      'The network response was not valid JSON.'
-    )
-  }
-
-  return responsePayloadError(request.action, data) || createSuccessResponse(data)
+  return responsePayloadError(request.action, result.data) || createSuccessResponse(result.data)
 }
 
 /**

--- a/src/background.js
+++ b/src/background.js
@@ -1,23 +1,3 @@
-chrome.runtime.onMessage.addListener(function(request, sender, callback) {
-  if (request.action == 'endic') {
-    fetch(request.url, {
-      method: request.method
-    })
-    .then(response => response.json())
-    .then(data => callback(data))
-    return true
-  }
-  else if (request.action == 'translation') {
-    fetch(request.url, {
-      method: request.method,
-      headers: {
-        "Content-Type": "application/json",
-        "Authorization": "DeepL-Auth-Key " + request.key
-      },
-      body: JSON.stringify(request.data)
-    })
-    .then(response => response.json())
-    .then(data => callback(data))
-    return true
-  }
-})
+import { registerBackgroundListener } from './background-handler.mjs'
+
+registerBackgroundListener(chrome.runtime)

--- a/src/components/Popup.vue
+++ b/src/components/Popup.vue
@@ -1,6 +1,11 @@
 <script setup>
 import { computed, ref, onMounted } from 'vue'
 import { buildNaverApiUrl, parseNaverDictionaryResponse } from '/src/dictionary/parser.mjs'
+import {
+  createDictionaryRequest,
+  reportMessageFailure,
+  sendRuntimeMessage
+} from '/src/messaging.mjs'
 import { getText } from '/src/text.js'
 
 const word = ref('')
@@ -10,18 +15,18 @@ const audioEntryIndex = computed(() => entries.value.findIndex(entry => entry.au
 async function searchWord(searchTerm) {
   const url = buildNaverApiUrl(searchTerm)
 
-  chrome.runtime.sendMessage({
-    method: 'GET',
-    action: 'endic',
-    url: url,
-    }, function(data) {
-      if (!data) {
-        entries.value = []
-        return
-      }
+  const response = await sendRuntimeMessage(
+    chrome.runtime,
+    createDictionaryRequest({method: 'GET', url})
+  )
 
-      entries.value = parseNaverDictionaryResponse(data)
-  })
+  if (!response.ok) {
+    entries.value = []
+    reportMessageFailure('dictionary lookup', response)
+    return
+  }
+
+  entries.value = parseNaverDictionaryResponse(response.data)
 }
 
 onMounted(() => {

--- a/src/content.js
+++ b/src/content.js
@@ -8,6 +8,13 @@ import {
 } from './content-interaction.mjs'
 import { createStorageLifecycle } from './content-storage.mjs'
 import {
+  MESSAGE_ERROR_CODES,
+  createDictionaryRequest,
+  createTranslationRequest,
+  reportMessageFailure,
+  sendRuntimeMessage
+} from './messaging.mjs'
+import {
   DEFAULT_OPTIONS,
   normalizeSettings,
   STORAGE_DEFAULTS
@@ -146,37 +153,53 @@ function showFrame(e, datain, top, left, type = 'dictionary') {
 async function consultDic(e, word, top, left) {
   const url = buildNaverApiUrl(word)
 
-  chrome.runtime.sendMessage({
-    method: 'GET',
-    action: 'endic',
-    url: url,
-  }, function(data) {
-    if (!data) {
-      return
-    }
+  const response = await sendRuntimeMessage(
+    chrome.runtime,
+    createDictionaryRequest({method: 'GET', url})
+  )
 
-    showFrame(e, parseNaverDictionaryResponse(data), top, left)
-  })
+  if (!response.ok) {
+    reportMessageFailure('dictionary lookup', response)
+    return
+  }
+
+  showFrame(e, parseNaverDictionaryResponse(response.data), top, left)
 }
 
 async function translate(e, text, top, left, key) {
   const url = 'https://api-free.deepl.com/v2/translate'
 
-  chrome.runtime.sendMessage({
-    method: 'POST',
-    action: 'translation',
-    url: url,
-    key: key,
-    data: {
-      text: [text],
-      target_lang: 'ko'
-    },
-  }, function(data) {
-    if (!data) {
-      return
-    }
-    showFrame(e, data['translations'][0]['text'], top, left, 'translation');
-  })
+  const response = await sendRuntimeMessage(
+    chrome.runtime,
+    createTranslationRequest({
+      method: 'POST',
+      url,
+      key,
+      data: {
+        text: [text],
+        target_lang: 'ko'
+      }
+    })
+  )
+
+  if (!response.ok) {
+    reportMessageFailure('translation', response)
+    return
+  }
+
+  const translatedText = response.data?.translations?.[0]?.text
+  if (typeof translatedText !== 'string') {
+    reportMessageFailure('translation', {
+      ok: false,
+      error: {
+        code: MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+        message: 'The translation response did not include translated text.'
+      }
+    })
+    return
+  }
+
+  showFrame(e, translatedText, top, left, 'translation')
 }
 
 function openPopup(e, key=null, type='search') {

--- a/src/messaging.mjs
+++ b/src/messaging.mjs
@@ -1,0 +1,233 @@
+export const DEFAULT_MESSAGE_TIMEOUT_MS = 10000
+
+export const MESSAGE_ACTIONS = Object.freeze({
+  DICTIONARY: 'endic',
+  TRANSLATION: 'translation'
+})
+
+export const MESSAGE_ERROR_CODES = Object.freeze({
+  INVALID_REQUEST: 'INVALID_REQUEST',
+  MISSING_PAYLOAD: 'MISSING_PAYLOAD',
+  UNKNOWN_ACTION: 'UNKNOWN_ACTION',
+  HTTP_ERROR: 'HTTP_ERROR',
+  INVALID_RESPONSE: 'INVALID_RESPONSE',
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  RUNTIME_ERROR: 'RUNTIME_ERROR',
+  TIMEOUT: 'TIMEOUT',
+  INTERNAL_ERROR: 'INTERNAL_ERROR'
+})
+
+/**
+ * Existing actions only. Both actions use the same response envelope:
+ * {ok: true, data: unknown} or
+ * {ok: false, error: {code: string, message: string, ...details}}.
+ *
+ * endic request:       {action: 'endic', method: 'GET', url: string}
+ * translation request: {action: 'translation', method: 'POST', url: string,
+ *                        key: string, data: {text: string[], target_lang: string}}
+ */
+export const MESSAGE_CONTRACTS = Object.freeze({
+  [MESSAGE_ACTIONS.DICTIONARY]: Object.freeze({
+    request: "{ action: 'endic', method: 'GET', url: string }",
+    response: 'MessageResponse<NaverDictionaryResponse>'
+  }),
+  [MESSAGE_ACTIONS.TRANSLATION]: Object.freeze({
+    request: "{ action: 'translation', method: 'POST', url: string, key: string, data: TranslationRequest }",
+    response: 'MessageResponse<DeepLTranslationResponse>'
+  })
+})
+
+const hasOwn = (value, key) => Object.prototype.hasOwnProperty.call(value, key)
+
+function getErrorMessage(error, fallback) {
+  if (typeof error === 'string' && error.trim()) {
+    return error.trim()
+  }
+
+  if (error && typeof error.message === 'string' && error.message.trim()) {
+    return error.message.trim()
+  }
+
+  return fallback
+}
+
+export function createDictionaryRequest({url, method = 'GET'} = {}) {
+  return {
+    action: MESSAGE_ACTIONS.DICTIONARY,
+    method,
+    url
+  }
+}
+
+export function createTranslationRequest({url, method = 'POST', key, data} = {}) {
+  return {
+    action: MESSAGE_ACTIONS.TRANSLATION,
+    method,
+    url,
+    key,
+    data
+  }
+}
+
+export function createSuccessResponse(data) {
+  return {ok: true, data}
+}
+
+export function createErrorResponse(code, message, details = {}) {
+  const error = {
+    code: code || MESSAGE_ERROR_CODES.INTERNAL_ERROR,
+    message: getErrorMessage(message, 'The message request failed.')
+  }
+
+  if (details && typeof details === 'object') {
+    Object.entries(details).forEach(([key, value]) => {
+      if (value !== undefined) {
+        error[key] = value
+      }
+    })
+  }
+
+  return {ok: false, error}
+}
+
+export function isMessageResponse(response) {
+  if (!response || typeof response !== 'object') {
+    return false
+  }
+
+  if (response.ok === true) {
+    return hasOwn(response, 'data')
+  }
+
+  return response.ok === false &&
+    response.error &&
+    typeof response.error === 'object' &&
+    typeof response.error.code === 'string' &&
+    typeof response.error.message === 'string'
+}
+
+function getRuntimeLastError(runtime) {
+  try {
+    const lastError = runtime?.lastError
+    return lastError && typeof lastError.message === 'string'
+      ? lastError
+      : null
+  } catch (_error) {
+    return null
+  }
+}
+
+/**
+ * Send one runtime message and always resolve with the shared response shape.
+ * The completion guard protects callers from callback/promise double delivery
+ * and from a late callback after the timeout has already fired.
+ */
+export function sendRuntimeMessage(
+  runtime,
+  request,
+  {timeoutMs = DEFAULT_MESSAGE_TIMEOUT_MS} = {}
+) {
+  return new Promise(resolve => {
+    let settled = false
+    let timeoutId = null
+
+    const complete = response => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+
+      const lastError = getRuntimeLastError(runtime)
+      if (lastError) {
+        resolve(createErrorResponse(
+          MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+          lastError.message
+        ))
+        return
+      }
+
+      resolve(isMessageResponse(response)
+        ? response
+        : createErrorResponse(
+          MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+          'The message response did not match the expected contract.'
+        ))
+    }
+
+    const normalizedTimeout = Number(timeoutMs)
+    if (Number.isFinite(normalizedTimeout) && normalizedTimeout > 0) {
+      timeoutId = setTimeout(() => {
+        complete(createErrorResponse(
+          MESSAGE_ERROR_CODES.TIMEOUT,
+          'The message request timed out.'
+        ))
+      }, normalizedTimeout)
+    }
+
+    try {
+      const returned = runtime?.sendMessage?.(request, complete)
+      // Some MV3 runtimes expose a Promise as well as the callback API. Keep
+      // this path guarded so either delivery mechanism can complete once.
+      if (returned && typeof returned.then === 'function') {
+        returned
+          .then(complete)
+          .catch(error => complete(createErrorResponse(
+            MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+            getErrorMessage(error, 'The runtime message failed.')
+          )))
+      }
+    } catch (error) {
+      complete(createErrorResponse(
+        MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+        getErrorMessage(error, 'The runtime message failed.')
+      ))
+    }
+  })
+}
+
+/**
+ * Report an already-normalized failure without adding a user-facing error UI.
+ * Task5 callers use this for console diagnostics while preserving the current
+ * no-result behaviour of the dictionary and translation popups.
+ */
+export function reportMessageFailure(scope, response, logger = globalThis.console) {
+  if (isMessageResponse(response) && response.ok === false) {
+    logger?.error?.(
+      `[naverdic] ${scope} failed (${response.error.code}): ${response.error.message}`
+    )
+    return true
+  }
+
+  if (!isMessageResponse(response)) {
+    logger?.error?.(`[naverdic] ${scope} failed: invalid message response`)
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Protect the background listener from duplicate sendResponse calls.
+ */
+export function respondOnce(sendResponse) {
+  let responded = false
+
+  return response => {
+    if (responded) {
+      return false
+    }
+
+    responded = true
+    try {
+      sendResponse?.(response)
+    } catch (_error) {
+      // The channel can close before a late response is delivered. It must not
+      // turn an already handled request into an uncaught service-worker error.
+    }
+    return true
+  }
+}

--- a/tests/messaging.test.mjs
+++ b/tests/messaging.test.mjs
@@ -162,6 +162,16 @@ test('turns HTTP, network, timeout, and malformed responses into explicit errors
     timeoutMs: 5
   })
   assert.equal(timeout.error.code, MESSAGE_ERROR_CODES.TIMEOUT)
+
+  const bodyTimeout = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: async () => ({
+      ok: true,
+      status: 200,
+      json: () => new Promise(() => {})
+    }),
+    timeoutMs: 5
+  })
+  assert.equal(bodyTimeout.error.code, MESSAGE_ERROR_CODES.TIMEOUT)
 })
 
 test('runtime sender handles lastError, invalid responses, timeout, and duplicate delivery', async () => {

--- a/tests/messaging.test.mjs
+++ b/tests/messaging.test.mjs
@@ -1,0 +1,260 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_MESSAGE_TIMEOUT_MS,
+  MESSAGE_ACTIONS,
+  MESSAGE_CONTRACTS,
+  MESSAGE_ERROR_CODES,
+  createDictionaryRequest,
+  createErrorResponse,
+  createSuccessResponse,
+  createTranslationRequest,
+  isMessageResponse,
+  reportMessageFailure,
+  respondOnce,
+  sendRuntimeMessage
+} from '../src/messaging.mjs'
+import {
+  handleBackgroundMessage,
+  registerBackgroundListener,
+  validateMessageRequest
+} from '../src/background-handler.mjs'
+
+function jsonResponse(data, overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    ...overrides
+  }
+}
+
+function dictionaryRequest(overrides = {}) {
+  return createDictionaryRequest({
+    method: 'GET',
+    url: 'https://en.dict.naver.com/api3/enko/search?query=hello',
+    ...overrides
+  })
+}
+
+function translationRequest(overrides = {}) {
+  return createTranslationRequest({
+    method: 'POST',
+    url: 'https://api-free.deepl.com/v2/translate',
+    key: 'test-key',
+    data: {text: ['hello'], target_lang: 'ko'},
+    ...overrides
+  })
+}
+
+test('documents the existing actions and creates their request envelopes', () => {
+  assert.deepEqual(MESSAGE_ACTIONS, {
+    DICTIONARY: 'endic',
+    TRANSLATION: 'translation'
+  })
+  assert.ok(MESSAGE_CONTRACTS.endic.request.includes("action: 'endic'"))
+  assert.ok(MESSAGE_CONTRACTS.translation.response.includes('DeepLTranslationResponse'))
+
+  assert.deepEqual(dictionaryRequest(), {
+    action: 'endic',
+    method: 'GET',
+    url: 'https://en.dict.naver.com/api3/enko/search?query=hello'
+  })
+  assert.deepEqual(translationRequest(), {
+    action: 'translation',
+    method: 'POST',
+    url: 'https://api-free.deepl.com/v2/translate',
+    key: 'test-key',
+    data: {text: ['hello'], target_lang: 'ko'}
+  })
+  assert.deepEqual(createSuccessResponse({value: 1}), {ok: true, data: {value: 1}})
+  assert.deepEqual(createErrorResponse('TEST', 'failed', {status: 500}), {
+    ok: false,
+    error: {code: 'TEST', message: 'failed', status: 500}
+  })
+})
+
+test('rejects unknown and incomplete requests before calling fetch', async () => {
+  let fetchCalls = 0
+  const dependencies = {
+    fetchFn: async () => {
+      fetchCalls += 1
+      return jsonResponse({})
+    }
+  }
+
+  const cases = [
+    [null, MESSAGE_ERROR_CODES.INVALID_REQUEST],
+    [{action: 'unknown', url: 'https://example.com', method: 'GET'}, MESSAGE_ERROR_CODES.UNKNOWN_ACTION],
+    [{action: 'endic', method: 'GET'}, MESSAGE_ERROR_CODES.MISSING_PAYLOAD],
+    [{action: 'endic', method: 'POST', url: 'https://example.com'}, MESSAGE_ERROR_CODES.INVALID_REQUEST],
+    [{action: 'endic', method: 'GET', url: 'not-a-url'}, MESSAGE_ERROR_CODES.INVALID_REQUEST],
+    [translationRequest({key: ''}), MESSAGE_ERROR_CODES.MISSING_PAYLOAD],
+    [translationRequest({data: undefined}), MESSAGE_ERROR_CODES.MISSING_PAYLOAD],
+    [translationRequest({data: {text: ['hello']}}), MESSAGE_ERROR_CODES.MISSING_PAYLOAD]
+  ]
+
+  for (const [request, code] of cases) {
+    const response = await handleBackgroundMessage(request, dependencies)
+    assert.equal(response.ok, false)
+    assert.equal(response.error.code, code)
+  }
+
+  assert.equal(fetchCalls, 0)
+  assert.equal(validateMessageRequest(dictionaryRequest()), null)
+})
+
+test('returns a shared success response for dictionary and translation requests', async () => {
+  const dictionaryData = {searchResultMap: {searchResultListMap: {WORD: {items: []}}}}
+  const translationData = {translations: [{text: '안녕'}]}
+  const calls = []
+
+  const dictionaryResponse = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: async (url, options) => {
+      calls.push({url, options})
+      return jsonResponse(dictionaryData)
+    }
+  })
+  const translationResponse = await handleBackgroundMessage(translationRequest(), {
+    fetchFn: async (url, options) => {
+      calls.push({url, options})
+      return jsonResponse(translationData)
+    }
+  })
+
+  assert.deepEqual(dictionaryResponse, {ok: true, data: dictionaryData})
+  assert.deepEqual(translationResponse, {ok: true, data: translationData})
+  assert.deepEqual(calls[0].options, {method: 'GET', signal: calls[0].options.signal})
+  assert.equal(calls[1].options.method, 'POST')
+  assert.equal(calls[1].options.headers.Authorization, 'DeepL-Auth-Key test-key')
+  assert.deepEqual(JSON.parse(calls[1].options.body), {
+    text: ['hello'],
+    target_lang: 'ko'
+  })
+})
+
+test('turns HTTP, network, timeout, and malformed responses into explicit errors', async () => {
+  const httpError = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: async () => jsonResponse({message: 'unauthorized'}, {ok: false, status: 401})
+  })
+  assert.equal(httpError.ok, false)
+  assert.equal(httpError.error.code, MESSAGE_ERROR_CODES.HTTP_ERROR)
+  assert.equal(httpError.error.status, 401)
+
+  const invalidJson = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: async () => ({ok: true, status: 200, json: async () => { throw new Error('bad json') }})
+  })
+  assert.equal(invalidJson.error.code, MESSAGE_ERROR_CODES.INVALID_RESPONSE)
+
+  const invalidTranslation = await handleBackgroundMessage(translationRequest(), {
+    fetchFn: async () => jsonResponse({translations: []})
+  })
+  assert.equal(invalidTranslation.error.code, MESSAGE_ERROR_CODES.INVALID_RESPONSE)
+
+  const networkError = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: async () => { throw new Error('offline') }
+  })
+  assert.equal(networkError.error.code, MESSAGE_ERROR_CODES.NETWORK_ERROR)
+
+  const timeout = await handleBackgroundMessage(dictionaryRequest(), {
+    fetchFn: () => new Promise(() => {}),
+    timeoutMs: 5
+  })
+  assert.equal(timeout.error.code, MESSAGE_ERROR_CODES.TIMEOUT)
+})
+
+test('runtime sender handles lastError, invalid responses, timeout, and duplicate delivery', async () => {
+  const request = dictionaryRequest()
+  const success = createSuccessResponse({searchResultMap: {}})
+
+  const duplicate = await sendRuntimeMessage({
+    sendMessage(_request, callback) {
+      callback(success)
+      callback(createErrorResponse(MESSAGE_ERROR_CODES.NETWORK_ERROR, 'late'))
+    }
+  }, request, {timeoutMs: 20})
+  assert.deepEqual(duplicate, success)
+
+  const lastError = await sendRuntimeMessage({
+    lastError: {message: 'The message port closed.'},
+    sendMessage(_request, callback) {
+      callback(undefined)
+    }
+  }, request, {timeoutMs: 20})
+  assert.equal(lastError.error.code, MESSAGE_ERROR_CODES.RUNTIME_ERROR)
+  assert.equal(lastError.error.message, 'The message port closed.')
+
+  const invalid = await sendRuntimeMessage({
+    sendMessage(_request, callback) {
+      callback({searchResultMap: {}})
+    }
+  }, request, {timeoutMs: 20})
+  assert.equal(invalid.error.code, MESSAGE_ERROR_CODES.INVALID_RESPONSE)
+
+  const timeout = await sendRuntimeMessage({
+    sendMessage() {}
+  }, request, {timeoutMs: 5})
+  assert.equal(timeout.error.code, MESSAGE_ERROR_CODES.TIMEOUT)
+
+  const promiseResponse = await sendRuntimeMessage({
+    sendMessage() {
+      return Promise.resolve(success)
+    }
+  }, request, {timeoutMs: 20})
+  assert.deepEqual(promiseResponse, success)
+})
+
+test('respondOnce and failure reporting prevent duplicate or silent handling', () => {
+  const sent = []
+  const respond = respondOnce(response => sent.push(response))
+  assert.equal(respond(createSuccessResponse('first')), true)
+  assert.equal(respond(createSuccessResponse('second')), false)
+  assert.deepEqual(sent, [createSuccessResponse('first')])
+
+  const errors = []
+  const failed = createErrorResponse(MESSAGE_ERROR_CODES.TIMEOUT, 'timed out')
+  assert.equal(reportMessageFailure('lookup', failed, {error: message => errors.push(message)}), true)
+  assert.equal(errors.length, 1)
+  assert.match(errors[0], /TIMEOUT/)
+  assert.equal(reportMessageFailure('lookup', createSuccessResponse('ok'), {
+    error: () => { throw new Error('success should not be logged') }
+  }), false)
+  assert.equal(isMessageResponse(failed), true)
+  assert.equal(DEFAULT_MESSAGE_TIMEOUT_MS > 0, true)
+})
+
+test('background listener keeps the channel open and sends one response', async () => {
+  let listener
+  const runtime = {
+    onMessage: {
+      addListener(value) {
+        listener = value
+      }
+    }
+  }
+  const response = createSuccessResponse({value: 1})
+  registerBackgroundListener(runtime, async () => response)
+
+  const sent = []
+  assert.equal(listener(dictionaryRequest(), {}, value => sent.push(value)), true)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.deepEqual(sent, [response])
+
+  const failedRuntime = {
+    onMessage: {
+      addListener(value) {
+        listener = value
+      }
+    }
+  }
+  registerBackgroundListener(failedRuntime, async () => {
+    throw new Error('unexpected')
+  })
+
+  const failures = []
+  assert.equal(listener(dictionaryRequest(), {}, value => failures.push(value)), true)
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(failures.length, 1)
+  assert.equal(failures[0].error.code, MESSAGE_ERROR_CODES.INTERNAL_ERROR)
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,6 +24,14 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/background-handler.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/messaging.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/content.js',
           dest: '.'
         },


### PR DESCRIPTION
## Summary

- Document the existing `endic` and `translation` request shapes and standardize both responses as `{ok, data}` or `{ok: false, error}`.
- Validate unknown actions and missing or malformed payloads before background fetches.
- Add one bounded background deadline covering fetch headers and response body parsing, including HTTP, network, invalid JSON, and timeout failures.
- Make content script and Popup callers handle runtime `lastError`, invalid responses, timeouts, and translation payload gaps without uncaught exceptions.
- Keep background `sendResponse` asynchronous lifecycle explicit with `return true` and a one-response guard.
- Preserve the existing dictionary and DeepL URLs/actions; no new action or user-facing error UI added.

## Validation

- `yarn test` — 34 tests passed, including a hanging `response.json()` timeout case
- `yarn vite build` — passed
- `esbuild --bundle src/content.js` — passed
- `git diff --check` — passed
