### PR TITLE
build: validate v6.6 packaging and regression checklist

### DIFF
--- a/docs/task6-verification.md
+++ b/docs/task6-verification.md
@@ -1,0 +1,45 @@
+# Task6 verification — v6.6 Stage 1 candidate
+
+## Automated result
+
+- `yarn test`: passed, 36 tests.
+- `yarn build`: passed as a one-shot Vite production build.
+- `yarn package` / `NAVERDIC_ZIP_DIR=/tmp/naverdic-task6-package bash pack.sh`: passed.
+- Artifact: `naverdic_6.6.zip`.
+- Package validator: 28 unpacked files and 28 ZIP files; manifest and raw content imports resolved; no development files; manifest/package version is consistent.
+- ZIP extraction compared with `dist/`: identical file set and contents.
+- `esbuild` background/content bundles: passed as part of `pack.sh`.
+
+## Chrome regression checklist
+
+Status is recorded explicitly because the Codex Chrome bridge was unavailable in this environment. Google Chrome 151.0.7922.138 was installed and running, but the Codex browser extension and native host were not installed, so no browser UI action was claimed as verified.
+
+| Scenario | Status | Evidence or follow-up |
+| --- | --- | --- |
+| Clean-profile unpacked install | Blocked | Load `dist/` after enabling the Codex Chrome bridge. |
+| Update an existing install and preserve settings | Blocked | Save settings, replace unpacked directory, reload extension, verify values. |
+| Double-click word search | Blocked | Smoke test in a normal page. |
+| Horizontal and vertical sentence drag | Blocked | Verify dictionary/translation routing. |
+| Ctrl, Command, Alt, and combined triggers | Automated | Trigger matching is covered by `tests/content-interaction.test.mjs`; real browser gesture remains blocked. |
+| Deny-list exact host and subdomain | Automated | Host boundary behavior is covered by unit tests; real navigation remains blocked. |
+| Selection inside an iframe | Blocked | Verify with an iframe page after Chrome bridge setup. |
+| Settings change does not duplicate events | Automated | Lifecycle registration/removal and change handling are unit-tested; real page update remains blocked. |
+| Headword, meanings, phonetic symbol, and audio | Automated/blocked | Parser/normalizer tests pass; real audio and popup rendering need Chrome. |
+| DeepL success and major error response | Automated/blocked | Message contract/error tests pass; real API interaction needs a configured key and Chrome. |
+| Popup position, removal, and recall | Blocked | Verify on page edges and repeated selections. |
+| Background message failure and recovery | Automated/blocked | Failure/timeout/response tests pass; real extension recovery needs Chrome. |
+| ZIP install | Blocked | ZIP contents are validated; install-only confirmation needs Chrome. |
+
+## Known limitations and final smoke test
+
+No packaging blocker remains. The remaining risk is environmental: Chrome extension installation and real user gestures were not executed by Codex. Before merging the final Stage 1 candidate, perform this smoke test in Chrome:
+
+1. Load `dist/` as an unpacked extension and confirm the popup opens.
+2. Search `hello`; confirm headword, meanings, pronunciation, and audio render.
+3. Double-click an English word, drag a short sentence horizontally and vertically, and try the configured Ctrl/Command/Alt combinations.
+4. Change a setting, reload the extension, and verify the page updates once without duplicate popups.
+5. Check deny-list exact host/subdomain behavior and a selection inside an iframe.
+6. Configure a DeepL key, verify one successful translation, then verify a failed request recovers without an uncaught error.
+7. Replace the unpacked install with the contents of `naverdic_6.6.zip` and repeat the popup/search smoke test.
+
+Unverified browser items are environment-blocked, not treated as passed. No unrelated improvements were added.

--- a/pack.py
+++ b/pack.py
@@ -4,6 +4,7 @@ import os
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 MANIFEST_PATH = os.path.join(BASE_DIR, 'public/manifest.json')
 
-manifest = json.loads(open(os.path.join(MANIFEST_PATH, MANIFEST_PATH)).read())
+with open(MANIFEST_PATH, encoding='utf-8') as manifest_file:
+    manifest = json.load(manifest_file)
 
 print("%s_%s.zip" % (os.path.basename(BASE_DIR), manifest.get('version')))

