### PR TITLE
[TASK 3] Add settings persistence and migration

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -234,12 +234,33 @@
     "message": "Controls for this screen will be connected in the next TASK."
   },
   "SETTINGS_SHELL_DRAFT_NOTE": {
-    "message": "Values entered here stay in memory while you move between screens and are not saved in this TASK."
+    "message": "Values entered here stay in memory while you move between screens and are applied only when you save."
   },
   "SETTINGS_SHELL_PREVIEW_TITLE": {
     "message": "Preview"
   },
   "SETTINGS_SHELL_PREVIEW_DESCRIPTION": {
     "message": "Preview the result of changes on the current screen."
+  },
+  "SETTINGS_SHELL_STATUS_LOADING": {
+    "message": "Loading…"
+  },
+  "SETTINGS_SHELL_STATUS_SAVING": {
+    "message": "Saving…"
+  },
+  "SETTINGS_SHELL_STATUS_UNSAVED": {
+    "message": "Unsaved changes"
+  },
+  "SETTINGS_SHELL_STATUS_SAVE_ERROR": {
+    "message": "Save failed"
+  },
+  "SETTINGS_SHELL_STATUS_LOAD_ERROR": {
+    "message": "Could not load settings"
+  },
+  "SETTINGS_SHELL_STATUS_RESET": {
+    "message": "Reset ready"
+  },
+  "SETTINGS_SHELL_RESET_CONFIRM": {
+    "message": "Reset all settings to their defaults? The reset will not affect stored settings until you save."
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -234,12 +234,33 @@
     "message": "이 화면의 설정 항목은 다음 TASK에서 연결됩니다."
   },
   "SETTINGS_SHELL_DRAFT_NOTE": {
-    "message": "현재 입력값은 화면을 이동해도 유지되며, 이 단계에서는 저장되지 않습니다."
+    "message": "현재 입력값은 화면을 이동해도 유지되며, 저장 버튼을 눌러야 실제 설정에 반영됩니다."
   },
   "SETTINGS_SHELL_PREVIEW_TITLE": {
     "message": "미리보기"
   },
   "SETTINGS_SHELL_PREVIEW_DESCRIPTION": {
     "message": "현재 화면의 변경 결과를 미리 볼 수 있습니다."
+  },
+  "SETTINGS_SHELL_STATUS_LOADING": {
+    "message": "불러오는 중…"
+  },
+  "SETTINGS_SHELL_STATUS_SAVING": {
+    "message": "저장 중…"
+  },
+  "SETTINGS_SHELL_STATUS_UNSAVED": {
+    "message": "저장되지 않음"
+  },
+  "SETTINGS_SHELL_STATUS_SAVE_ERROR": {
+    "message": "저장 실패"
+  },
+  "SETTINGS_SHELL_STATUS_LOAD_ERROR": {
+    "message": "설정 불러오기 실패"
+  },
+  "SETTINGS_SHELL_STATUS_RESET": {
+    "message": "초기화 준비됨"
+  },
+  "SETTINGS_SHELL_RESET_CONFIRM": {
+    "message": "모든 설정을 기본값으로 초기화할까요? 저장하기 전까지는 실제 설정에 반영되지 않습니다."
   }
 }

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -1,26 +1,172 @@
 <script setup>
