### PR TITLE
[TASK 4] Add dictionary, popup, and site settings

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -262,5 +262,106 @@
   },
   "SETTINGS_SHELL_RESET_CONFIRM": {
     "message": "Reset all settings to their defaults? The reset will not affect stored settings until you save."
+  },
+  "SETTINGS_SECTION_POPUP_APPEARANCE": {
+    "message": "Popup appearance"
+  },
+  "SETTINGS_SECTION_POPUP_APPEARANCE_DESCRIPTION": {
+    "message": "Adjust the popup dictionary colors and typography."
+  },
+  "SETTINGS_FIELD_BACKGROUND_COLOR": {
+    "message": "Background color"
+  },
+  "SETTINGS_FIELD_BACKGROUND_COLOR_HINT": {
+    "message": "Popup dictionary background"
+  },
+  "SETTINGS_FIELD_FONT_COLOR": {
+    "message": "Text color"
+  },
+  "SETTINGS_FIELD_FONT_COLOR_HINT": {
+    "message": "Text color used for results"
+  },
+  "SETTINGS_FIELD_FONT_SIZE": {
+    "message": "Text size"
+  },
+  "SETTINGS_FIELD_FONT_SIZE_HINT": {
+    "message": "Result text size"
+  },
+  "SETTINGS_POPUP_THEME_GUIDE": {
+    "message": "View theme guide"
+  },
+  "SETTINGS_SECTION_DOUBLE_CLICK": {
+    "message": "Double-click search"
+  },
+  "SETTINGS_SECTION_DOUBLE_CLICK_DESCRIPTION": {
+    "message": "Configure how the dictionary appears when you double-click a word."
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_ENABLED": {
+    "message": "Show dictionary on double-click"
+  },
+  "SETTINGS_FIELD_TRIGGER_KEY": {
+    "message": "Trigger key"
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_TRIGGER_HINT": {
+    "message": "Hold a modifier key when needed."
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_SPEED": {
+    "message": "Double-click speed"
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_SPEED_HINT": {
+    "message": "Shorter intervals respond more quickly."
+  },
+  "SETTINGS_SECTION_DRAG": {
+    "message": "Drag search"
+  },
+  "SETTINGS_SECTION_DRAG_DESCRIPTION": {
+    "message": "Configure dictionary search for selected words or sentences."
+  },
+  "SETTINGS_FIELD_DRAG_ENABLED": {
+    "message": "Enable drag search"
+  },
+  "SETTINGS_FIELD_DRAG_TRIGGER_HINT": {
+    "message": "Choose the modifier key used while dragging."
+  },
+  "SETTINGS_SECTION_BLOCKED_SITES": {
+    "message": "Blocked sites"
+  },
+  "SETTINGS_SECTION_BLOCKED_SITES_DESCRIPTION": {
+    "message": "Manage websites where the popup dictionary should not appear."
+  },
+  "SETTINGS_FIELD_BLOCKED_SITES_ENABLED": {
+    "message": "Enable blocked sites"
+  },
+  "SETTINGS_FIELD_BLOCKED_SITES": {
+    "message": "Site list"
+  },
+  "SETTINGS_BLOCKED_SITES_HINT": {
+    "message": "Enter one per line, or separate entries with commas or semicolons."
+  },
+  "SETTINGS_BLOCKED_SITES_PLACEHOLDER": {
+    "message": "Example: google.com\nnaver.com"
+  },
+  "SETTINGS_BLOCKED_SITES_INVALID": {
+    "message": "$count$ entries need attention. Use a domain or URL.",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "SETTINGS_BLOCKED_SITES_NORMALIZED": {
+    "message": "Normalized domains"
+  },
+  "SETTINGS_BLOCKED_SITES_EMPTY": {
+    "message": "No sites have been added."
+  },
+  "SETTINGS_PREVIEW_WORD": {
+    "message": "dictionary"
+  },
+  "SETTINGS_PREVIEW_MEANING": {
+    "message": "Dictionary result preview"
+  },
+  "SETTINGS_PREVIEW_HINT": {
+    "message": "Current popup settings"
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -262,5 +262,106 @@
   },
   "SETTINGS_SHELL_RESET_CONFIRM": {
     "message": "모든 설정을 기본값으로 초기화할까요? 저장하기 전까지는 실제 설정에 반영되지 않습니다."
+  },
+  "SETTINGS_SECTION_POPUP_APPEARANCE": {
+    "message": "팝업 모양"
+  },
+  "SETTINGS_SECTION_POPUP_APPEARANCE_DESCRIPTION": {
+    "message": "팝업 사전의 색상과 글자 모양을 조정합니다."
+  },
+  "SETTINGS_FIELD_BACKGROUND_COLOR": {
+    "message": "배경색"
+  },
+  "SETTINGS_FIELD_BACKGROUND_COLOR_HINT": {
+    "message": "팝업 사전의 배경색"
+  },
+  "SETTINGS_FIELD_FONT_COLOR": {
+    "message": "글자색"
+  },
+  "SETTINGS_FIELD_FONT_COLOR_HINT": {
+    "message": "검색 결과에 사용할 글자색"
+  },
+  "SETTINGS_FIELD_FONT_SIZE": {
+    "message": "글자 크기"
+  },
+  "SETTINGS_FIELD_FONT_SIZE_HINT": {
+    "message": "검색 결과의 글자 크기"
+  },
+  "SETTINGS_POPUP_THEME_GUIDE": {
+    "message": "테마 가이드 보기"
+  },
+  "SETTINGS_SECTION_DOUBLE_CLICK": {
+    "message": "더블클릭 검색"
+  },
+  "SETTINGS_SECTION_DOUBLE_CLICK_DESCRIPTION": {
+    "message": "단어를 더블클릭했을 때 사전을 표시하는 방법을 설정합니다."
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_ENABLED": {
+    "message": "더블클릭으로 사전 보기"
+  },
+  "SETTINGS_FIELD_TRIGGER_KEY": {
+    "message": "트리거 키"
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_TRIGGER_HINT": {
+    "message": "필요하면 보조 키를 함께 누르세요."
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_SPEED": {
+    "message": "더블클릭 속도"
+  },
+  "SETTINGS_FIELD_DOUBLE_CLICK_SPEED_HINT": {
+    "message": "더 빠른 간격일수록 민감하게 반응합니다."
+  },
+  "SETTINGS_SECTION_DRAG": {
+    "message": "드래그 검색"
+  },
+  "SETTINGS_SECTION_DRAG_DESCRIPTION": {
+    "message": "문장이나 단어를 드래그해 사전을 검색하는 방법을 설정합니다."
+  },
+  "SETTINGS_FIELD_DRAG_ENABLED": {
+    "message": "드래그 검색 사용"
+  },
+  "SETTINGS_FIELD_DRAG_TRIGGER_HINT": {
+    "message": "드래그할 때 사용할 보조 키를 선택하세요."
+  },
+  "SETTINGS_SECTION_BLOCKED_SITES": {
+    "message": "중지 사이트"
+  },
+  "SETTINGS_SECTION_BLOCKED_SITES_DESCRIPTION": {
+    "message": "팝업 사전을 표시하지 않을 웹사이트를 관리합니다."
+  },
+  "SETTINGS_FIELD_BLOCKED_SITES_ENABLED": {
+    "message": "중지목록 사용"
+  },
+  "SETTINGS_FIELD_BLOCKED_SITES": {
+    "message": "사이트 목록"
+  },
+  "SETTINGS_BLOCKED_SITES_HINT": {
+    "message": "한 줄에 하나씩 입력하거나 쉼표(,)·세미콜론(;)으로 구분하세요."
+  },
+  "SETTINGS_BLOCKED_SITES_PLACEHOLDER": {
+    "message": "예: google.com\nnaver.com"
+  },
+  "SETTINGS_BLOCKED_SITES_INVALID": {
+    "message": "$count$개 항목을 확인하세요. 도메인 또는 URL 형식이어야 합니다.",
+    "placeholders": {
+      "count": {
+        "content": "$1"
+      }
+    }
+  },
+  "SETTINGS_BLOCKED_SITES_NORMALIZED": {
+    "message": "정규화된 도메인"
+  },
+  "SETTINGS_BLOCKED_SITES_EMPTY": {
+    "message": "등록된 사이트가 없습니다."
+  },
+  "SETTINGS_PREVIEW_WORD": {
+    "message": "dictionary"
+  },
+  "SETTINGS_PREVIEW_MEANING": {
+    "message": "사전 결과 미리보기"
+  },
+  "SETTINGS_PREVIEW_HINT": {
+    "message": "현재 팝업 설정"
   }
 }

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -2,6 +2,7 @@
 import { computed, ref, watch } from 'vue'
 import { getText } from '/src/text.js'
 import { getTriggerLabels } from '/src/content-interaction.mjs'