--- a/pack.sh
+++ b/pack.sh
@@ -1,8 +1,52 @@
-./node_modules/.bin/esbuild --bundle src/background.js --minify --format=esm --outfile=dist/background.js
-./node_modules/.bin/esbuild --bundle src/content.js --minify --format=esm --outfile=dist/content.js
-./node_modules/.bin/esbuild --bundle src/content.css --minify --outfile=dist/content.css
+#!/usr/bin/env bash
+set -euo pipefail
 
-filename=`python3 pack.py`
-cd dist
-zip -r ~/Downloads/$filename *
-cd ..
+PROJECT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DIST_DIR="$PROJECT_ROOT/dist"
+VITE_BIN="$PROJECT_ROOT/node_modules/.bin/vite"
+ESBUILD_BIN="$PROJECT_ROOT/node_modules/.bin/esbuild"
+
+if [[ ! -x "$VITE_BIN" || ! -x "$ESBUILD_BIN" ]]; then
+  echo "Missing local build dependencies. Run yarn install first." >&2
+  exit 1
+fi
+
+cd "$PROJECT_ROOT"
+"$VITE_BIN" build
+
+# Vite copies the raw service/content modules for development. The release
+# package uses minified bundles while retaining the static modules declared by
+# the manifest for unpacked/content-script compatibility.
+"$ESBUILD_BIN" --bundle src/background.js --minify --format=esm --outfile="$DIST_DIR/background.js"
+"$ESBUILD_BIN" --bundle src/content.js --minify --format=esm --outfile="$DIST_DIR/content.js"
+"$ESBUILD_BIN" --bundle src/content.css --minify --outfile="$DIST_DIR/content.css"
+
+# index.html and its index-* chunks are the repository's development demo, not
+# extension entry points. These public demo assets are not needed by Chrome.
+rm -f \
+  "$DIST_DIR/index.html" \
+  "$DIST_DIR/favicon.ico" \
+  "$DIST_DIR/logo.png" \
+  "$DIST_DIR/icon.png"
+find "$DIST_DIR/assets" -maxdepth 1 -type f -name 'index-*' -delete
+
+ZIP_NAME="$(python3 "$PROJECT_ROOT/pack.py")"
+ZIP_DIR="${NAVERDIC_ZIP_DIR:-${HOME:-$PROJECT_ROOT}/Downloads}"
+mkdir -p "$ZIP_DIR"
+ZIP_DIR="$(cd -- "$ZIP_DIR" && pwd)"
+ZIP_PATH="$ZIP_DIR/$ZIP_NAME"
+TEMP_ZIP="$ZIP_PATH.tmp.$$"
+trap 'rm -f "$TEMP_ZIP"' EXIT
+
+(
+  cd "$DIST_DIR"
+  zip -qr "$TEMP_ZIP" .
+)
+mv -f "$TEMP_ZIP" "$ZIP_PATH"
+
+node "$PROJECT_ROOT/scripts/validate-package.mjs" \
+  --project-root "$PROJECT_ROOT" \
+  --dir "$DIST_DIR" \
+  --zip "$ZIP_PATH"
+
+printf 'Created %s\n' "$ZIP_PATH"

--- a/pack.sh
+++ b/pack.sh
@@ -28,7 +28,11 @@ rm -f \
   "$DIST_DIR/favicon.ico" \
   "$DIST_DIR/logo.png" \
   "$DIST_DIR/icon.png"
-find "$DIST_DIR/assets" -maxdepth 1 -type f -name 'index-*' -delete
+for index_asset in "$DIST_DIR"/assets/index-*; do
+  if [[ -f "$index_asset" ]]; then
+    rm -f "$index_asset"
+  fi
+done
 
 ZIP_NAME="$(python3 "$PROJECT_ROOT/pack.py")"
 ZIP_DIR="${NAVERDIC_ZIP_DIR:-${HOME:-$PROJECT_ROOT}/Downloads}"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "test": "node --test tests/*.test.mjs",
