### PR TITLE
fix: preserve deny-list entries and macOS trigger labels

### DIFF
--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -7,26 +7,14 @@ import {
   settingsFromOptionForm
 } from '/src/settings.mjs'
 import { loadSettings, saveSettings } from '/src/settings-storage.mjs'
+import { getTriggerLabels } from '/src/content-interaction.mjs'
 
 const options = reactive(createOptionForm())
 const version = chrome.runtime.getManifest().version
 let statusText = ref('')
-
-let ctrl = 'ctrl'
-let alt = 'alt'
-
-if (navigator.userAgentData) {
-  if (navigator.userAgentData.platform.includes('mac')) {
-    ctrl = 'cmd'
-    alt = 'option'
-  }
-}
+const {ctrl, alt} = getTriggerLabels()
 
 function saveOptions() {
-  if (options.useDenyList && options.safeURLs) {
-    options.safeURLs = options.safeURLs.replace(/\s/g, '')
-  }
-
   saveSettings(chrome.storage, settingsFromOptionForm(options), function() {
     statusText.value = getText('SAVE_STATUS');
     setTimeout(function() {

--- a/src/content-interaction.mjs
+++ b/src/content-interaction.mjs
@@ -1,15 +1,21 @@
 const DEFAULT_SELECTION_DISTANCE = 8
 
-function getNavigatorPlatform() {
-  if (typeof navigator === 'undefined') {
-    return ''
-  }
+export function getNavigatorPlatform(navigatorLike) {
+  const currentNavigator = navigatorLike === undefined
+    ? (typeof navigator === 'undefined' ? null : navigator)
+    : navigatorLike
 
-  return navigator.userAgentData?.platform || navigator.platform || ''
+  return currentNavigator?.userAgentData?.platform || currentNavigator?.platform || ''
 }
 
 export function isMacPlatform(platform = getNavigatorPlatform()) {
   return /mac/i.test(String(platform))
+}
+
+export function getTriggerLabels(platform = getNavigatorPlatform()) {
+  return isMacPlatform(platform)
+    ? {ctrl: 'cmd', alt: 'option'}
+    : {ctrl: 'ctrl', alt: 'alt'}
 }
 
 /**
@@ -137,7 +143,7 @@ function normalizeHost(value) {
 export function normalizeDenyList(value) {
   const entries = Array.isArray(value)
     ? value
-    : String(value ?? '').split(/[,;\n]+/)
+    : String(value ?? '').split(/[,;\r\n]+/)
 
   return entries
     .map(normalizeHost)

--- a/tests/content-interaction.test.mjs
+++ b/tests/content-interaction.test.mjs
@@ -5,6 +5,8 @@ import {
   checkTrigger,
   createInteractionController,
   getDictionaryQuery,
+  getNavigatorPlatform,
+  getTriggerLabels,
   getSelectionText,
   isDeniedSite,
   normalizeDenyList,
@@ -120,10 +122,32 @@ test('matches configured trigger keys on Windows and macOS', () => {
   assert.equal(checkTrigger(mouseEvent({metaKey: true, ctrlKey: true}), 'ctrl', 'MacIntel'), false)
 })
 
+test('uses one platform rule for trigger labels and navigator fallbacks', () => {
+  assert.equal(getNavigatorPlatform({
+    userAgentData: {platform: 'macOS'},
+    platform: 'Win32'
+  }), 'macOS')
+  assert.equal(getNavigatorPlatform({platform: 'MacIntel'}), 'MacIntel')
+
+  assert.deepEqual(getTriggerLabels('macOS'), {ctrl: 'cmd', alt: 'option'})
+  assert.deepEqual(getTriggerLabels('MACOS'), {ctrl: 'cmd', alt: 'option'})
+  assert.deepEqual(getTriggerLabels('MacIntel'), {ctrl: 'cmd', alt: 'option'})
+  assert.deepEqual(getTriggerLabels('Win32'), {ctrl: 'ctrl', alt: 'alt'})
+})
+
 test('matches deny-list hosts by exact domain or subdomain boundary', () => {
   assert.deepEqual(normalizeDenyList(' example.com, https://www.naver.com/path\n'), [
     'example.com',
     'www.naver.com'
+  ])
+  const multipleLines = 'example.com\nnaver.com'
+  assert.deepEqual(normalizeDenyList(multipleLines), ['example.com', 'naver.com'])
+  assert.equal(isDeniedSite('example.com', multipleLines), true)
+  assert.equal(isDeniedSite('www.naver.com', multipleLines), true)
+  assert.equal(isDeniedSite('docs.naver.com', multipleLines), true)
+  assert.deepEqual(normalizeDenyList('example.com; naver.com'), [
+    'example.com',
+    'naver.com'
   ])
   assert.equal(isDeniedSite('example.com', 'example.com'), true)
   assert.equal(isDeniedSite('docs.example.com', 'example.com'), true)

--- a/tests/settings.test.mjs
+++ b/tests/settings.test.mjs
@@ -126,6 +126,17 @@ test('maps the shared storage contract to the existing Options form shape', () =
   assert.equal(storageValues.dclick_speed, '200')
   assert.equal(storageValues.use_deny_list, true)
   assert.equal(storageValues.safe_urls, 'example.com')
+
+  const multilineStorageValues = settingsFromOptionForm({
+    ...defaults,
+    useDenyList: true,
+    safeURLs: ' example.com \n naver.com '
+  })
+  assert.equal(multilineStorageValues.safe_urls, 'example.com \n naver.com')
+  assert.equal(
+    optionFormFromSettings(multilineStorageValues).safeURLs,
+    'example.com \n naver.com'
+  )
 })
 
 test('loads normalized settings without writing defaults back', () => {


### PR DESCRIPTION
## Summary

최신 `testflight` 기준 Task9 보완입니다. `master`와 `firstlight`는 수정하지 않았습니다.

- Options의 제외 사이트 저장 시 공백 전체 제거를 없애 줄바꿈·쉼표·세미콜론 구분을 보존
- 기존 공통 `normalizeDenyList()`가 각 도메인을 독립적으로 판정하도록 multiline/subdomain 테스트 보강
- `userAgentData.platform`과 `navigator.platform` fallback을 공통화
- Options 표시와 실제 트리거 판정이 동일한 macOS 감지 규칙을 사용하도록 `getTriggerLabels()` 추가
- macOS는 `cmd`/`option`, Windows/Linux는 기존 `ctrl`/`alt` 표시 유지

## Validation

- `yarn test`: 37 passed
- `yarn build`: passed
- `NAVERDIC_ZIP_DIR=/tmp/naverdic-task9-package bash pack.sh`: passed
- `git diff --check`: passed
- `naverdic_6.6.zip` 생성 및 패키지 validator 통과

## Manual checklist

- [ ] 제외 사이트 textarea에 `example.com`과 `naver.com`을 줄바꿈으로 입력
- [ ] 저장 후 설정 화면을 다시 열어 두 항목이 분리되어 있는지 확인
- [ ] 두 도메인과 각 하위 도메인에서 팝업이 차단되는지 확인
- [ ] macOS 설정 화면에 Command/Option 명칭이 표시되는지 확인
- [ ] 기존 쉼표 구분 제외 사이트가 계속 동작하는지 확인

수동 확인 후에도 이 PR은 Draft 상태로 유지하며, Ready for Review 전환이나 merge는 수행하지 않습니다.