-import { computed, reactive, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { getText } from '/src/text.js'
 import {
+  createDefaultSecretsV2,
   createDefaultSettingsV2,
   SETTINGS_NAVIGATION
 } from '/src/settings-v2.mjs'
+import {
+  hasPendingSettingsChanges,
+  loadSettingsV2,
+  saveSettingsV2,
+  shouldWarnBeforeUnload
+} from '/src/settings-v2-storage.mjs'
 
 const navigation = SETTINGS_NAVIGATION
 const activeNavigationId = ref(navigation[0].id)
+const storage = globalThis.chrome?.storage || null
 
-// TASK 2 owns only the in-memory draft boundary. TASK 3 will connect this
-// object to the explicit save and migration flow; this shell deliberately
-// does not read from or write to chrome.storage.
+const defaultSettings = createDefaultSettingsV2()
+const defaultSecrets = createDefaultSecretsV2()
+const persistedSettings = reactive(createDefaultSettingsV2())
+const persistedSecrets = reactive(createDefaultSecretsV2())
 const draftSettings = reactive(createDefaultSettingsV2())
+const draftSecrets = reactive(createDefaultSecretsV2())
 const navButtonRefs = ref([])
+const isLoading = ref(true)
+const isSaving = ref(false)
+const migrationPending = ref(false)
+const hasLoadError = ref(false)
+const saveState = ref('idle')
 
 const currentNavigation = computed(() => navigation.find(item => (
   item.id === activeNavigationId.value
 )) || navigation[0])
 
+function cloneValue(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function replaceReactive(target, source) {
+  Object.keys(target).forEach(key => {
+    if (!Object.prototype.hasOwnProperty.call(source, key)) {
+      delete target[key]
+    }
+  })
+  Object.assign(target, cloneValue(source))
+}
+
+const hasPendingChanges = computed(() => (
+  hasPendingSettingsChanges(
+    {settings: persistedSettings, secrets: persistedSecrets},
+    {settings: draftSettings, secrets: draftSecrets}
+  )
+))
+
+const canSave = computed(() => (
+  !isLoading.value &&
+  !isSaving.value &&
+  (hasPendingChanges.value || migrationPending.value)
+))
+
+const statusMessageKey = computed(() => {
+  if (isLoading.value) {
+    return 'SETTINGS_SHELL_STATUS_LOADING'
+  }
+  if (isSaving.value) {
+    return 'SETTINGS_SHELL_STATUS_SAVING'
+  }
+  if (hasLoadError.value) {
+    return 'SETTINGS_SHELL_STATUS_LOAD_ERROR'
+  }
+  if (saveState.value === 'error' || migrationPending.value) {
+    return 'SETTINGS_SHELL_STATUS_SAVE_ERROR'
+  }
+  if (saveState.value === 'reset') {
+    return 'SETTINGS_SHELL_STATUS_RESET'
+  }
+  if (hasPendingChanges.value) {
+    return 'SETTINGS_SHELL_STATUS_UNSAVED'
+  }
+  return 'SETTINGS_SHELL_STATUS_SAVED'
+})
+
+const statusClass = computed(() => ({
+  'settings-header__status--unsaved': hasPendingChanges.value || migrationPending.value,
+  'settings-header__status--error': hasLoadError.value ||
+    saveState.value === 'error' || migrationPending.value,
+  'settings-header__status--saving': isLoading.value || isSaving.value
+}))
+
 function text(key, placeholders = undefined) {
   return getText(key, placeholders)
+}
+
+function resetDraft() {
+  const confirmMessage = text('SETTINGS_SHELL_RESET_CONFIRM')
+  const confirmFn = globalThis.confirm
+  if (typeof confirmFn === 'function' && !confirmFn(confirmMessage)) {
+    return
+  }
+
+  replaceReactive(draftSettings, defaultSettings)
+  replaceReactive(draftSecrets, defaultSecrets)
+  saveState.value = 'reset'
+}
+
+async function initializeSettings() {
+  isLoading.value = true
+  hasLoadError.value = false
+  saveState.value = 'idle'
+
+  try {
+    const loaded = await loadSettingsV2(storage)
+    replaceReactive(persistedSettings, loaded.settings)
+    replaceReactive(persistedSecrets, loaded.secrets)
+    replaceReactive(draftSettings, loaded.settings)
+    replaceReactive(draftSecrets, loaded.secrets)
+    migrationPending.value = loaded.migrationNeeded
+
+    if (loaded.migrationNeeded) {
+      try {
+        await saveSettingsV2(storage, loaded)
+        migrationPending.value = false
+      } catch (_error) {
+        saveState.value = 'error'
+      }
+    }
+  } catch (_error) {
+    hasLoadError.value = true
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function saveDraft() {
+  if (!canSave.value) {
+    return
+  }
+
+  isSaving.value = true
+  saveState.value = 'saving'
+
+  try {
+    const saved = await saveSettingsV2(storage, {
+      settings: draftSettings,
+      secrets: draftSecrets
+    })
+    replaceReactive(persistedSettings, saved.settings)
+    replaceReactive(persistedSecrets, saved.secrets)
+    replaceReactive(draftSettings, saved.settings)
+    replaceReactive(draftSecrets, saved.secrets)
+    migrationPending.value = false
+    hasLoadError.value = false
+    saveState.value = 'success'
+  } catch (_error) {
+    saveState.value = 'error'
+  } finally {
+    isSaving.value = false
+  }
+}
+
+function handleBeforeUnload(event) {
+  if (!shouldWarnBeforeUnload(hasPendingChanges.value)) {
+    return
+  }
+
+  event.preventDefault()
+  event.returnValue = ''
 }
 
 function selectNavigation(item) {
@@ -69,10 +215,30 @@ function handleNavigationKeydown(event, index) {
 
 defineExpose({
   activeNavigationId,
+  canSave,
   currentNavigation,
   draftSettings,
+  draftSecrets,
+  hasPendingChanges,
+  initializeSettings,
+  isLoading,
+  isSaving,
+  migrationPending,
   navigation,
+  persistedSettings,
+  persistedSecrets,
+  resetDraft,
+  saveDraft,
   selectNavigation
+})
+
+onMounted(() => {
+  globalThis.window?.addEventListener('beforeunload', handleBeforeUnload)
+  initializeSettings()
+})
+
+onBeforeUnmount(() => {
+  globalThis.window?.removeEventListener('beforeunload', handleBeforeUnload)
 })
 </script>
 
@@ -84,15 +250,21 @@ defineExpose({
       </h1>
 
       <div class="settings-header__actions" aria-live="polite">
-        <span class="settings-header__status" data-testid="settings-save-status">
-          {{ text('SETTINGS_SHELL_STATUS_SAVED') }}
+        <span
+          class="settings-header__status"
+          :class="statusClass"
+          data-testid="settings-save-status"
+          :data-status="statusMessageKey"
+        >
+          {{ text(statusMessageKey) }}
         </span>
         <button
           type="button"
           class="settings-header__save"
           data-testid="settings-save-button"
-          disabled
+          :disabled="!canSave"
           :aria-label="text('SETTINGS_SHELL_SAVE')"
+          @click="saveDraft"
         >
           {{ text('SETTINGS_SHELL_SAVE') }}
         </button>
@@ -172,6 +344,7 @@ defineExpose({
             name="page"
             :active-page="currentNavigation"
             :draft="draftSettings"
+            :draft-secrets="draftSecrets"
           >
             <div class="settings-placeholder-card" data-testid="settings-page-placeholder">
               <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>
@@ -187,7 +360,8 @@ defineExpose({
                   type="button"
                   class="settings-placeholder-card__reset"
                   data-testid="settings-reset-button"
-                  disabled
+                  :disabled="isLoading || isSaving"
+                  @click="resetDraft"
                 >
                   {{ text('RESET') }}
                 </button>
@@ -286,6 +460,18 @@ a {
   font-weight: var(--naverdic-font-weight-medium);
   line-height: 40px;
   text-align: right;
+}
+
+.settings-header__status--unsaved {
+  color: var(--naverdic-color-warning);
+}
+
+.settings-header__status--error {
+  color: var(--naverdic-color-danger);
+}
+
+.settings-header__status--saving {
+  color: var(--naverdic-settings-text-muted);
 }
 
 .settings-header__save {
@@ -481,6 +667,17 @@ a {
   font-size: var(--naverdic-font-size-sm);
   font-weight: var(--naverdic-font-weight-medium);
   cursor: not-allowed;
+}
+
+.settings-placeholder-card__reset:not(:disabled) {
+  color: var(--naverdic-color-danger);
+  background: var(--naverdic-settings-surface);
+  border-color: var(--naverdic-color-danger);
+  cursor: pointer;
+}
+
+.settings-placeholder-card__reset:not(:disabled):hover {
+  background: var(--naverdic-settings-danger-hover);
 }
 
 .settings-preview-card {

--- a/src/settings-migration-v2.mjs
+++ b/src/settings-migration-v2.mjs
@@ -18,6 +18,10 @@ import {
 
 export const V66_STORAGE_AREA = 'sync'
 
+export const LEGACY_SECRET_KEYS = Object.freeze([
+  'deepl_auth_key'
+])
+
 export const LEGACY_SETTING_KEYS = Object.freeze(
   SETTINGS_SCHEMA.map(definition => definition.key)
 )

--- a/src/settings-v2-storage.mjs
+++ b/src/settings-v2-storage.mjs
@@ -7,6 +7,7 @@ import {
   normalizeSettingsV2
 } from './settings-v2.mjs'
 import {
+  LEGACY_SECRET_KEYS,
   LEGACY_SETTING_KEYS,
   migrateV66ToV2
 } from './settings-migration-v2.mjs'
@@ -119,6 +120,40 @@ function writeStorageArea(area, values) {
   })
 }
 
+function removeStorageArea(area, keys) {
+  if (!area?.remove) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (callback, value) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      callback(value)
+    }
+    const callback = () => {
+      const lastError = getLastError()
+      if (lastError) {
+        finish(reject, lastError)
+        return
+      }
+      finish(resolve)
+    }
+
+    try {
+      const result = area.remove(keys, callback)
+      if (result && typeof result.then === 'function') {
+        result.then(() => callback()).catch(error => finish(reject, error))
+      }
+    } catch (error) {
+      finish(reject, error)
+    }
+  })
+}
+
 function mergeSecrets(localSecrets, migratedSecrets) {
   const local = normalizeSecretsV2(localSecrets)
   const migrated = normalizeSecretsV2(migratedSecrets)
@@ -163,25 +198,33 @@ export async function loadSettingsV2(storage) {
     ? normalizeSettingsV2(storedSettings)
     : legacyMigration.settings
   const storedSecrets = localValues[SETTINGS_STORAGE.secrets.key]
-  const secrets = mergeSecrets(storedSecrets, legacyMigration.secrets)
+  const hasV2Secrets = hasOwn(localValues, SETTINGS_STORAGE.secrets.key)
+  const secrets = hasV2Secrets
+    ? normalizeSecretsV2(storedSecrets)
+    : mergeSecrets(storedSecrets, legacyMigration.secrets)
   const hasSyncStorage = Boolean(areas.sync?.get || areas.sync?.set)
   const hasLocalStorage = Boolean(areas.local?.get || areas.local?.set)
   const storageAvailable = hasSyncStorage || hasLocalStorage
+  const legacySecretKeys = LEGACY_SECRET_KEYS.filter(key => hasOwn(syncValues, key))
 
   const settingsNeedNormalization = !hasV2Settings || !valuesEqual(storedSettings, settings)
-  const secretsNeedNormalization = !hasOwn(localValues, SETTINGS_STORAGE.secrets.key) ||
+  const secretsNeedNormalization = !hasV2Secrets ||
     !valuesEqual(storedSecrets, secrets)
   const migrationNeeded = storageAvailable && (
-    settingsNeedNormalization || secretsNeedNormalization
+    settingsNeedNormalization ||
+    secretsNeedNormalization ||
+    legacySecretKeys.length > 0
   )
 
   return {
     settings,
     secrets,
     hasV2Settings,
+    hasV2Secrets,
     migratedFromV66: !hasV2Settings && legacyMigration.sourceKeys.length > 0,
     migrationNeeded,
     storageAvailable,
+    legacySecretKeys,
     sourceKeys: legacyMigration.sourceKeys,
     unknownKeys: legacyMigration.unknownKeys
   }
@@ -202,6 +245,7 @@ export async function saveSettingsV2(storage, values = {}) {
   await writeStorageArea(areas.local, {
     [SETTINGS_STORAGE.secrets.key]: secrets
   })
+  await removeStorageArea(areas.sync, LEGACY_SECRET_KEYS)
 
   return {settings, secrets}
 }

--- a/src/settings-v2-storage.mjs
+++ b/src/settings-v2-storage.mjs
@@ -3,6 +3,7 @@ import {
   createDefaultSecretsV2,
   createDefaultSettingsV2,
   hasSettingsV2Envelope,
+  hasSecretsV2Envelope,
   normalizeSecretsV2,
   normalizeSettingsV2
 } from './settings-v2.mjs'
@@ -198,7 +199,7 @@ export async function loadSettingsV2(storage) {
     ? normalizeSettingsV2(storedSettings)
     : legacyMigration.settings
   const storedSecrets = localValues[SETTINGS_STORAGE.secrets.key]
-  const hasV2Secrets = hasOwn(localValues, SETTINGS_STORAGE.secrets.key)
+  const hasV2Secrets = hasSecretsV2Envelope(storedSecrets)
   const secrets = hasV2Secrets
     ? normalizeSecretsV2(storedSecrets)
     : mergeSecrets(storedSecrets, legacyMigration.secrets)

--- a/src/settings-v2-storage.mjs
+++ b/src/settings-v2-storage.mjs
@@ -1,0 +1,230 @@
+import {
+  SETTINGS_STORAGE,
+  createDefaultSecretsV2,
+  createDefaultSettingsV2,
+  hasSettingsV2Envelope,
+  normalizeSecretsV2,
+  normalizeSettingsV2
+} from './settings-v2.mjs'
+import {
+  LEGACY_SETTING_KEYS,
+  migrateV66ToV2
+} from './settings-migration-v2.mjs'
+
+function hasOwn(value, key) {
+  return Object.prototype.hasOwnProperty.call(value, key)
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function stableSerialize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableSerialize).join(',')}]`
+  }
+
+  if (isRecord(value)) {
+    return `{${Object.keys(value).sort().map(key => (
+      `${JSON.stringify(key)}:${stableSerialize(value[key])}`
+    )).join(',')}}`
+  }
+
+  return JSON.stringify(value)
+}
+
+function valuesEqual(left, right) {
+  return stableSerialize(left) === stableSerialize(right)
+}
+
+export function hasPendingSettingsChanges(persisted, draft) {
+  return !valuesEqual(persisted?.settings, draft?.settings) ||
+    !valuesEqual(persisted?.secrets, draft?.secrets)
+}
+
+export function shouldWarnBeforeUnload(hasPendingChanges) {
+  return Boolean(hasPendingChanges)
+}
+
+function getLastError() {
+  const lastError = globalThis.chrome?.runtime?.lastError
+  return lastError?.message ? new Error(lastError.message) : null
+}
+
+function readStorageArea(area, keys) {
+  if (!area?.get) {
+    return Promise.resolve({})
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (callback, value) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      callback(value)
+    }
+    const callback = values => {
+      const lastError = getLastError()
+      if (lastError) {
+        finish(reject, lastError)
+        return
+      }
+      finish(resolve, isRecord(values) ? values : {})
+    }
+
+    try {
+      const result = area.get(keys, callback)
+      if (result && typeof result.then === 'function') {
+        result.then(callback).catch(error => finish(reject, error))
+      }
+    } catch (error) {
+      finish(reject, error)
+    }
+  })
+}
+
+function writeStorageArea(area, values) {
+  if (!area?.set) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const finish = (callback, value) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      callback(value)
+    }
+    const callback = () => {
+      const lastError = getLastError()
+      if (lastError) {
+        finish(reject, lastError)
+        return
+      }
+      finish(resolve)
+    }
+
+    try {
+      const result = area.set(values, callback)
+      if (result && typeof result.then === 'function') {
+        result.then(() => callback()).catch(error => finish(reject, error))
+      }
+    } catch (error) {
+      finish(reject, error)
+    }
+  })
+}
+
+function mergeSecrets(localSecrets, migratedSecrets) {
+  const local = normalizeSecretsV2(localSecrets)
+  const migrated = normalizeSecretsV2(migratedSecrets)
+  const merged = createDefaultSecretsV2()
+
+  Object.entries(migrated.providers).forEach(([providerId, credentials]) => {
+    merged.providers[providerId] = {...credentials}
+  })
+  Object.entries(local.providers).forEach(([providerId, credentials]) => {
+    merged.providers[providerId] = {
+      ...merged.providers[providerId],
+      ...credentials
+    }
+  })
+
+  return normalizeSecretsV2(merged)
+}
+
+function getStorageAreas(storage) {
+  return {
+    sync: storage?.sync || null,
+    local: storage?.local || null
+  }
+}
+
+/**
+ * Read v7 envelopes and legacy v6.6 keys without changing either storage
+ * area. Individual invalid v2 fields are normalized to their own defaults.
+ */
+export async function loadSettingsV2(storage) {
+  const areas = getStorageAreas(storage)
+  const syncKeys = [SETTINGS_STORAGE.settings.key, ...LEGACY_SETTING_KEYS]
+  const [syncValues, localValues] = await Promise.all([
+    readStorageArea(areas.sync, syncKeys),
+    readStorageArea(areas.local, [SETTINGS_STORAGE.secrets.key])
+  ])
+
+  const storedSettings = syncValues[SETTINGS_STORAGE.settings.key]
+  const hasV2Settings = hasSettingsV2Envelope(storedSettings)
+  const legacyMigration = migrateV66ToV2(syncValues)
+  const settings = hasV2Settings
+    ? normalizeSettingsV2(storedSettings)
+    : legacyMigration.settings
+  const storedSecrets = localValues[SETTINGS_STORAGE.secrets.key]
+  const secrets = mergeSecrets(storedSecrets, legacyMigration.secrets)
+  const hasSyncStorage = Boolean(areas.sync?.get || areas.sync?.set)
+  const hasLocalStorage = Boolean(areas.local?.get || areas.local?.set)
+  const storageAvailable = hasSyncStorage || hasLocalStorage
+
+  const settingsNeedNormalization = !hasV2Settings || !valuesEqual(storedSettings, settings)
+  const secretsNeedNormalization = !hasOwn(localValues, SETTINGS_STORAGE.secrets.key) ||
+    !valuesEqual(storedSecrets, secrets)
+  const migrationNeeded = storageAvailable && (
+    settingsNeedNormalization || secretsNeedNormalization
+  )
+
+  return {
+    settings,
+    secrets,
+    hasV2Settings,
+    migratedFromV66: !hasV2Settings && legacyMigration.sourceKeys.length > 0,
+    migrationNeeded,
+    storageAvailable,
+    sourceKeys: legacyMigration.sourceKeys,
+    unknownKeys: legacyMigration.unknownKeys
+  }
+}
+
+/**
+ * Persist only the v7 envelopes. Settings are sync-safe; credentials are
+ * always sent to local storage and never included in the sync payload.
+ */
+export async function saveSettingsV2(storage, values = {}) {
+  const areas = getStorageAreas(storage)
+  const settings = normalizeSettingsV2(values.settings)
+  const secrets = normalizeSecretsV2(values.secrets)
+
+  await writeStorageArea(areas.sync, {
+    [SETTINGS_STORAGE.settings.key]: settings
+  })
+  await writeStorageArea(areas.local, {
+    [SETTINGS_STORAGE.secrets.key]: secrets
+  })
+
+  return {settings, secrets}
+}
+
+export const persistSettingsV2 = saveSettingsV2
+
+export async function migrateAndPersistSettingsV2(storage) {
+  const loaded = await loadSettingsV2(storage)
+  if (!loaded.migrationNeeded) {
+    return loaded
+  }
+
+  const saved = await saveSettingsV2(storage, loaded)
+  return {
+    ...loaded,
+    ...saved,
+    migrationNeeded: false
+  }
+}
+
+export function createEmptySettingsV2State() {
+  return {
+    settings: createDefaultSettingsV2(),
+    secrets: createDefaultSecretsV2()
+  }
+}

--- a/src/settings-v2.mjs
+++ b/src/settings-v2.mjs
@@ -489,3 +489,9 @@ export function getSettingPathValue(settings, path) {
 export function hasSettingsV2Envelope(value) {
   return isRecord(value) && value.schemaVersion === SETTINGS_SCHEMA_VERSION
 }
+
+export function hasSecretsV2Envelope(value) {
+  return isRecord(value) &&
+    value.schemaVersion === SETTINGS_SCHEMA_VERSION &&
+    isRecord(value.providers)
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -101,6 +101,7 @@
   --naverdic-settings-nav-text: #344054;
   --naverdic-settings-nav-hover: #F8FAFC;
   --naverdic-settings-success: #3C8B6B;
+  --naverdic-settings-danger-hover: #FEF2F2;
   --naverdic-settings-primary: #3F82F5;
   --naverdic-settings-primary-text: #1A4FA8;
   --naverdic-settings-nav-active: #EAF2FF;

--- a/tests/settings-v2-storage.test.mjs
+++ b/tests/settings-v2-storage.test.mjs
@@ -18,8 +18,10 @@ class FakeStorageArea {
     this.items = {...items}
     this.getCalls = []
     this.setCalls = []
+    this.removeCalls = []
     this.failGet = options.failGet || null
     this.failSet = options.failSet || null
+    this.failRemove = options.failRemove || null
   }
 
   get(keys, callback) {
@@ -46,6 +48,17 @@ class FakeStorageArea {
     }
 
     Object.assign(this.items, values)
+    callback?.()
+  }
+
+  remove(keys, callback) {
+    this.removeCalls.push(Array.isArray(keys) ? [...keys] : [keys])
+    if (this.failRemove) {
+      throw this.failRemove
+    }
+
+    const keysToRemove = Array.isArray(keys) ? keys : [keys]
+    keysToRemove.forEach(key => delete this.items[key])
     callback?.()
   }
 }
@@ -104,10 +117,11 @@ test('persists the v6.6 migration into separate v2 sync and local envelopes', as
   assert.equal(migrated.migrationNeeded, false)
   assert.equal(storage.sync.setCalls.length, 1)
   assert.equal(storage.local.setCalls.length, 1)
+  assert.deepEqual(storage.sync.removeCalls, [['deepl_auth_key']])
   assert.deepEqual(Object.keys(storage.sync.setCalls[0]), [settingsKey])
   assert.deepEqual(Object.keys(storage.local.setCalls[0]), [secretsKey])
   assert.equal(storage.sync.items.unrelated_key, 'keep-me')
-  assert.equal(storage.sync.items.deepl_auth_key, legacyValues.deepl_auth_key)
+  assert.equal('deepl_auth_key' in storage.sync.items, false)
   assert.equal(
     storage.sync.items[settingsKey].translation.providerId,
     'deepl-free'
@@ -116,6 +130,34 @@ test('persists the v6.6 migration into separate v2 sync and local envelopes', as
     storage.local.items[secretsKey].providers['deepl-free'],
     {apiKey: 'legacy-secret'}
   )
+})
+
+test('does not resurrect a deleted credential from legacy sync storage', async () => {
+  const settingsKey = SETTINGS_STORAGE.settings.key
+  const secretsKey = SETTINGS_STORAGE.secrets.key
+  const storage = createStorage({
+    [settingsKey]: SETTINGS_V2_DEFAULTS,
+    deepl_auth_key: '  stale-secret  ',
+    unrelated_key: 'keep-me'
+  }, {
+    [secretsKey]: {
+      schemaVersion: 2,
+      providers: {}
+    }
+  })
+
+  const loaded = await loadSettingsV2(storage)
+
+  assert.equal(loaded.hasV2Secrets, true)
+  assert.deepEqual(loaded.secrets.providers, {})
+  assert.equal(loaded.migrationNeeded, true)
+  assert.deepEqual(loaded.legacySecretKeys, ['deepl_auth_key'])
+
+  await migrateAndPersistSettingsV2(storage)
+
+  assert.deepEqual(storage.local.items[secretsKey].providers, {})
+  assert.equal('deepl_auth_key' in storage.sync.items, false)
+  assert.equal(storage.sync.items.unrelated_key, 'keep-me')
 })
 
 test('normalizes only invalid v2 fields and schedules the corrected envelope', async () => {
@@ -206,6 +248,32 @@ test('surfaces sync and local write failures to the caller', async () => {
     /local unavailable/
   )
   assert.equal(localFailure.sync.setCalls.length, 1)
+  assert.equal(localFailure.sync.removeCalls.length, 0)
+})
+
+test('reports legacy cleanup failures after local credentials are persisted', async () => {
+  const storage = createStorage({
+    deepl_auth_key: 'legacy-secret'
+  }, {}, {
+    sync: {failRemove: new Error('legacy cleanup unavailable')}
+  })
+
+  await assert.rejects(
+    saveSettingsV2(storage, {
+      secrets: {
+        schemaVersion: 2,
+        providers: {
+          'deepl-free': {apiKey: 'local-secret'}
+        }
+      }
+    }),
+    /legacy cleanup unavailable/
+  )
+  assert.equal(
+    storage.local.items[SETTINGS_STORAGE.secrets.key].providers['deepl-free'].apiKey,
+    'local-secret'
+  )
+  assert.equal(storage.sync.items.deepl_auth_key, 'legacy-secret')
 })
 
 test('tracks draft changes separately from persisted settings for unload warnings', () => {

--- a/tests/settings-v2-storage.test.mjs
+++ b/tests/settings-v2-storage.test.mjs
@@ -1,0 +1,227 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  SETTINGS_STORAGE,
+  SETTINGS_V2_DEFAULTS
+} from '../src/settings-v2.mjs'
+import {
+  hasPendingSettingsChanges,
+  loadSettingsV2,
+  migrateAndPersistSettingsV2,
+  saveSettingsV2,
+  shouldWarnBeforeUnload
+} from '../src/settings-v2-storage.mjs'
+
+class FakeStorageArea {
+  constructor(items = {}, options = {}) {
+    this.items = {...items}
+    this.getCalls = []
+    this.setCalls = []
+    this.failGet = options.failGet || null
+    this.failSet = options.failSet || null
+  }
+
+  get(keys, callback) {
+    this.getCalls.push(keys)
+    if (this.failGet) {
+      throw this.failGet
+    }
+
+    const requestedKeys = Array.isArray(keys)
+      ? keys
+      : typeof keys === 'string'
+        ? [keys]
+        : Object.keys(this.items)
+    const values = Object.fromEntries(requestedKeys
+      .filter(key => Object.prototype.hasOwnProperty.call(this.items, key))
+      .map(key => [key, this.items[key]]))
+    callback(values)
+  }
+
+  set(values, callback) {
+    this.setCalls.push({...values})
+    if (this.failSet) {
+      throw this.failSet
+    }
+
+    Object.assign(this.items, values)
+    callback?.()
+  }
+}
+
+function createStorage(syncItems = {}, localItems = {}, options = {}) {
+  return {
+    sync: new FakeStorageArea(syncItems, options.sync),
+    local: new FakeStorageArea(localItems, options.local)
+  }
+}
+
+const legacyValues = {
+  dclick: 'false',
+  dclick_trigger_key: ' alt ',
+  dclick_speed: '300',
+  drag: 0,
+  drag_trigger_key: 'ctrlalt',
+  translate: 'true',
+  translate_trigger_key: 'none',
+  deepl_auth_key: '  legacy-secret  ',
+  popup_bgcolor: ' #123456 ',
+  popup_fontcolor: ' #ffffff ',
+  popup_fontsize: '13',
+  use_deny_list: true,
+  safe_urls: ' https://www.Example.com/path, *.example.com; naver.com\n'
+}
+
+test('loads v6.6 values into a draft without writing during the read', async () => {
+  const storage = createStorage(legacyValues)
+
+  const loaded = await loadSettingsV2(storage)
+
+  assert.equal(loaded.hasV2Settings, false)
+  assert.equal(loaded.migratedFromV66, true)
+  assert.equal(loaded.migrationNeeded, true)
+  assert.equal(loaded.settings.dictionary.doubleClick.enabled, false)
+  assert.equal(loaded.settings.dictionary.doubleClick.speedMs, 300)
+  assert.equal(loaded.settings.sites.denyList[0], 'www.example.com')
+  assert.deepEqual(loaded.secrets.providers['deepl-free'], {
+    apiKey: 'legacy-secret'
+  })
+  assert.equal(storage.sync.setCalls.length, 0)
+  assert.equal(storage.local.setCalls.length, 0)
+})
+
+test('persists the v6.6 migration into separate v2 sync and local envelopes', async () => {
+  const storage = createStorage({
+    ...legacyValues,
+    unrelated_key: 'keep-me'
+  })
+
+  const migrated = await migrateAndPersistSettingsV2(storage)
+  const settingsKey = SETTINGS_STORAGE.settings.key
+  const secretsKey = SETTINGS_STORAGE.secrets.key
+
+  assert.equal(migrated.migrationNeeded, false)
+  assert.equal(storage.sync.setCalls.length, 1)
+  assert.equal(storage.local.setCalls.length, 1)
+  assert.deepEqual(Object.keys(storage.sync.setCalls[0]), [settingsKey])
+  assert.deepEqual(Object.keys(storage.local.setCalls[0]), [secretsKey])
+  assert.equal(storage.sync.items.unrelated_key, 'keep-me')
+  assert.equal(storage.sync.items.deepl_auth_key, legacyValues.deepl_auth_key)
+  assert.equal(
+    storage.sync.items[settingsKey].translation.providerId,
+    'deepl-free'
+  )
+  assert.deepEqual(
+    storage.local.items[secretsKey].providers['deepl-free'],
+    {apiKey: 'legacy-secret'}
+  )
+})
+
+test('normalizes only invalid v2 fields and schedules the corrected envelope', async () => {
+  const storage = createStorage({
+    [SETTINGS_STORAGE.settings.key]: {
+      schemaVersion: 2,
+      interface: {language: 'fr'},
+      popup: {
+        backgroundColor: '  red  ',
+        fontColor: '',
+        fontSizePt: '-2'
+      },
+      translation: {
+        providerId: 'missing-provider',
+        targetLanguage: 'ja'
+      }
+    }
+  }, {
+    [SETTINGS_STORAGE.secrets.key]: {
+      schemaVersion: 2,
+      providers: {}
+    }
+  })
+
+  const loaded = await loadSettingsV2(storage)
+
+  assert.equal(loaded.hasV2Settings, true)
+  assert.equal(loaded.settings.interface.language, 'auto')
+  assert.equal(loaded.settings.popup.backgroundColor, 'red')
+  assert.equal(loaded.settings.popup.fontColor, SETTINGS_V2_DEFAULTS.popup.fontColor)
+  assert.equal(loaded.settings.popup.fontSizePt, SETTINGS_V2_DEFAULTS.popup.fontSizePt)
+  assert.equal(loaded.settings.translation.providerId, 'deepl-free')
+  assert.equal(loaded.settings.translation.targetLanguage, 'ja')
+  assert.equal(loaded.migrationNeeded, true)
+
+  await migrateAndPersistSettingsV2(storage)
+  assert.equal(
+    storage.sync.items[SETTINGS_STORAGE.settings.key].interface.language,
+    'auto'
+  )
+  assert.equal(storage.sync.setCalls.length, 1)
+})
+
+test('keeps API credentials out of sync when saving v2 settings', async () => {
+  const storage = createStorage({legacy_key: 'keep-me'})
+  const result = await saveSettingsV2(storage, {
+    settings: {
+      ...SETTINGS_V2_DEFAULTS,
+      translation: {
+        ...SETTINGS_V2_DEFAULTS.translation,
+        enabled: true
+      }
+    },
+    secrets: {
+      schemaVersion: 2,
+      providers: {
+        'deepl-free': {apiKey: 'local-only-secret'}
+      }
+    }
+  })
+
+  const syncPayload = storage.sync.setCalls[0]
+  const localPayload = storage.local.setCalls[0]
+  assert.equal(storage.sync.items.legacy_key, 'keep-me')
+  assert.equal('apiKey' in syncPayload, false)
+  assert.equal('deepl_auth_key' in syncPayload, false)
+  assert.equal(
+    localPayload[SETTINGS_STORAGE.secrets.key].providers['deepl-free'].apiKey,
+    'local-only-secret'
+  )
+  assert.equal(result.settings.translation.enabled, true)
+})
+
+test('surfaces sync and local write failures to the caller', async () => {
+  const syncFailure = createStorage({}, {}, {
+    sync: {failSet: new Error('sync unavailable')}
+  })
+  await assert.rejects(
+    saveSettingsV2(syncFailure, {}),
+    /sync unavailable/
+  )
+
+  const localFailure = createStorage({}, {}, {
+    local: {failSet: new Error('local unavailable')}
+  })
+  await assert.rejects(
+    saveSettingsV2(localFailure, {}),
+    /local unavailable/
+  )
+  assert.equal(localFailure.sync.setCalls.length, 1)
+})
+
+test('tracks draft changes separately from persisted settings for unload warnings', () => {
+  const persisted = {
+    settings: {popup: {fontSizePt: 11}},
+    secrets: {providers: {}}
+  }
+  const draft = {
+    settings: {popup: {fontSizePt: 11}},
+    secrets: {providers: {}}
+  }
+
+  assert.equal(hasPendingSettingsChanges(persisted, draft), false)
+  assert.equal(shouldWarnBeforeUnload(false), false)
+
+  draft.settings.popup.fontSizePt = 14
+  assert.equal(hasPendingSettingsChanges(persisted, draft), true)
+  assert.equal(shouldWarnBeforeUnload(true), true)
+})

--- a/tests/settings-v2-storage.test.mjs
+++ b/tests/settings-v2-storage.test.mjs
@@ -160,6 +160,37 @@ test('does not resurrect a deleted credential from legacy sync storage', async (
   assert.equal(storage.sync.items.unrelated_key, 'keep-me')
 })
 
+for (const [label, invalidEnvelope] of [
+  ['null', null],
+  ['an array', []],
+  ['a wrong schema version', {schemaVersion: 1, providers: {}}]
+]) {
+  test(`recovers a legacy credential from ${label} local secrets`, async () => {
+    const settingsKey = SETTINGS_STORAGE.settings.key
+    const secretsKey = SETTINGS_STORAGE.secrets.key
+    const storage = createStorage({
+      [settingsKey]: SETTINGS_V2_DEFAULTS,
+      deepl_auth_key: '  recoverable-secret  '
+    }, {
+      [secretsKey]: invalidEnvelope
+    })
+
+    const loaded = await loadSettingsV2(storage)
+
+    assert.equal(loaded.hasV2Secrets, false)
+    assert.equal(loaded.secrets.providers['deepl-free'].apiKey, 'recoverable-secret')
+    assert.equal(loaded.migrationNeeded, true)
+
+    await migrateAndPersistSettingsV2(storage)
+
+    assert.equal(
+      storage.local.items[secretsKey].providers['deepl-free'].apiKey,
+      'recoverable-secret'
+    )
+    assert.equal('deepl_auth_key' in storage.sync.items, false)
+  })
+}
+
 test('normalizes only invalid v2 fields and schedules the corrected envelope', async () => {
   const storage = createStorage({
     [SETTINGS_STORAGE.settings.key]: {


### PR DESCRIPTION
## Summary
- v2 설정 저장 어댑터와 v6.6 설정 자동 마이그레이션을 추가했습니다.
- 편집 중 상태와 저장된 상태를 분리하고, 명시적 저장·변경 감지·저장/로드 상태·새로고침 경고를 연결했습니다.
- 고급 메뉴 초기화 확인 절차를 추가했습니다.
- API 키는 chrome.storage.local에만 저장하고 sync 저장 대상에서 제외했습니다.
- 기존 v2 local secrets가 있으면 legacy sync credential을 되살리지 않으며, local 저장 성공 후 legacy `deepl_auth_key`만 sync에서 제거합니다. 일반 legacy/unknown 키는 보존합니다.
- 손상된 local secrets envelope(null·배열·잘못된 schema)은 legacy credential을 복구하고, 명시적인 빈 v2 envelope만 삭제 상태로 존중합니다.

## Verification
- npm test — 61 passing
- npm run build — passed
- NAVERDIC_ZIP_DIR=/tmp/naverdic-task3-invalid-envelope-package npm run package — passed
- 로컬 options 화면 브라우저 QA — 저장 버튼 비활성 상태, 고급 메뉴 초기화 버튼, 콘솔 오류 없음 확인