-    "build": "vite build --watch",
+    "build": "vite build",
+    "package": "bash pack.sh",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -1,0 +1,297 @@
+import {execFileSync} from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const SOURCE_ENTRYPOINTS = [
+  'src/background.js',
+  'src/content.js'
+]
+
+const FORBIDDEN_PACKAGE_PATHS = [
+  /^(src|tests|node_modules|\.git)(\/|$)/,
+  /(^|\/)(package\.json|yarn\.lock|vite\.config\.js|pack\.sh|pack\.py)$/,
+  /(^|\/)\.DS_Store$/,
+  /\.map$/,
+  /^index\.html$/,
+  /^favicon\.ico$/,
+  /^(logo|icon)\.png$/,
+  /^assets\/index-[^/]+$/
+]
+
+function normalizeEntry(value) {
+  return String(value)
+    .replaceAll('\\', '/')
+    .replace(/^\.\//, '')
+    .replace(/^\/+/, '')
+}
+
+function addManifestPath(paths, value) {
+  if (typeof value === 'string' && value && !value.includes('*')) {
+    paths.add(normalizeEntry(value))
+  }
+}
+
+export function collectManifestFiles(manifest) {
+  const files = new Set(['manifest.json'])
+
+  Object.values(manifest.icons || {}).forEach(value => addManifestPath(files, value))
+  addManifestPath(files, manifest.options_ui?.page)
+  addManifestPath(files, manifest.action?.default_popup)
+  addManifestPath(files, manifest.background?.service_worker)
+
+  for (const contentScript of manifest.content_scripts || []) {
+    for (const file of contentScript.js || []) {
+      addManifestPath(files, file)
+    }
+    for (const file of contentScript.css || []) {
+      addManifestPath(files, file)
+    }
+  }
+
+  for (const ruleResource of manifest.declarative_net_request?.rule_resources || []) {
+    addManifestPath(files, ruleResource.path)
+  }
+
+  for (const resourceGroup of manifest.web_accessible_resources || []) {
+    for (const file of resourceGroup.resources || []) {
+      addManifestPath(files, file)
+    }
+  }
+
+  return files
+}
+
+function localImportSpecs(source) {
+  const specs = new Set()
+  const patterns = [
+    /\bfrom\s*["'](\.[^"']+)["']/g,
+    /\bimport\s*\(\s*["'](\.[^"']+)["']\s*\)/g,
+    /\bimport\s*["'](\.[^"']+)["']/g
+  ]
+
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      specs.add(match[1])
+    }
+  }
+
+  return specs
+}
+
+function sourceToPackagePath(projectRoot, sourcePath) {
+  const sourceRoot = path.join(projectRoot, 'src')
+  const relativeSource = normalizeEntry(path.relative(sourceRoot, sourcePath))
+  return relativeSource.startsWith('dictionary/')
+    ? relativeSource
+    : relativeSource
+}
+
+/**
+ * Follow the raw background/content imports that Vite copies for unpacked
+ * extension loading. The pack step may bundle these files, but keeping their
+ * static counterparts makes the Vite and ZIP outputs compatible.
+ */
+export function collectSourceDependencies(projectRoot) {
+  const queue = SOURCE_ENTRYPOINTS.map(entry => path.join(projectRoot, entry))
+  const visited = new Set()
+  const dependencies = new Set()
+  const sourceRoot = path.join(projectRoot, 'src')
+
+  while (queue.length > 0) {
+    const sourcePath = path.resolve(queue.shift())
+    if (visited.has(sourcePath) || !sourcePath.startsWith(`${sourceRoot}${path.sep}`)) {
+      continue
+    }
+    visited.add(sourcePath)
+
+    if (!fs.existsSync(sourcePath)) {
+      continue
+    }
+
+    dependencies.add(sourceToPackagePath(projectRoot, sourcePath))
+    const source = fs.readFileSync(sourcePath, 'utf8')
+    for (const spec of localImportSpecs(source)) {
+      const importedPath = path.resolve(path.dirname(sourcePath), spec)
+      if (fs.existsSync(importedPath)) {
+        queue.push(importedPath)
+      }
+    }
+  }
+
+  return dependencies
+}
+
+function listFiles(root, current = root) {
+  const files = []
+  for (const entry of fs.readdirSync(current, {withFileTypes: true})) {
+    const absolutePath = path.join(current, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...listFiles(root, absolutePath))
+    } else if (entry.isFile()) {
+      files.push(normalizeEntry(path.relative(root, absolutePath)))
+    }
+  }
+  return files
+}
+
+function missingAndExtra(expected, actual) {
+  const expectedSet = new Set(expected)
+  const actualSet = new Set(actual)
+  return {
+    missing: [...expectedSet].filter(file => !actualSet.has(file)).sort(),
+    extra: [...actualSet].filter(file => !expectedSet.has(file)).sort()
+  }
+}
+
+function packageForbiddenFiles(files) {
+  return files.filter(file => FORBIDDEN_PACKAGE_PATHS.some(pattern => pattern.test(file))).sort()
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+export function validatePackageDirectory({projectRoot, packageDir}) {
+  const errors = []
+  const manifestPath = path.join(packageDir, 'manifest.json')
+  const actualFiles = fs.existsSync(packageDir) ? listFiles(packageDir) : []
+
+  if (!fs.existsSync(manifestPath)) {
+    return {
+      errors: [`Missing ${path.relative(packageDir, manifestPath)}.`],
+      actualFiles,
+      expectedFiles: []
+    }
+  }
+
+  let manifest
+  try {
+    manifest = readJson(manifestPath)
+  } catch (error) {
+    return {
+      errors: [`Manifest is not valid JSON: ${error.message}`],
+      actualFiles,
+      expectedFiles: []
+    }
+  }
+
+  const expectedFiles = new Set([
+    ...collectManifestFiles(manifest),
+    ...collectSourceDependencies(projectRoot)
+  ])
+  const differences = missingAndExtra(expectedFiles, actualFiles)
+
+  if (differences.missing.length > 0) {
+    errors.push(`Manifest/import files missing from package: ${differences.missing.join(', ')}`)
+  }
+
+  const forbidden = packageForbiddenFiles(actualFiles)
+  if (forbidden.length > 0) {
+    errors.push(`Development files found in package: ${forbidden.join(', ')}`)
+  }
+
+  const packageJsonPath = path.join(projectRoot, 'package.json')
+  if (fs.existsSync(packageJsonPath)) {
+    const packageVersion = String(readJson(packageJsonPath).version || '')
+    const manifestVersion = String(manifest.version || '')
+    if (!manifestVersion || !packageVersion.startsWith(`${manifestVersion}.`)) {
+      errors.push(`Version mismatch: manifest ${manifestVersion || '(missing)'} vs package ${packageVersion || '(missing)'}.`)
+    }
+  }
+
+  return {
+    errors,
+    actualFiles,
+    expectedFiles: [...expectedFiles].sort(),
+    manifest
+  }
+}
+
+function listZipFiles(zipPath) {
+  execFileSync('unzip', ['-t', zipPath], {stdio: 'ignore'})
+  const output = execFileSync('unzip', ['-Z1', zipPath], {encoding: 'utf8'})
+  return output
+    .split(/\r?\n/)
+    .map(normalizeEntry)
+    .filter(file => file && !file.endsWith('/'))
+}
+
+export function validatePackageZip({projectRoot, zipPath, packageFiles, manifestVersion}) {
+  const errors = []
+  let zipFiles
+
+  try {
+    zipFiles = listZipFiles(zipPath)
+  } catch (error) {
+    return {errors: [`ZIP could not be read or tested: ${error.message}`], zipFiles: []}
+  }
+
+  const differences = missingAndExtra(packageFiles, zipFiles)
+  if (differences.missing.length > 0 || differences.extra.length > 0) {
+    if (differences.missing.length > 0) {
+      errors.push(`ZIP is missing files from the unpacked build: ${differences.missing.join(', ')}`)
+    }
+    if (differences.extra.length > 0) {
+      errors.push(`ZIP has files not present in the unpacked build: ${differences.extra.join(', ')}`)
+    }
+  }
+
+  const forbidden = packageForbiddenFiles(zipFiles)
+  if (forbidden.length > 0) {
+    errors.push(`Development files found in ZIP: ${forbidden.join(', ')}`)
+  }
+
+  const expectedName = `${path.basename(projectRoot)}_${manifestVersion}.zip`
+  if (path.basename(zipPath) !== expectedName) {
+    errors.push(`ZIP name mismatch: expected ${expectedName}, received ${path.basename(zipPath)}.`)
+  }
+
+  return {errors, zipFiles}
+}
+
+export function validatePackage({projectRoot, packageDir, zipPath}) {
+  const directoryResult = validatePackageDirectory({projectRoot, packageDir})
+  const errors = [...directoryResult.errors]
+  let zipResult = {errors: [], zipFiles: []}
+
+  if (zipPath && directoryResult.errors.length === 0) {
+    zipResult = validatePackageZip({
+      projectRoot,
+      zipPath,
+      packageFiles: directoryResult.actualFiles,
+      manifestVersion: directoryResult.manifest.version
+    })
+    errors.push(...zipResult.errors)
+  }
+
+  return {...directoryResult, ...zipResult, errors}
+}
+
+function optionValue(args, name, fallback) {
+  const index = args.indexOf(name)
+  return index === -1 ? fallback : args[index + 1]
+}
+
+function main() {
+  const projectRoot = path.resolve(optionValue(process.argv.slice(2), '--project-root', process.cwd()))
+  const packageDir = path.resolve(optionValue(process.argv.slice(2), '--dir', path.join(projectRoot, 'dist')))
+  const zipOption = optionValue(process.argv.slice(2), '--zip', '')
+  const result = validatePackage({
+    projectRoot,
+    packageDir,
+    zipPath: zipOption ? path.resolve(zipOption) : null
+  })
+
+  if (result.errors.length > 0) {
+    console.error(result.errors.map(error => `- ${error}`).join('\n'))
+    process.exitCode = 1
+    return
+  }
+
+  const zipSummary = zipOption ? ` and ZIP (${result.zipFiles.length} files)` : ''
+  console.log(`Package validation passed: ${result.actualFiles.length} unpacked files${zipSummary}.`)
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === path.resolve(new URL(import.meta.url).pathname)) {
+  main()
+}

--- a/tests/packaging.test.mjs
+++ b/tests/packaging.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import {fileURLToPath} from 'node:url'
+
+import {
+  collectManifestFiles,
+  collectSourceDependencies
+} from '../scripts/validate-package.mjs'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const manifest = JSON.parse(
+  fs.readFileSync(path.join(projectRoot, 'public/manifest.json'), 'utf8')
+)
+
+test('package validator covers manifest entry points and web resources', () => {
+  const files = collectManifestFiles(manifest)
+
+  for (const file of [
+    'manifest.json',
+    'contentWrapper.js',
+    'background.js',
+    'popup.html',
+    'options.html',
+    'content.css',
+    'messaging.mjs',
+    'dictionary/parser.mjs',
+    'dictionary/normalizer.mjs',
+    'icon16.png',
+    'icon32.png',
+    'icon48.png',
+    'icon128.png',
+    'rule_endic.json'
+  ]) {
+    assert.equal(files.has(file), true, `${file} should be manifest-required`)
+  }
+})
+
+test('package validator follows raw background and content imports', () => {
+  const dependencies = collectSourceDependencies(projectRoot)
+
+  for (const file of [
+    'background-handler.mjs',
+    'content.js',
+    'content-interaction.mjs',
+    'content-storage.mjs',
+    'messaging.mjs',
+    'settings.mjs',
+    'dictionary/parser.mjs',
+    'dictionary/normalizer.mjs'
+  ]) {
+    assert.equal(dependencies.has(file), true, `${file} should be an imported package dependency`)
+  }
+})


### PR DESCRIPTION
## Summary

Task 7과 Task 8을 Task 6으로 묶어 v6.6 Stage 1 후보의 빌드·패키징 검증을 고정했습니다.

- `pack.sh`가 Vite one-shot build와 esbuild 번들을 모두 수행하도록 정리
- manifest entry point, raw content/background imports, 정적 리소스, 버전, ZIP 파일 집합을 검증하는 패키지 validator 추가
- 개발용 Vite demo 산출물이 배포 ZIP에 포함되지 않도록 정리
- packaging unit test와 Chrome 실사용 regression checklist 추가
- `pack.py`의 manifest 읽기 및 산출물 이름을 안정화

## Validation

- `yarn test`: 36 passed
- `yarn build`: passed
- `NAVERDIC_ZIP_DIR=... bash pack.sh`: passed
- clean checkout에서 `yarn test`와 `pack.sh`: passed
- 산출물: `naverdic_6.6.zip`
- unpacked `dist/`와 ZIP extraction: 28개 파일 집합 및 내용 일치
- `git diff --cached --check`: passed

## Chrome verification

Chrome 실사용 회귀는 주인님께서 직접 진행하실 예정입니다. Codex 환경에서는 Chrome bridge extension/native host가 없어 UI 조작을 실행하지 못했으므로, 해당 항목을 통과로 주장하지 않고 `docs/task6-verification.md`에 미검증 체크리스트와 smoke test를 기록했습니다.

수동 smoke test 통과 후 Stage 1 후보를 merge할 수 있습니다. 기능 UX 변경이나 Task 6 이후 범위의 개선은 포함하지 않았습니다.