### PR TITLE
[TASK 2] Implement settings screen shell

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -148,5 +148,98 @@
   },
   "RESET": {
     "message": "Reset"
+  },
+  "SETTINGS_PRODUCT_TITLE": {
+    "message": "Naver English Dictionary · NaverDic 7.0"
+  },
+  "SETTINGS_SIDEBAR_HEADING": {
+    "message": "Settings"
+  },
+  "SETTINGS_NAV_APPEARANCE": {
+    "message": "Appearance"
+  },
+  "SETTINGS_NAV_DOUBLE_CLICK": {
+    "message": "Double click"
+  },
+  "SETTINGS_NAV_BLOCKED_SITES": {
+    "message": "Blocked sites"
+  },
+  "SETTINGS_NAV_BEHAVIOR": {
+    "message": "Behavior"
+  },
+  "SETTINGS_NAV_TRANSLATION": {
+    "message": "Translation service"
+  },
+  "SETTINGS_NAV_HELP": {
+    "message": "Help"
+  },
+  "SETTINGS_NAV_ADVANCED": {
+    "message": "Advanced"
+  },
+  "SETTINGS_PAGE_APPEARANCE_TITLE": {
+    "message": "Appearance"
+  },
+  "SETTINGS_PAGE_APPEARANCE_DESCRIPTION": {
+    "message": "Configure the popup dictionary colors and typography."
+  },
+  "SETTINGS_PAGE_DOUBLE_CLICK_TITLE": {
+    "message": "Double click"
+  },
+  "SETTINGS_PAGE_DOUBLE_CLICK_DESCRIPTION": {
+    "message": "Configure how the dictionary appears when a word is double-clicked on a page."
+  },
+  "SETTINGS_PAGE_BLOCKED_SITES_TITLE": {
+    "message": "Blocked sites"
+  },
+  "SETTINGS_PAGE_BLOCKED_SITES_DESCRIPTION": {
+    "message": "Manage websites where the popup dictionary should not appear."
+  },
+  "SETTINGS_PAGE_BEHAVIOR_TITLE": {
+    "message": "Behavior"
+  },
+  "SETTINGS_PAGE_BEHAVIOR_DESCRIPTION": {
+    "message": "Configure drag search and page interaction behavior."
+  },
+  "SETTINGS_PAGE_TRANSLATION_TITLE": {
+    "message": "Translation service"
+  },
+  "SETTINGS_PAGE_TRANSLATION_DESCRIPTION": {
+    "message": "Configure translation features and providers."
+  },
+  "SETTINGS_PAGE_HELP_TITLE": {
+    "message": "Help"
+  },
+  "SETTINGS_PAGE_HELP_DESCRIPTION": {
+    "message": "Find NaverDic usage instructions and the latest guidance."
+  },
+  "SETTINGS_PAGE_ADVANCED_TITLE": {
+    "message": "Advanced"
+  },
+  "SETTINGS_PAGE_ADVANCED_DESCRIPTION": {
+    "message": "Manage advanced features such as settings data and reset."
+  },
+  "SETTINGS_SHELL_STATUS_SAVED": {
+    "message": "Saved"
+  },
+  "SETTINGS_SHELL_SAVE": {
+    "message": "Save"
+  },
+  "SETTINGS_SHELL_VERSION": {
+    "message": "NaverDic 7.0"
+  },
+  "SETTINGS_SHELL_PLACEHOLDER_TITLE": {
+    "message": "Settings"
+  },
+  "SETTINGS_SHELL_PLACEHOLDER_DESCRIPTION": {
+    "message": "Controls for this screen will be connected in the next TASK."
+  },
+  "SETTINGS_SHELL_DRAFT_NOTE": {
+    "message": "Values entered here stay in memory while you move between screens and are not saved in this TASK."
+  },
+  "SETTINGS_SHELL_PREVIEW_TITLE": {
+    "message": "Preview"
+  },
+  "SETTINGS_SHELL_PREVIEW_DESCRIPTION": {
+    "message": "Preview the result of changes on the current screen."
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -148,5 +148,98 @@
   },
   "RESET": {
     "message": "초기화"
+  },
+  "SETTINGS_PRODUCT_TITLE": {
+    "message": "네이버 영어사전 · NaverDic 7.0"
+  },
+  "SETTINGS_SIDEBAR_HEADING": {
+    "message": "설정"
+  },
+  "SETTINGS_NAV_APPEARANCE": {
+    "message": "모양"
+  },
+  "SETTINGS_NAV_DOUBLE_CLICK": {
+    "message": "더블클릭"
+  },
+  "SETTINGS_NAV_BLOCKED_SITES": {
+    "message": "중지목록"
+  },
+  "SETTINGS_NAV_BEHAVIOR": {
+    "message": "동작"
+  },
+  "SETTINGS_NAV_TRANSLATION": {
+    "message": "번역 서비스"
+  },
+  "SETTINGS_NAV_HELP": {
+    "message": "도움말"
+  },
+  "SETTINGS_NAV_ADVANCED": {
+    "message": "고급 설정"
+  },
+  "SETTINGS_PAGE_APPEARANCE_TITLE": {
+    "message": "모양"
+  },
+  "SETTINGS_PAGE_APPEARANCE_DESCRIPTION": {
+    "message": "팝업 사전의 색상과 글자 모양을 설정합니다."
+  },
+  "SETTINGS_PAGE_DOUBLE_CLICK_TITLE": {
+    "message": "더블클릭"
+  },
+  "SETTINGS_PAGE_DOUBLE_CLICK_DESCRIPTION": {
+    "message": "페이지에서 단어를 더블클릭했을 때 사전을 표시하는 방법을 설정합니다."
+  },
+  "SETTINGS_PAGE_BLOCKED_SITES_TITLE": {
+    "message": "중지목록"
+  },
+  "SETTINGS_PAGE_BLOCKED_SITES_DESCRIPTION": {
+    "message": "팝업 사전을 표시하지 않을 웹사이트를 관리합니다."
+  },
+  "SETTINGS_PAGE_BEHAVIOR_TITLE": {
+    "message": "동작"
+  },
+  "SETTINGS_PAGE_BEHAVIOR_DESCRIPTION": {
+    "message": "드래그 검색과 페이지 상호작용 방식을 설정합니다."
+  },
+  "SETTINGS_PAGE_TRANSLATION_TITLE": {
+    "message": "번역 서비스"
+  },
+  "SETTINGS_PAGE_TRANSLATION_DESCRIPTION": {
+    "message": "번역 기능과 번역 제공자를 설정합니다."
+  },
+  "SETTINGS_PAGE_HELP_TITLE": {
+    "message": "도움말"
+  },
+  "SETTINGS_PAGE_HELP_DESCRIPTION": {
+    "message": "NaverDic 사용법과 최신 안내를 확인합니다."
+  },
+  "SETTINGS_PAGE_ADVANCED_TITLE": {
+    "message": "고급 설정"
+  },
+  "SETTINGS_PAGE_ADVANCED_DESCRIPTION": {
+    "message": "설정 데이터와 초기화 같은 고급 기능을 관리합니다."
+  },
+  "SETTINGS_SHELL_STATUS_SAVED": {
+    "message": "저장됨"
+  },
+  "SETTINGS_SHELL_SAVE": {
+    "message": "저장"
+  },
+  "SETTINGS_SHELL_VERSION": {
+    "message": "NaverDic 7.0"
+  },
+  "SETTINGS_SHELL_PLACEHOLDER_TITLE": {
+    "message": "설정 항목"
+  },
+  "SETTINGS_SHELL_PLACEHOLDER_DESCRIPTION": {
+    "message": "이 화면의 설정 항목은 다음 TASK에서 연결됩니다."
+  },
+  "SETTINGS_SHELL_DRAFT_NOTE": {
+    "message": "현재 입력값은 화면을 이동해도 유지되며, 이 단계에서는 저장되지 않습니다."
+  },
+  "SETTINGS_SHELL_PREVIEW_TITLE": {
+    "message": "미리보기"
+  },
+  "SETTINGS_SHELL_PREVIEW_DESCRIPTION": {
+    "message": "현재 화면의 변경 결과를 미리 볼 수 있습니다."
   }
 }

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -1,0 +1,635 @@
+<script setup>
+import { computed, reactive, ref } from 'vue'
+import { getText } from '/src/text.js'
+import {
+  createDefaultSettingsV2,
+  SETTINGS_NAVIGATION
+} from '/src/settings-v2.mjs'
+
+const navigation = SETTINGS_NAVIGATION
+const activeNavigationId = ref(navigation[0].id)
+
+// TASK 2 owns only the in-memory draft boundary. TASK 3 will connect this
+// object to the explicit save and migration flow; this shell deliberately
+// does not read from or write to chrome.storage.
+const draftSettings = reactive(createDefaultSettingsV2())
+const navButtonRefs = ref([])
+
+const currentNavigation = computed(() => navigation.find(item => (
+  item.id === activeNavigationId.value
+)) || navigation[0])
+
+function text(key, placeholders = undefined) {
+  return getText(key, placeholders)
+}
+
+function selectNavigation(item) {
+  if (item.kind !== 'page') {
+    return
+  }
+
+  activeNavigationId.value = item.id
+}
+
+function setNavigationRef(element, index) {
+  if (element) {
+    navButtonRefs.value[index] = element
+  }
+}
+
+function focusNavigation(index) {
+  const item = navigation[index]
+  if (!item) {
+    return
+  }
+
+  navButtonRefs.value[index]?.focus()
+  selectNavigation(item)
+}
+
+function handleNavigationKeydown(event, index) {
+  const lastIndex = navigation.length - 1
+  let nextIndex = index
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+    nextIndex = index === lastIndex ? 0 : index + 1
+  } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+    nextIndex = index === 0 ? lastIndex : index - 1
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = lastIndex
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  focusNavigation(nextIndex)
+}
+
+defineExpose({
+  activeNavigationId,
+  currentNavigation,
+  draftSettings,
+  navigation,
+  selectNavigation
+})
+</script>
+
+<template>
+  <main class="settings-shell" data-testid="settings-shell">
+    <header class="settings-header">
+      <h1 class="settings-header__title">
+        {{ text('SETTINGS_PRODUCT_TITLE') }}
+      </h1>
+
+      <div class="settings-header__actions" aria-live="polite">
+        <span class="settings-header__status" data-testid="settings-save-status">
+          {{ text('SETTINGS_SHELL_STATUS_SAVED') }}
+        </span>
+        <button
+          type="button"
+          class="settings-header__save"
+          data-testid="settings-save-button"
+          disabled
+          :aria-label="text('SETTINGS_SHELL_SAVE')"
+        >
+          {{ text('SETTINGS_SHELL_SAVE') }}
+        </button>
+      </div>
+    </header>
+
+    <div class="settings-body">
+      <aside class="settings-sidebar">
+        <div class="settings-sidebar__heading">
+          {{ text('SETTINGS_SIDEBAR_HEADING') }}
+        </div>
+
+        <nav
+          class="settings-navigation"
+          :aria-label="text('SETTINGS_SIDEBAR_HEADING')"
+        >
+          <template
+            v-for="(item, index) in navigation"
+            :key="item.id"
+          >
+            <button
+              v-if="item.kind === 'page'"
+              :ref="element => setNavigationRef(element, index)"
+              type="button"
+              class="settings-navigation__item"
+              :class="{ 'settings-navigation__item--active': activeNavigationId === item.id }"
+              :data-navigation-id="item.id"
+              :aria-current="activeNavigationId === item.id ? 'page' : undefined"
+              @click="selectNavigation(item)"
+              @keydown="handleNavigationKeydown($event, index)"
+            >
+              <span class="settings-navigation__label">
+                {{ text(item.labelKey) }}
+              </span>
+              <span
+                v-if="activeNavigationId === item.id"
+                class="settings-navigation__indicator"
+                aria-hidden="true"
+              />
+            </button>
+
+            <a
+              v-else
+              :ref="element => setNavigationRef(element, index)"
+              class="settings-navigation__item settings-navigation__item--external"
+              :href="item.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              :data-navigation-id="item.id"
+              @keydown="handleNavigationKeydown($event, index)"
+            >
+              <span class="settings-navigation__label">
+                {{ text(item.labelKey) }}
+              </span>
+            </a>
+          </template>
+        </nav>
+
+        <div class="settings-sidebar__version">
+          {{ text('SETTINGS_SHELL_VERSION') }}
+        </div>
+      </aside>
+
+      <section
+        class="settings-content"
+        :aria-labelledby="`settings-page-title-${currentNavigation.id}`"
+      >
+        <div class="settings-form-column">
+          <div class="settings-page-heading">
+            <h2 :id="`settings-page-title-${currentNavigation.id}`">
+              {{ text(currentNavigation.titleKey) }}
+            </h2>
+            <p>{{ text(currentNavigation.descriptionKey) }}</p>
+          </div>
+
+          <slot
+            name="page"
+            :active-page="currentNavigation"
+            :draft="draftSettings"
+          >
+            <div class="settings-placeholder-card" data-testid="settings-page-placeholder">
+              <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>
+              <p>{{ text('SETTINGS_SHELL_PLACEHOLDER_DESCRIPTION') }}</p>
+              <div class="settings-placeholder-card__note">
+                {{ text('SETTINGS_SHELL_DRAFT_NOTE') }}
+              </div>
+              <div
+                v-if="currentNavigation.id === 'advanced'"
+                class="settings-placeholder-card__actions"
+              >
+                <button
+                  type="button"
+                  class="settings-placeholder-card__reset"
+                  data-testid="settings-reset-button"
+                  disabled
+                >
+                  {{ text('RESET') }}
+                </button>
+              </div>
+            </div>
+          </slot>
+        </div>
+
+        <aside
+          class="settings-preview-column"
+          :aria-label="text('SETTINGS_SHELL_PREVIEW_TITLE')"
+        >
+          <div class="settings-preview-heading">
+            <h2>{{ text('SETTINGS_SHELL_PREVIEW_TITLE') }}</h2>
+            <p>{{ text('SETTINGS_SHELL_PREVIEW_DESCRIPTION') }}</p>
+          </div>
+          <div class="settings-preview-card" aria-hidden="true">
+            <div class="settings-preview-card__window">
+              <div class="settings-preview-card__bar" />
+              <div class="settings-preview-card__line settings-preview-card__line--long" />
+              <div class="settings-preview-card__line settings-preview-card__line--medium" />
+              <div class="settings-preview-card__line settings-preview-card__line--short" />
+              <div class="settings-preview-card__surface" />
+            </div>
+          </div>
+        </aside>
+      </section>
+    </div>
+  </main>
+</template>
+
+<style scoped>
+:global(*) {
+  box-sizing: border-box;
+}
+
+:global(html),
+:global(body),
+:global(#app) {
+  min-width: 0;
+  min-height: 100%;
+  margin: 0;
+}
+
+:global(body) {
+  background: var(--naverdic-settings-canvas);
+  color: var(--naverdic-settings-text);
+  font-family: var(--naverdic-font-family);
+  font-size: var(--naverdic-font-size-md);
+}
+
+button,
+a {
+  font: inherit;
+}
+
+.settings-shell {
+  width: min(1200px, calc(100% - 32px));
+  min-height: min(860px, calc(100vh - 32px));
+  margin: 16px auto;
+  overflow: hidden;
+  background: var(--naverdic-settings-page);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: var(--naverdic-settings-radius);
+  box-shadow: var(--naverdic-settings-shadow);
+}
+
+.settings-header {
+  display: flex;
+  align-items: center;
+  min-height: var(--naverdic-settings-header-height);
+  padding: 16px 20px 16px 32px;
+  background: var(--naverdic-settings-surface);
+  border-bottom: 1px solid var(--naverdic-settings-divider);
+}
+
+.settings-header__title {
+  margin: 0;
+  color: var(--naverdic-settings-text);
+  font-size: var(--naverdic-font-size-lg);
+  font-weight: var(--naverdic-font-weight-medium);
+  line-height: 40px;
+}
+
+.settings-header__actions {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-left: auto;
+}
+
+.settings-header__status {
+  min-width: 84px;
+  color: var(--naverdic-settings-success);
+  font-size: var(--naverdic-font-size-sm);
+  font-weight: var(--naverdic-font-weight-medium);
+  line-height: 40px;
+  text-align: right;
+}
+
+.settings-header__save {
+  width: 68px;
+  min-height: 40px;
+  padding: 0 8px;
+  color: var(--naverdic-button-text-default);
+  background: var(--naverdic-button-background-default);
+  border: 0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 40px;
+}
+
+.settings-header__save:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.settings-body {
+  display: grid;
+  grid-template-columns: var(--naverdic-settings-sidebar-width) minmax(0, 1fr);
+  min-height: calc(min(860px, 100vh - 32px) - var(--naverdic-settings-header-height));
+}
+
+.settings-sidebar {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 24px 0;
+  background: var(--naverdic-settings-surface);
+}
+
+.settings-sidebar__heading {
+  min-height: 24px;
+  margin: 0 24px 16px;
+  color: var(--naverdic-settings-text-subtle);
+  font-size: var(--naverdic-font-size-sm);
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.settings-navigation {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 16px;
+}
+
+.settings-navigation__item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 40px;
+  padding: 0 16px;
+  overflow: hidden;
+  color: var(--naverdic-settings-nav-text);
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: var(--naverdic-font-weight-medium);
+  line-height: 40px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.settings-navigation__item:hover {
+  background: var(--naverdic-settings-nav-hover);
+}
+
+.settings-navigation__item--active {
+  color: var(--naverdic-settings-primary-text);
+  background: var(--naverdic-settings-nav-active);
+  font-weight: 700;
+}
+
+.settings-navigation__item--active:hover {
+  background: var(--naverdic-settings-nav-active);
+}
+
+.settings-navigation__item:focus-visible,
+.settings-header__save:focus-visible,
+.settings-navigation__item--external:focus-visible {
+  outline: 2px solid var(--naverdic-color-focus);
+  outline-offset: 2px;
+  box-shadow: var(--naverdic-button-focus-ring);
+}
+
+.settings-navigation__indicator {
+  position: absolute;
+  top: 10px;
+  left: 0;
+  width: 3px;
+  height: 20px;
+  background: var(--naverdic-settings-primary);
+  border-radius: 2px;
+}
+
+.settings-sidebar__version {
+  margin: auto 24px 0;
+  color: var(--naverdic-settings-text-subtle);
+  font-size: var(--naverdic-font-size-xs);
+  line-height: 20px;
+}
+
+.settings-content {
+  display: grid;
+  grid-template-columns: minmax(0, 556px) minmax(220px, 300px);
+  gap: 68px;
+  min-width: 0;
+  padding: 30px 40px;
+  background: var(--naverdic-settings-page);
+}
+
+.settings-form-column,
+.settings-preview-column {
+  min-width: 0;
+}
+
+.settings-page-heading,
+.settings-preview-heading {
+  min-height: 42px;
+}
+
+.settings-page-heading h2,
+.settings-preview-heading h2 {
+  margin: 0;
+  color: var(--naverdic-settings-text);
+  font-size: 22px;
+  font-weight: 700;
+  line-height: 32px;
+}
+
+.settings-page-heading p,
+.settings-preview-heading p {
+  margin: 0;
+  color: var(--naverdic-settings-text-muted);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.settings-placeholder-card {
+  min-height: 220px;
+  margin-top: 12px;
+  padding: 24px;
+  background: var(--naverdic-settings-surface);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: 10px;
+}
+
+.settings-placeholder-card h3 {
+  margin: 0 0 8px;
+  color: var(--naverdic-settings-text);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.settings-placeholder-card p {
+  margin: 0;
+  color: var(--naverdic-settings-text-muted);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.settings-placeholder-card__note {
+  margin-top: 24px;
+  padding: 12px 14px;
+  color: var(--naverdic-settings-primary-text);
+  background: var(--naverdic-settings-info);
+  border-radius: 8px;
+  font-size: 11px;
+  line-height: 18px;
+}
+
+.settings-placeholder-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.settings-placeholder-card__reset {
+  min-height: 34px;
+  padding: 0 16px;
+  color: var(--naverdic-color-text-disabled);
+  background: var(--naverdic-input-background-disabled);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: var(--naverdic-radius-sm);
+  font-size: var(--naverdic-font-size-sm);
+  font-weight: var(--naverdic-font-weight-medium);
+  cursor: not-allowed;
+}
+
+.settings-preview-card {
+  min-height: 360px;
+  margin-top: 12px;
+  padding: 22px 15px;
+  overflow: hidden;
+  background: var(--naverdic-settings-preview-surface);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: 10px;
+}
+
+.settings-preview-card__window {
+  position: relative;
+  min-height: 300px;
+  padding: 48px 14px 20px;
+  overflow: hidden;
+  background: var(--naverdic-settings-preview-window);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: 10px;
+}
+
+.settings-preview-card__bar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  height: 34px;
+  background: var(--naverdic-settings-preview-bar);
+  border-bottom: 1px solid var(--naverdic-settings-border);
+}
+
+.settings-preview-card__line {
+  height: 8px;
+  margin-bottom: 12px;
+  background: var(--naverdic-settings-divider);
+  border-radius: 4px;
+}
+
+.settings-preview-card__line--long {
+  width: 82%;
+}
+
+.settings-preview-card__line--medium {
+  width: 94%;
+}
+
+.settings-preview-card__line--short {
+  width: 56%;
+}
+
+.settings-preview-card__surface {
+  width: 92%;
+  height: 128px;
+  margin: 22px auto 0;
+  background: var(--naverdic-settings-info);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: 6px;
+}
+
+@media (max-width: 1050px) {
+  .settings-content {
+    grid-template-columns: minmax(0, 556px);
+  }
+
+  .settings-preview-column {
+    display: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .settings-shell {
+    width: 100%;
+    min-height: 100vh;
+    margin: 0;
+    border-radius: 0;
+  }
+
+  .settings-body {
+    min-height: calc(100vh - var(--naverdic-settings-header-height));
+  }
+
+  .settings-content {
+    padding: 24px;
+  }
+}
+
+@media (max-width: 600px) {
+  .settings-header {
+    padding: 12px 16px;
+  }
+
+  .settings-header__title {
+    max-width: 60%;
+    overflow: hidden;
+    font-size: 14px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .settings-header__actions {
+    gap: 12px;
+  }
+
+  .settings-header__status {
+    display: none;
+  }
+
+  .settings-body {
+    display: block;
+  }
+
+  .settings-sidebar {
+    display: block;
+    padding: 12px 0;
+    border-bottom: 1px solid var(--naverdic-settings-divider);
+  }
+
+  .settings-sidebar__heading,
+  .settings-sidebar__version {
+    display: none;
+  }
+
+  .settings-navigation {
+    flex-direction: row;
+    gap: 4px;
+    padding: 0 12px;
+    overflow-x: auto;
+  }
+
+  .settings-navigation__item {
+    flex: 0 0 auto;
+    width: auto;
+    min-width: max-content;
+    padding: 0 14px;
+  }
+
+  .settings-navigation__indicator {
+    top: auto;
+    right: 16px;
+    bottom: 0;
+    left: 16px;
+    width: auto;
+    height: 3px;
+  }
+
+  .settings-content {
+    display: block;
+    padding: 24px 16px 32px;
+  }
+}
+</style>

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -1,7 +1,7 @@
 <script setup>
-import Options from '/src/components/Options.vue'
+import SettingsShell from '/src/components/SettingsShell.vue'
 </script>
 
 <template>
-  <Options />
+  <SettingsShell />
 </template>

--- a/src/settings-v2.mjs
+++ b/src/settings-v2.mjs
@@ -74,6 +74,86 @@ export const SETTINGS_MENU = Object.freeze([
   })
 ])
 
+// The settings data contract groups dictionary behavior under one page, while
+// the v7 shell exposes the two dictionary behaviors as separate screens. Keep
+// that UI detail explicit so the shell can match Figma without duplicating
+// persisted settings or changing the stable page IDs above.
+export const SETTINGS_NAVIGATION = Object.freeze([
+  Object.freeze({
+    id: 'appearance',
+    pageId: SETTINGS_PAGE_IDS.POPUP,
+    section: 'appearance',
+    kind: 'page',
+    order: 10,
+    labelKey: 'SETTINGS_NAV_APPEARANCE',
+    titleKey: 'SETTINGS_PAGE_APPEARANCE_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_APPEARANCE_DESCRIPTION'
+  }),
+  Object.freeze({
+    id: 'double-click',
+    pageId: SETTINGS_PAGE_IDS.DICTIONARY,
+    section: 'doubleClick',
+    kind: 'page',
+    order: 20,
+    labelKey: 'SETTINGS_NAV_DOUBLE_CLICK',
+    titleKey: 'SETTINGS_PAGE_DOUBLE_CLICK_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_DOUBLE_CLICK_DESCRIPTION'
+  }),
+  Object.freeze({
+    id: 'blocked-sites',
+    pageId: SETTINGS_PAGE_IDS.SITES,
+    section: 'sites',
+    kind: 'page',
+    order: 30,
+    labelKey: 'SETTINGS_NAV_BLOCKED_SITES',
+    titleKey: 'SETTINGS_PAGE_BLOCKED_SITES_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_BLOCKED_SITES_DESCRIPTION'
+  }),
+  Object.freeze({
+    id: 'behavior',
+    pageId: SETTINGS_PAGE_IDS.DICTIONARY,
+    section: 'behavior',
+    kind: 'page',
+    order: 40,
+    labelKey: 'SETTINGS_NAV_BEHAVIOR',
+    titleKey: 'SETTINGS_PAGE_BEHAVIOR_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_BEHAVIOR_DESCRIPTION'
+  }),
+  Object.freeze({
+    id: 'translation-service',
+    pageId: SETTINGS_PAGE_IDS.TRANSLATION,
+    section: 'translation',
+    kind: 'page',
+    order: 50,
+    labelKey: 'SETTINGS_NAV_TRANSLATION',
+    titleKey: 'SETTINGS_PAGE_TRANSLATION_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_TRANSLATION_DESCRIPTION'
+  }),
+  Object.freeze({
+    id: 'help',
+    pageId: SETTINGS_PAGE_IDS.HELP,
+    section: 'help',
+    kind: 'external',
+    order: 60,
+    labelKey: 'SETTINGS_NAV_HELP',
+    titleKey: 'SETTINGS_PAGE_HELP_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_HELP_DESCRIPTION',
+    url: SETTINGS_MENU.find(item => item.id === SETTINGS_PAGE_IDS.HELP).url,
+    external: true
+  }),
+  Object.freeze({
+    id: 'advanced',
+    pageId: SETTINGS_PAGE_IDS.ADVANCED,
+    section: 'advanced',
+    kind: 'page',
+    order: 70,
+    labelKey: 'SETTINGS_NAV_ADVANCED',
+    titleKey: 'SETTINGS_PAGE_ADVANCED_TITLE',
+    descriptionKey: 'SETTINGS_PAGE_ADVANCED_DESCRIPTION',
+    actions: Object.freeze(['reset'])
+  })
+])
+
 const TRIGGER_KEYS = Object.freeze(['none', 'ctrl', 'alt', 'ctrlalt'])
 const INTERFACE_LANGUAGES = Object.freeze(['auto', 'ko', 'en'])
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -88,4 +88,28 @@
   --naverdic-card-border-default: var(--naverdic-color-border);
   --naverdic-card-border-selected: var(--naverdic-color-action-primary);
   --naverdic-card-shadow-default: 0 1px 2px rgba(15, 23, 42, 0.06);
+
+  /* v7 Settings shell values from the finalized Figma frame. */
+  --naverdic-settings-canvas: #E5E5E5;
+  --naverdic-settings-page: #F4F6F9;
+  --naverdic-settings-surface: #FFFFFF;
+  --naverdic-settings-border: #DCE4EE;
+  --naverdic-settings-divider: #E7ECF2;
+  --naverdic-settings-text: #1A2638;
+  --naverdic-settings-text-muted: #667085;
+  --naverdic-settings-text-subtle: #8A96A8;
+  --naverdic-settings-nav-text: #344054;
+  --naverdic-settings-nav-hover: #F8FAFC;
+  --naverdic-settings-success: #3C8B6B;
+  --naverdic-settings-primary: #3F82F5;
+  --naverdic-settings-primary-text: #1A4FA8;
+  --naverdic-settings-nav-active: #EAF2FF;
+  --naverdic-settings-info: #F0F6FF;
+  --naverdic-settings-preview-surface: #EEF1F5;
+  --naverdic-settings-preview-window: #FAFBFC;
+  --naverdic-settings-preview-bar: #F0F3F7;
+  --naverdic-settings-shadow: 0 8px 11px rgba(26, 36, 51, 0.14);
+  --naverdic-settings-header-height: 72px;
+  --naverdic-settings-sidebar-width: 236px;
+  --naverdic-settings-radius: 12px;
 }

--- a/src/text.js
+++ b/src/text.js
@@ -1,7 +1,35 @@
 import en from '/src/_locales/en/messages.json'
 import ko from '/src/_locales/ko/messages.json'
 
+function fallbackText(textId, placeholder) {
+  const locale = globalThis.navigator?.language?.toLowerCase().startsWith('ko')
+    ? ko
+    : en
+  const entry = locale[textId]
+  if (!entry?.message) {
+    return ''
+  }
 
-export function getText(textId, placeholder=null) {
-  return chrome.i18n.getMessage(textId, placeholder)
+  let message = entry.message
+  Object.entries(entry.placeholders || {}).forEach(([name, definition]) => {
+    const match = /\$(\d+)\$/.exec(definition.content || '')
+    const index = match ? Number(match[1]) - 1 : -1
+    const value = Array.isArray(placeholder)
+      ? placeholder[index]
+      : placeholder?.[name]
+    message = message.replaceAll(`$${name}$`, String(value ?? ''))
+  })
+  return message
+}
+
+export function getText(textId, placeholder = null) {
+  const chromeMessage = globalThis.chrome?.i18n?.getMessage
+  if (chromeMessage) {
+    const message = chromeMessage.call(globalThis.chrome.i18n, textId, placeholder)
+    if (message) {
+      return message
+    }
+  }
+
+  return fallbackText(textId, placeholder)
 }

--- a/tests/stage2-contracts.test.mjs
+++ b/tests/stage2-contracts.test.mjs
@@ -6,6 +6,7 @@ import {fileURLToPath} from 'node:url'
 
 import {
   SETTINGS_MENU,
+  SETTINGS_NAVIGATION,
   SETTINGS_PAGE_IDS,
   SETTINGS_SCHEMA_VERSION,
   SETTINGS_SCHEMA_V2,
@@ -51,6 +52,28 @@ test('defines stable settings pages, ordering, and advanced actions', () => {
   assert.equal(help.kind, 'external')
   assert.equal(help.external, true)
   assert.match(help.url, /^https:\/\//)
+})
+
+test('maps the finalized Figma navigation to stable settings sections', () => {
+  assert.deepEqual(
+    SETTINGS_NAVIGATION.map(item => item.id),
+    ['appearance', 'double-click', 'blocked-sites', 'behavior', 'translation-service', 'help', 'advanced']
+  )
+  assert.equal(
+    SETTINGS_NAVIGATION.find(item => item.id === 'double-click').pageId,
+    SETTINGS_PAGE_IDS.DICTIONARY
+  )
+  assert.equal(
+    SETTINGS_NAVIGATION.find(item => item.id === 'behavior').pageId,
+    SETTINGS_PAGE_IDS.DICTIONARY
+  )
+
+  const help = SETTINGS_NAVIGATION.find(item => item.id === 'help')
+  const advanced = SETTINGS_NAVIGATION.find(item => item.id === 'advanced')
+  assert.equal(help.kind, 'external')
+  assert.equal(help.external, true)
+  assert.match(help.url, /^https:\/\//)
+  assert.deepEqual(advanced.actions, ['reset'])
 })
 
 test('defines the v2 storage split and nested settings defaults', () => {


### PR DESCRIPTION
## Summary
- implement the Figma-based v7 settings shell in Vue
- add the seven-section navigation, external help link, advanced reset placement, responsive layout, and keyboard focus behavior
- keep a v2 settings draft in memory only; leave explicit persistence and migration for TASK 3
- add Korean/English shell strings and finalized Figma navigation mapping

## Verification
- `npm test` (50 passing)
- `npm run build`
- `NAVERDIC_ZIP_DIR=/tmp/naverdic-task2-package npm run package`
- local browser visual check at default and 600px viewport
- staged `git diff --check`