+import { resolveCssColor } from '/src/settings-colors.mjs'
 import {
   formatDenyList,
   parseDenyListInput
@@ -37,23 +38,13 @@ const props = defineProps({
 const {ctrl, alt} = getTriggerLabels()
 const siteInput = ref('')
 const invalidSiteEntries = ref([])
+const controlsDisabled = computed(() => props.isLoading || props.isSaving)
 
 const pageId = computed(() => props.activePage?.id || '')
 const siteDomains = computed(() => props.draft.sites?.denyList || [])
 
 function text(key, placeholders = undefined) {
   return getText(key, placeholders)
-}
-
-function previewColor(value, fallback) {
-  const candidate = String(value ?? '').trim()
-  if (/^#[\da-f]{3,8}$/i.test(candidate) ||
-      /^(?:rgb|hsl)a?\([^)]*\)$/i.test(candidate) ||
-      /^[a-z]+$/i.test(candidate)) {
-    return candidate
-  }
-
-  return fallback
 }
 
 function syncSiteInput() {
@@ -98,7 +89,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         <div class="settings-color-control">
           <span
             class="settings-color-control__swatch"
-            :style="{backgroundColor: previewColor(draft.popup.backgroundColor, '#FFF59D')}"
+            :style="{backgroundColor: resolveCssColor(draft.popup.backgroundColor, '#FFF59D')}"
             aria-hidden="true"
           />
           <input
@@ -107,6 +98,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
             type="text"
             autocomplete="off"
             spellcheck="false"
+            :disabled="controlsDisabled"
             data-testid="settings-popup-background-color"
           >
         </div>
@@ -122,7 +114,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         <div class="settings-color-control">
           <span
             class="settings-color-control__swatch"
-            :style="{backgroundColor: previewColor(draft.popup.fontColor, '#000000')}"
+            :style="{backgroundColor: resolveCssColor(draft.popup.fontColor, '#000000')}"
             aria-hidden="true"
           />
           <input
@@ -131,6 +123,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
             type="text"
             autocomplete="off"
             spellcheck="false"
+            :disabled="controlsDisabled"
             data-testid="settings-popup-font-color"
           >
         </div>
@@ -150,6 +143,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
             type="number"
             min="1"
             step="1"
+            :disabled="controlsDisabled"
             data-testid="settings-popup-font-size"
           >
           <span>pt</span>
@@ -181,6 +175,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
           id="settings-double-click-enabled"
           v-model="draft.dictionary.doubleClick.enabled"
           type="checkbox"
+          :disabled="controlsDisabled"
           data-testid="settings-double-click-enabled"
         >
         <span class="settings-switch__track" aria-hidden="true">
@@ -201,6 +196,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         <select
           id="settings-double-click-trigger"
           v-model="draft.dictionary.doubleClick.triggerKey"
+          :disabled="controlsDisabled"
           data-testid="settings-double-click-trigger"
         >
           <option value="none">{{ text('DCLICK') }}</option>
@@ -220,6 +216,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         <select
           id="settings-double-click-speed"
           v-model.number="draft.dictionary.doubleClick.speedMs"
+          :disabled="controlsDisabled"
           data-testid="settings-double-click-speed"
         >
           <option :value="200">{{ text('DCLICK_SPEED_FASTEST') }} · 200ms</option>
@@ -245,6 +242,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
           id="settings-drag-enabled"
           v-model="draft.dictionary.drag.enabled"
           type="checkbox"
+          :disabled="controlsDisabled"
           data-testid="settings-drag-enabled"
         >
         <span class="settings-switch__track" aria-hidden="true">
@@ -265,6 +263,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         <select
           id="settings-drag-trigger"
           v-model="draft.dictionary.drag.triggerKey"
+          :disabled="controlsDisabled"
           data-testid="settings-drag-trigger"
         >
           <option value="none">{{ text('DRAG') }}</option>
@@ -290,6 +289,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
           id="settings-blocked-sites-enabled"
           v-model="draft.sites.denyListEnabled"
           type="checkbox"
+          :disabled="controlsDisabled"
           data-testid="settings-blocked-sites-enabled"
         >
         <span class="settings-switch__track" aria-hidden="true">
@@ -312,6 +312,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
           :value="siteInput"
           rows="5"
           :placeholder="text('SETTINGS_BLOCKED_SITES_PLACEHOLDER')"
+          :disabled="controlsDisabled"
           data-testid="settings-blocked-sites-input"
           @input="updateSiteInput"
         />

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -1,0 +1,697 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { getText } from '/src/text.js'
+import { getTriggerLabels } from '/src/content-interaction.mjs'
+import {
+  formatDenyList,
+  parseDenyListInput
+} from '/src/settings-sites.mjs'
+
+const props = defineProps({
+  activePage: {
+    type: Object,
+    required: true
+  },
+  draft: {
+    type: Object,
+    required: true
+  },
+  draftRevision: {
+    type: Number,
+    default: 0
+  },
+  isLoading: {
+    type: Boolean,
+    default: false
+  },
+  isSaving: {
+    type: Boolean,
+    default: false
+  },
+  resetDraft: {
+    type: Function,
+    default: null
+  }
+})
+
+const {ctrl, alt} = getTriggerLabels()
+const siteInput = ref('')
+const invalidSiteEntries = ref([])
+
+const pageId = computed(() => props.activePage?.id || '')
+const siteDomains = computed(() => props.draft.sites?.denyList || [])
+
+function text(key, placeholders = undefined) {
+  return getText(key, placeholders)
+}
+
+function previewColor(value, fallback) {
+  const candidate = String(value ?? '').trim()
+  if (/^#[\da-f]{3,8}$/i.test(candidate) ||
+      /^(?:rgb|hsl)a?\([^)]*\)$/i.test(candidate) ||
+      /^[a-z]+$/i.test(candidate)) {
+    return candidate
+  }
+
+  return fallback
+}
+
+function syncSiteInput() {
+  siteInput.value = formatDenyList(siteDomains.value)
+  invalidSiteEntries.value = []
+}
+
+function updateSiteInput(event) {
+  const value = event.target.value
+  const parsed = parseDenyListInput(value)
+  siteInput.value = value
+  invalidSiteEntries.value = parsed.invalidEntries
+  props.draft.sites.denyList = parsed.domains
+}
+
+watch(() => props.draftRevision, syncSiteInput, {immediate: true})
+</script>
+
+<template>
+  <div
+    class="settings-page"
+    :data-page-id="pageId"
+    :data-testid="`settings-page-${pageId}`"
+  >
+    <section
+      v-if="pageId === 'appearance'"
+      class="settings-card"
+      data-testid="settings-appearance-form"
+    >
+      <div class="settings-card__heading">
+        <h3>{{ text('SETTINGS_SECTION_POPUP_APPEARANCE') }}</h3>
+        <p>{{ text('SETTINGS_SECTION_POPUP_APPEARANCE_DESCRIPTION') }}</p>
+      </div>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-popup-background-color">
+            {{ text('SETTINGS_FIELD_BACKGROUND_COLOR') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_BACKGROUND_COLOR_HINT') }}</span>
+        </div>
+        <div class="settings-color-control">
+          <span
+            class="settings-color-control__swatch"
+            :style="{backgroundColor: previewColor(draft.popup.backgroundColor, '#FFF59D')}"
+            aria-hidden="true"
+          />
+          <input
+            id="settings-popup-background-color"
+            v-model="draft.popup.backgroundColor"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            data-testid="settings-popup-background-color"
+          >
+        </div>
+      </div>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-popup-font-color">
+            {{ text('SETTINGS_FIELD_FONT_COLOR') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_FONT_COLOR_HINT') }}</span>
+        </div>
+        <div class="settings-color-control">
+          <span
+            class="settings-color-control__swatch"
+            :style="{backgroundColor: previewColor(draft.popup.fontColor, '#000000')}"
+            aria-hidden="true"
+          />
+          <input
+            id="settings-popup-font-color"
+            v-model="draft.popup.fontColor"
+            type="text"
+            autocomplete="off"
+            spellcheck="false"
+            data-testid="settings-popup-font-color"
+          >
+        </div>
+      </div>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-popup-font-size">
+            {{ text('SETTINGS_FIELD_FONT_SIZE') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_FONT_SIZE_HINT') }}</span>
+        </div>
+        <div class="settings-number-control">
+          <input
+            id="settings-popup-font-size"
+            v-model.number="draft.popup.fontSizePt"
+            type="number"
+            min="1"
+            step="1"
+            data-testid="settings-popup-font-size"
+          >
+          <span>pt</span>
+        </div>
+      </div>
+
+      <a
+        class="settings-inline-link"
+        href="https://neverworkalone.github.io/naverdic/themes.html"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {{ text('SETTINGS_POPUP_THEME_GUIDE') }}
+      </a>
+    </section>
+
+    <section
+      v-else-if="pageId === 'double-click'"
+      class="settings-card"
+      data-testid="settings-double-click-form"
+    >
+      <div class="settings-card__heading">
+        <h3>{{ text('SETTINGS_SECTION_DOUBLE_CLICK') }}</h3>
+        <p>{{ text('SETTINGS_SECTION_DOUBLE_CLICK_DESCRIPTION') }}</p>
+      </div>
+
+      <label class="settings-switch" for="settings-double-click-enabled">
+        <input
+          id="settings-double-click-enabled"
+          v-model="draft.dictionary.doubleClick.enabled"
+          type="checkbox"
+          data-testid="settings-double-click-enabled"
+        >
+        <span class="settings-switch__track" aria-hidden="true">
+          <span class="settings-switch__thumb" />
+        </span>
+        <span class="settings-switch__label">
+          {{ text('SETTINGS_FIELD_DOUBLE_CLICK_ENABLED') }}
+        </span>
+      </label>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-double-click-trigger">
+            {{ text('SETTINGS_FIELD_TRIGGER_KEY') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_DOUBLE_CLICK_TRIGGER_HINT') }}</span>
+        </div>
+        <select
+          id="settings-double-click-trigger"
+          v-model="draft.dictionary.doubleClick.triggerKey"
+          data-testid="settings-double-click-trigger"
+        >
+          <option value="none">{{ text('DCLICK') }}</option>
+          <option value="ctrl">{{ text('CTRL_DCLICK', [ctrl]) }}</option>
+          <option value="alt">{{ text('ALT_DCLICK', [alt]) }}</option>
+          <option value="ctrlalt">{{ text('CTRL_ALT_DCLICK', [ctrl, alt]) }}</option>
+        </select>
+      </div>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-double-click-speed">
+            {{ text('SETTINGS_FIELD_DOUBLE_CLICK_SPEED') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_DOUBLE_CLICK_SPEED_HINT') }}</span>
+        </div>
+        <select
+          id="settings-double-click-speed"
+          v-model.number="draft.dictionary.doubleClick.speedMs"
+          data-testid="settings-double-click-speed"
+        >
+          <option :value="200">{{ text('DCLICK_SPEED_FASTEST') }} · 200ms</option>
+          <option :value="300">{{ text('DCLICK_SPEED_FAST') }} · 300ms</option>
+          <option :value="400">{{ text('DCLICK_SPEED_SLOW') }} · 400ms</option>
+          <option :value="500">{{ text('DCLICK_SPEED_SLOWEST') }} · 500ms</option>
+        </select>
+      </div>
+    </section>
+
+    <section
+      v-else-if="pageId === 'behavior'"
+      class="settings-card"
+      data-testid="settings-behavior-form"
+    >
+      <div class="settings-card__heading">
+        <h3>{{ text('SETTINGS_SECTION_DRAG') }}</h3>
+        <p>{{ text('SETTINGS_SECTION_DRAG_DESCRIPTION') }}</p>
+      </div>
+
+      <label class="settings-switch" for="settings-drag-enabled">
+        <input
+          id="settings-drag-enabled"
+          v-model="draft.dictionary.drag.enabled"
+          type="checkbox"
+          data-testid="settings-drag-enabled"
+        >
+        <span class="settings-switch__track" aria-hidden="true">
+          <span class="settings-switch__thumb" />
+        </span>
+        <span class="settings-switch__label">
+          {{ text('SETTINGS_FIELD_DRAG_ENABLED') }}
+        </span>
+      </label>
+
+      <div class="settings-field-row">
+        <div class="settings-field-row__label">
+          <label for="settings-drag-trigger">
+            {{ text('SETTINGS_FIELD_TRIGGER_KEY') }}
+          </label>
+          <span>{{ text('SETTINGS_FIELD_DRAG_TRIGGER_HINT') }}</span>
+        </div>
+        <select
+          id="settings-drag-trigger"
+          v-model="draft.dictionary.drag.triggerKey"
+          data-testid="settings-drag-trigger"
+        >
+          <option value="none">{{ text('DRAG') }}</option>
+          <option value="ctrl">{{ text('CTRL_DRAG', [ctrl]) }}</option>
+          <option value="alt">{{ text('ALT_DRAG', [alt]) }}</option>
+          <option value="ctrlalt">{{ text('CTRL_ALT_DRAG', [ctrl, alt]) }}</option>
+        </select>
+      </div>
+    </section>
+
+    <section
+      v-else-if="pageId === 'blocked-sites'"
+      class="settings-card"
+      data-testid="settings-blocked-sites-form"
+    >
+      <div class="settings-card__heading">
+        <h3>{{ text('SETTINGS_SECTION_BLOCKED_SITES') }}</h3>
+        <p>{{ text('SETTINGS_SECTION_BLOCKED_SITES_DESCRIPTION') }}</p>
+      </div>
+
+      <label class="settings-switch" for="settings-blocked-sites-enabled">
+        <input
+          id="settings-blocked-sites-enabled"
+          v-model="draft.sites.denyListEnabled"
+          type="checkbox"
+          data-testid="settings-blocked-sites-enabled"
+        >
+        <span class="settings-switch__track" aria-hidden="true">
+          <span class="settings-switch__thumb" />
+        </span>
+        <span class="settings-switch__label">
+          {{ text('SETTINGS_FIELD_BLOCKED_SITES_ENABLED') }}
+        </span>
+      </label>
+
+      <div class="settings-textarea-field">
+        <label for="settings-blocked-sites-input">
+          {{ text('SETTINGS_FIELD_BLOCKED_SITES') }}
+        </label>
+        <span class="settings-textarea-field__hint">
+          {{ text('SETTINGS_BLOCKED_SITES_HINT') }}
+        </span>
+        <textarea
+          id="settings-blocked-sites-input"
+          :value="siteInput"
+          rows="5"
+          :placeholder="text('SETTINGS_BLOCKED_SITES_PLACEHOLDER')"
+          data-testid="settings-blocked-sites-input"
+          @input="updateSiteInput"
+        />
+        <p
+          v-if="invalidSiteEntries.length"
+          class="settings-field-error"
+          role="alert"
+          data-testid="settings-blocked-sites-error"
+        >
+          {{ text('SETTINGS_BLOCKED_SITES_INVALID', [invalidSiteEntries.length]) }}
+        </p>
+      </div>
+
+      <div class="settings-normalized-sites">
+        <div class="settings-normalized-sites__heading">
+          {{ text('SETTINGS_BLOCKED_SITES_NORMALIZED') }}
+        </div>
+        <div
+          v-if="siteDomains.length"
+          class="settings-domain-list"
+          data-testid="settings-blocked-sites-normalized"
+        >
+          <span
+            v-for="domain in siteDomains"
+            :key="domain"
+            class="settings-domain-chip"
+          >
+            {{ domain }}
+          </span>
+        </div>
+        <p v-else class="settings-normalized-sites__empty">
+          {{ text('SETTINGS_BLOCKED_SITES_EMPTY') }}
+        </p>
+      </div>
+    </section>
+
+    <section v-else class="settings-card settings-card--placeholder">
+      <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>
+      <p>{{ text('SETTINGS_SHELL_PLACEHOLDER_DESCRIPTION') }}</p>
+      <div class="settings-placeholder-card__note">
+        {{ text('SETTINGS_SHELL_DRAFT_NOTE') }}
+      </div>
+      <div
+        v-if="pageId === 'advanced' && resetDraft"
+        class="settings-placeholder-card__actions"
+      >
+        <button
+          type="button"
+          class="settings-placeholder-card__reset"
+          data-testid="settings-reset-button"
+          :disabled="isLoading || isSaving"
+          @click="resetDraft"
+        >
+          {{ text('RESET') }}
+        </button>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.settings-page {
+  min-width: 0;
+  margin-top: 12px;
+}
+
+.settings-card {
+  padding: 24px;
+  background: var(--naverdic-settings-surface);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: var(--naverdic-radius-md);
+  box-shadow: var(--naverdic-card-shadow-default);
+}
+
+.settings-card__heading {
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--naverdic-settings-divider);
+}
+
+.settings-card__heading h3,
+.settings-card--placeholder h3 {
+  margin: 0;
+  color: var(--naverdic-settings-text);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 24px;
+}
+
+.settings-card__heading p,
+.settings-card--placeholder p {
+  margin: 4px 0 0;
+  color: var(--naverdic-settings-text-muted);
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.settings-field-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  min-height: 68px;
+  border-bottom: 1px solid var(--naverdic-settings-divider);
+}
+
+.settings-field-row__label,
+.settings-textarea-field {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 4px;
+}
+
+.settings-field-row__label label,
+.settings-textarea-field label {
+  color: var(--naverdic-settings-text);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.settings-field-row__label span,
+.settings-textarea-field__hint {
+  color: var(--naverdic-settings-text-muted);
+  font-size: 11px;
+  line-height: 17px;
+}
+
+.settings-color-control,
+.settings-number-control {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.settings-color-control__swatch {
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 2px var(--naverdic-settings-surface);
+}
+
+.settings-color-control input,
+.settings-number-control input,
+.settings-field-row select,
+.settings-textarea-field textarea {
+  color: var(--naverdic-settings-text);
+  background: var(--naverdic-input-background-default);
+  border: 1px solid var(--naverdic-input-border-default);
+  border-radius: var(--naverdic-radius-sm);
+  font: inherit;
+}
+
+.settings-color-control input {
+  width: 112px;
+  min-height: 36px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.settings-number-control input {
+  width: 76px;
+  min-height: 36px;
+  padding: 0 10px;
+  font-size: 12px;
+}
+
+.settings-number-control span {
+  color: var(--naverdic-settings-text-muted);
+  font-size: 12px;
+}
+
+.settings-field-row select {
+  min-width: 172px;
+  min-height: 36px;
+  padding: 0 28px 0 10px;
+  font-size: 12px;
+}
+
+.settings-color-control input:hover,
+.settings-number-control input:hover,
+.settings-field-row select:hover,
+.settings-textarea-field textarea:hover {
+  border-color: var(--naverdic-input-border-hover);
+}
+
+.settings-color-control input:focus-visible,
+.settings-number-control input:focus-visible,
+.settings-field-row select:focus-visible,
+.settings-textarea-field textarea:focus-visible,
+.settings-switch input:focus-visible + .settings-switch__track {
+  outline: 2px solid var(--naverdic-color-focus);
+  outline-offset: 2px;
+  box-shadow: var(--naverdic-input-focus-ring);
+}
+
+.settings-inline-link {
+  display: inline-block;
+  margin-top: 18px;
+  color: var(--naverdic-settings-primary-text);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.settings-inline-link:hover {
+  text-decoration: underline;
+}
+
+.settings-switch {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 64px;
+  color: var(--naverdic-settings-text);
+  cursor: pointer;
+}
+
+.settings-switch input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+
+.settings-switch__track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 36px;
+  height: 20px;
+  padding: 2px;
+  background: var(--naverdic-settings-text-subtle);
+  border-radius: 999px;
+  transition: background 120ms ease;
+}
+
+.settings-switch__thumb {
+  width: 16px;
+  height: 16px;
+  background: var(--naverdic-settings-surface);
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.2);
+  transition: transform 120ms ease;
+}
+
+.settings-switch input:checked + .settings-switch__track {
+  background: var(--naverdic-settings-primary);
+}
+
+.settings-switch input:checked + .settings-switch__track .settings-switch__thumb {
+  transform: translateX(16px);
+}
+
+.settings-switch__label {
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.settings-textarea-field {
+  padding-top: 20px;
+}
+
+.settings-textarea-field textarea {
+  width: 100%;
+  min-height: 116px;
+  margin-top: 6px;
+  padding: 10px 12px;
+  resize: vertical;
+  font-size: 12px;
+  line-height: 20px;
+}
+
+.settings-field-error {
+  margin: 4px 0 0;
+  color: var(--naverdic-color-danger);
+  font-size: 11px;
+  line-height: 17px;
+}
+
+.settings-normalized-sites {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--naverdic-settings-divider);
+}
+
+.settings-normalized-sites__heading {
+  color: var(--naverdic-settings-text);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.settings-domain-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.settings-domain-chip {
+  padding: 5px 9px;
+  color: var(--naverdic-settings-primary-text);
+  background: var(--naverdic-settings-nav-active);
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.settings-normalized-sites__empty {
+  margin: 8px 0 0;
+  color: var(--naverdic-settings-text-subtle);
+  font-size: 11px;
+  line-height: 17px;
+}
+
+.settings-card--placeholder {
+  min-height: 220px;
+}
+
+.settings-placeholder-card__note {
+  margin-top: 24px;
+  padding: 12px 14px;
+  color: var(--naverdic-settings-primary-text);
+  background: var(--naverdic-settings-info);
+  border-radius: var(--naverdic-radius-sm);
+  font-size: 11px;
+  line-height: 18px;
+}
+
+.settings-placeholder-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 20px;
+}
+
+.settings-placeholder-card__reset {
+  min-height: 34px;
+  padding: 0 16px;
+  color: var(--naverdic-color-danger);
+  background: var(--naverdic-settings-surface);
+  border: 1px solid var(--naverdic-color-danger);
+  border-radius: var(--naverdic-radius-sm);
+  font-size: var(--naverdic-font-size-sm);
+  font-weight: var(--naverdic-font-weight-medium);
+  cursor: pointer;
+}
+
+.settings-placeholder-card__reset:hover {
+  background: var(--naverdic-settings-danger-hover);
+}
+
+.settings-placeholder-card__reset:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+@media (max-width: 600px) {
+  .settings-card {
+    padding: 18px;
+  }
+
+  .settings-field-row {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 0;
+  }
+
+  .settings-color-control,
+  .settings-number-control,
+  .settings-field-row select {
+    align-self: stretch;
+  }
+
+  .settings-field-row select {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/SettingsPreview.vue
+++ b/src/components/SettingsPreview.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { getText } from '/src/text.js'
+import { resolveCssColor } from '/src/settings-colors.mjs'
 
 const props = defineProps({
   activePage: {
@@ -17,20 +18,9 @@ function text(key, placeholders = undefined) {
   return getText(key, placeholders)
 }
 
-function previewColor(value, fallback) {
-  const candidate = String(value ?? '').trim()
-  if (/^#[\da-f]{3,8}$/i.test(candidate) ||
-      /^(?:rgb|hsl)a?\([^)]*\)$/i.test(candidate) ||
-      /^[a-z]+$/i.test(candidate)) {
-    return candidate
-  }
-
-  return fallback
-}
-
 const popupStyle = computed(() => ({
-  backgroundColor: previewColor(props.draft.popup?.backgroundColor, '#FFF59D'),
-  color: previewColor(props.draft.popup?.fontColor, '#000000'),
+  backgroundColor: resolveCssColor(props.draft.popup?.backgroundColor, '#FFF59D'),
+  color: resolveCssColor(props.draft.popup?.fontColor, '#000000'),
   fontSize: `${Number(props.draft.popup?.fontSizePt) > 0 ? Number(props.draft.popup.fontSizePt) : 11}pt`
 }))
 </script>

--- a/src/components/SettingsPreview.vue
+++ b/src/components/SettingsPreview.vue
@@ -1,0 +1,143 @@
+<script setup>
+import { computed } from 'vue'
+import { getText } from '/src/text.js'
+
+const props = defineProps({
+  activePage: {
+    type: Object,
+    required: true
+  },
+  draft: {
+    type: Object,
+    required: true
+  }
+})
+
+function text(key, placeholders = undefined) {
+  return getText(key, placeholders)
+}
+
+function previewColor(value, fallback) {
+  const candidate = String(value ?? '').trim()
+  if (/^#[\da-f]{3,8}$/i.test(candidate) ||
+      /^(?:rgb|hsl)a?\([^)]*\)$/i.test(candidate) ||
+      /^[a-z]+$/i.test(candidate)) {
+    return candidate
+  }
+
+  return fallback
+}
+
+const popupStyle = computed(() => ({
+  backgroundColor: previewColor(props.draft.popup?.backgroundColor, '#FFF59D'),
+  color: previewColor(props.draft.popup?.fontColor, '#000000'),
+  fontSize: `${Number(props.draft.popup?.fontSizePt) > 0 ? Number(props.draft.popup.fontSizePt) : 11}pt`
+}))
+</script>
+
+<template>
+  <div
+    class="settings-live-preview"
+    :data-preview-page="activePage.id"
+    data-testid="settings-live-preview"
+  >
+    <div class="settings-live-preview__browser-bar">
+      <span class="settings-live-preview__dot" />
+      <span class="settings-live-preview__dot" />
+      <span class="settings-live-preview__dot" />
+    </div>
+    <div class="settings-live-preview__content">
+      <div class="settings-live-preview__line settings-live-preview__line--long" />
+      <div class="settings-live-preview__line settings-live-preview__line--medium" />
+      <div class="settings-live-preview__line settings-live-preview__line--short" />
+      <article class="settings-live-preview__popup" :style="popupStyle">
+        <strong>{{ text('SETTINGS_PREVIEW_WORD') }}</strong>
+        <span>{{ text('SETTINGS_PREVIEW_MEANING') }}</span>
+        <small>{{ text('SETTINGS_PREVIEW_HINT') }}</small>
+      </article>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.settings-live-preview {
+  min-height: 360px;
+  overflow: hidden;
+  background: var(--naverdic-settings-preview-surface);
+  border: 1px solid var(--naverdic-settings-border);
+  border-radius: var(--naverdic-radius-md);
+  box-shadow: var(--naverdic-card-shadow-default);
+}
+
+.settings-live-preview__browser-bar {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  height: 32px;
+  padding: 0 12px;
+  background: var(--naverdic-settings-preview-bar);
+  border-bottom: 1px solid var(--naverdic-settings-border);
+}
+
+.settings-live-preview__dot {
+  width: 7px;
+  height: 7px;
+  background: var(--naverdic-settings-text-subtle);
+  border-radius: 50%;
+}
+
+.settings-live-preview__content {
+  position: relative;
+  min-height: 328px;
+  padding: 36px 18px 20px;
+  background: var(--naverdic-settings-preview-window);
+}
+
+.settings-live-preview__line {
+  height: 8px;
+  margin-bottom: 12px;
+  background: var(--naverdic-settings-divider);
+  border-radius: 4px;
+}
+
+.settings-live-preview__line--long {
+  width: 76%;
+}
+
+.settings-live-preview__line--medium {
+  width: 91%;
+}
+
+.settings-live-preview__line--short {
+  width: 53%;
+}
+
+.settings-live-preview__popup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: min(100%, 220px);
+  margin: 26px auto 0;
+  padding: 16px;
+  border: 1px solid rgba(26, 36, 51, 0.16);
+  border-radius: var(--naverdic-radius-sm);
+  box-shadow: var(--naverdic-shadow-popup);
+}
+
+.settings-live-preview__popup strong {
+  font-size: 1.15em;
+  line-height: 1.3;
+}
+
+.settings-live-preview__popup span {
+  font-size: 0.92em;
+  line-height: 1.4;
+}
+
+.settings-live-preview__popup small {
+  color: currentColor;
+  opacity: 0.62;
+  font-size: 0.78em;
+  line-height: 1.4;
+}
+</style>

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { getText } from '/src/text.js'
+import SettingsPreview from '/src/components/SettingsPreview.vue'
 import {
   createDefaultSecretsV2,
   createDefaultSettingsV2,
@@ -27,6 +28,7 @@ const navButtonRefs = ref([])
 const isLoading = ref(true)
 const isSaving = ref(false)
 const migrationPending = ref(false)
+const draftRevision = ref(0)
 const hasLoadError = ref(false)
 const saveState = ref('idle')
 
@@ -102,6 +104,7 @@ function resetDraft() {
 
   replaceReactive(draftSettings, defaultSettings)
   replaceReactive(draftSecrets, defaultSecrets)
+  draftRevision.value += 1
   saveState.value = 'reset'
 }
 
@@ -116,6 +119,7 @@ async function initializeSettings() {
     replaceReactive(persistedSecrets, loaded.secrets)
     replaceReactive(draftSettings, loaded.settings)
     replaceReactive(draftSecrets, loaded.secrets)
+    draftRevision.value += 1
     migrationPending.value = loaded.migrationNeeded
 
     if (loaded.migrationNeeded) {
@@ -150,6 +154,7 @@ async function saveDraft() {
     replaceReactive(persistedSecrets, saved.secrets)
     replaceReactive(draftSettings, saved.settings)
     replaceReactive(draftSecrets, saved.secrets)
+    draftRevision.value += 1
     migrationPending.value = false
     hasLoadError.value = false
     saveState.value = 'success'
@@ -219,6 +224,7 @@ defineExpose({
   currentNavigation,
   draftSettings,
   draftSecrets,
+  draftRevision,
   hasPendingChanges,
   initializeSettings,
   isLoading,
@@ -345,6 +351,10 @@ onBeforeUnmount(() => {
             :active-page="currentNavigation"
             :draft="draftSettings"
             :draft-secrets="draftSecrets"
+            :draft-revision="draftRevision"
+            :is-loading="isLoading"
+            :is-saving="isSaving"
+            :reset-draft="resetDraft"
           >
             <div class="settings-placeholder-card" data-testid="settings-page-placeholder">
               <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>
@@ -378,15 +388,10 @@ onBeforeUnmount(() => {
             <h2>{{ text('SETTINGS_SHELL_PREVIEW_TITLE') }}</h2>
             <p>{{ text('SETTINGS_SHELL_PREVIEW_DESCRIPTION') }}</p>
           </div>
-          <div class="settings-preview-card" aria-hidden="true">
-            <div class="settings-preview-card__window">
-              <div class="settings-preview-card__bar" />
-              <div class="settings-preview-card__line settings-preview-card__line--long" />
-              <div class="settings-preview-card__line settings-preview-card__line--medium" />
-              <div class="settings-preview-card__line settings-preview-card__line--short" />
-              <div class="settings-preview-card__surface" />
-            </div>
-          </div>
+          <SettingsPreview
+            :active-page="currentNavigation"
+            :draft="draftSettings"
+          />
         </aside>
       </section>
     </div>
@@ -678,64 +683,6 @@ a {
 
 .settings-placeholder-card__reset:not(:disabled):hover {
   background: var(--naverdic-settings-danger-hover);
-}
-
-.settings-preview-card {
-  min-height: 360px;
-  margin-top: 12px;
-  padding: 22px 15px;
-  overflow: hidden;
-  background: var(--naverdic-settings-preview-surface);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: 10px;
-}
-
-.settings-preview-card__window {
-  position: relative;
-  min-height: 300px;
-  padding: 48px 14px 20px;
-  overflow: hidden;
-  background: var(--naverdic-settings-preview-window);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: 10px;
-}
-
-.settings-preview-card__bar {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 34px;
-  background: var(--naverdic-settings-preview-bar);
-  border-bottom: 1px solid var(--naverdic-settings-border);
-}
-
-.settings-preview-card__line {
-  height: 8px;
-  margin-bottom: 12px;
-  background: var(--naverdic-settings-divider);
-  border-radius: 4px;
-}
-
-.settings-preview-card__line--long {
-  width: 82%;
-}
-
-.settings-preview-card__line--medium {
-  width: 94%;
-}
-
-.settings-preview-card__line--short {
-  width: 56%;
-}
-
-.settings-preview-card__surface {
-  width: 92%;
-  height: 128px;
-  margin: 22px auto 0;
-  background: var(--naverdic-settings-info);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: 6px;
 }
 
 @media (max-width: 1050px) {

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -1,7 +1,19 @@
 <script setup>
 import SettingsShell from '/src/components/SettingsShell.vue'
+import SettingsPage from '/src/components/SettingsPage.vue'
 </script>
 
 <template>
-  <SettingsShell />
+  <SettingsShell>
+    <template #page="{ activePage, draft, draftRevision, isLoading, isSaving, resetDraft }">
+      <SettingsPage
+        :active-page="activePage"
+        :draft="draft"
+        :draft-revision="draftRevision"
+        :is-loading="isLoading"
+        :is-saving="isSaving"
+        :reset-draft="resetDraft"
+      />
+    </template>
+  </SettingsShell>
 </template>

--- a/src/settings-colors.mjs
+++ b/src/settings-colors.mjs
@@ -1,0 +1,25 @@
+function supportsCssColor(value) {
+  const css = globalThis.CSS
+  if (css && typeof css.supports === 'function') {
+    return css.supports('color', value)
+  }
+
+  if (typeof document === 'undefined' || typeof document.createElement !== 'function') {
+    return false
+  }
+
+  const element = document.createElement('span')
+  element.style.color = ''
+  element.style.color = value
+  return element.style.color !== ''
+}
+
+export function resolveCssColor(value, fallback) {
+  const candidate = String(value ?? '').trim()
+
+  try {
+    return candidate && supportsCssColor(candidate) ? candidate : fallback
+  } catch (_error) {
+    return fallback
+  }
+}

--- a/src/settings-sites.mjs
+++ b/src/settings-sites.mjs
@@ -1,0 +1,88 @@
+function isValidIpv4(value) {
+  const parts = value.split('.')
+  return parts.length === 4 && parts.every(part => {
+    if (!/^\d{1,3}$/.test(part)) {
+      return false
+    }
+
+    const number = Number(part)
+    return number >= 0 && number <= 255
+  })
+}
+
+function isValidHostname(value) {
+  if (value === 'localhost' || isValidIpv4(value)) {
+    return true
+  }
+
+  const labels = value.split('.')
+  if (labels.length < 2) {
+    return false
+  }
+
+  return labels.every(label => (
+    label.length > 0 &&
+    label.length <= 63 &&
+    /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/i.test(label)
+  ))
+}
+
+function normalizeSiteToken(value) {
+  let candidate = String(value ?? '').trim().toLowerCase()
+  if (!candidate) {
+    return ''
+  }
+
+  candidate = candidate.replace(/^\*\./, '')
+  const urlValue = /^[a-z][a-z\d+.-]*:\/\//i.test(candidate)
+    ? candidate
+    : `http://${candidate}`
+
+  try {
+    const url = new URL(urlValue)
+    if (url.username || url.password || !isValidHostname(url.hostname)) {
+      return ''
+    }
+
+    return url.hostname.toLowerCase().replace(/^\.+|\.+$/g, '')
+  } catch (_error) {
+    return ''
+  }
+}
+
+export function parseDenyListInput(value) {
+  const entries = Array.isArray(value)
+    ? value
+    : String(value ?? '').split(/[,;\r\n]+/)
+  const domains = []
+  const invalidEntries = []
+  const seenDomains = new Set()
+  const seenInvalidEntries = new Set()
+
+  entries.forEach(entry => {
+    const raw = String(entry ?? '').trim()
+    if (!raw) {
+      return
+    }
+
+    const domain = normalizeSiteToken(raw)
+    if (!domain) {
+      if (!seenInvalidEntries.has(raw)) {
+        seenInvalidEntries.add(raw)
+        invalidEntries.push(raw)
+      }
+      return
+    }
+
+    if (!seenDomains.has(domain)) {
+      seenDomains.add(domain)
+      domains.push(domain)
+    }
+  })
+
+  return {domains, invalidEntries}
+}
+
+export function formatDenyList(value) {
+  return parseDenyListInput(value).domains.join('\n')
+}

--- a/src/text.js
+++ b/src/text.js
@@ -12,7 +12,7 @@ function fallbackText(textId, placeholder) {
 
   let message = entry.message
   Object.entries(entry.placeholders || {}).forEach(([name, definition]) => {
-    const match = /\$(\d+)\$/.exec(definition.content || '')
+    const match = /^\$(\d+)\$?$/.exec(definition.content || '')
     const index = match ? Number(match[1]) - 1 : -1
     const value = Array.isArray(placeholder)
       ? placeholder[index]

--- a/tests/settings-colors.test.mjs
+++ b/tests/settings-colors.test.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {resolveCssColor} from '../src/settings-colors.mjs'
+
+test('uses the browser CSS parser instead of a permissive color regex', () => {
+  const originalCss = globalThis.CSS
+  const supported = new Set(['#123456', 'red'])
+  globalThis.CSS = {
+    supports(_property, value) {
+      return supported.has(value)
+    }
+  }
+
+  try {
+    assert.equal(resolveCssColor('#123456', '#fallback'), '#123456')
+    assert.equal(resolveCssColor('red', '#fallback'), 'red')
+    assert.equal(resolveCssColor('garbage', '#fallback'), '#fallback')
+    assert.equal(resolveCssColor('#12345', '#fallback'), '#fallback')
+    assert.equal(resolveCssColor('rgb(foo)', '#fallback'), '#fallback')
+  } finally {
+    if (originalCss === undefined) {
+      delete globalThis.CSS
+    } else {
+      globalThis.CSS = originalCss
+    }
+  }
+})
+
+test('returns the fallback when no browser color parser is available', () => {
+  const originalCss = globalThis.CSS
+  delete globalThis.CSS
+
+  try {
+    assert.equal(resolveCssColor('#123456', '#fallback'), '#fallback')
+  } finally {
+    if (originalCss !== undefined) {
+      globalThis.CSS = originalCss
+    }
+  }
+})

--- a/tests/settings-sites.test.mjs
+++ b/tests/settings-sites.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  formatDenyList,
+  parseDenyListInput
+} from '../src/settings-sites.mjs'
+
+test('normalizes site input across supported separators and URL forms', () => {
+  const result = parseDenyListInput(
+    ' https://www.Example.com/path, *.example.com; naver.com\nNAVER.com '
+  )
+
+  assert.deepEqual(result.domains, ['www.example.com', 'example.com', 'naver.com'])
+  assert.deepEqual(result.invalidEntries, [])
+  assert.equal(formatDenyList(result.domains), 'www.example.com\nexample.com\nnaver.com')
+})
+
+test('reports invalid entries without dropping valid domains', () => {
+  const result = parseDenyListInput('example.com, not a domain; http://valid.test')
+
+  assert.deepEqual(result.domains, ['example.com', 'valid.test'])
+  assert.deepEqual(result.invalidEntries, ['not a domain'])
+})
+
+test('deduplicates repeated invalid entries and accepts localhost', () => {
+  const result = parseDenyListInput('localhost, bad value, bad value, 127.0.0.1')
+
+  assert.deepEqual(result.domains, ['localhost', '127.0.0.1'])
+  assert.deepEqual(result.invalidEntries, ['bad value'])
+})
+
+test('returns an empty normalized list for empty input', () => {
+  assert.deepEqual(parseDenyListInput(' , ;\n '), {
+    domains: [],
+    invalidEntries: []
+  })
+})


### PR DESCRIPTION
## Summary
- Connect the Stage 2 settings shell to dictionary, popup appearance, behavior, and blocked-site settings.
- Keep all edits in the TASK3 draft and reuse the explicit shared save flow.
- Add live popup preview updates for popup colors and font size.
- Normalize blocked-site input from lines, commas, semicolons, URLs, and wildcard prefixes with invalid-entry feedback.
- Add Korean/English locale strings and fix Chrome-style locale placeholder fallback.

## Verification
- `npm test` — 65 passing
- `npm run build`
- `NAVERDIC_ZIP_DIR=/tmp/naverdic-task4-package npm run package`
- Browser QA: Figma-aligned settings shell, draft retention across menu navigation, live preview, normalized domains, invalid-entry alert, advanced reset action, and no console errors.

Targets `firstlight` as TASK 4.