### PR TITLE
[TASK 5] Add translation provider adapters and permissions

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "messaging.mjs", "settings.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "messaging.mjs", "settings.mjs", "translation-provider.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],
@@ -48,6 +48,12 @@
   "host_permissions" : [
     "https://dict.naver.com/",
     "https://en.dict.naver.com/",
-    "https://api-free.deepl.com/"
+    "https://api-free.deepl.com/",
+    "https://api.deepl.com/",
+    "https://generativelanguage.googleapis.com/"
+  ],
+  "optional_host_permissions": [
+    "http://*/*",
+    "https://*/*"
   ]
 }

--- a/src/background-handler.mjs
+++ b/src/background-handler.mjs
@@ -6,6 +6,12 @@ import {
   createSuccessResponse,
   respondOnce
 } from './messaging.mjs'
+import {
+  executeProviderTranslation,
+  PROVIDER_ERROR_CODES
+} from './translation-engine.mjs'
+import {getProviderPreset, normalizeProviderDefinition} from './translation-provider.mjs'
+import {hasProviderOriginPermission} from './provider-permissions.mjs'
 
 function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
@@ -18,7 +24,8 @@ function isHttpUrl(value) {
 
   try {
     const url = new URL(value)
-    return url.protocol === 'http:' || url.protocol === 'https:'
+    return (url.protocol === 'http:' || url.protocol === 'https:') &&
+      !url.username && !url.password
   } catch (_error) {
     return false
   }
@@ -30,6 +37,10 @@ function hasMessageAction(action) {
 
 function expectedMethod(action) {
   return action === MESSAGE_ACTIONS.DICTIONARY ? 'GET' : 'POST'
+}
+
+function hasProvider(request) {
+  return isRecord(request.provider)
 }
 
 /**
@@ -59,35 +70,39 @@ export function validateMessageRequest(request) {
     )
   }
 
-  if (request.url === undefined || request.url === null || request.url === '') {
+  const providerRequest = request.action === MESSAGE_ACTIONS.TRANSLATION && hasProvider(request)
+  if ((request.url === undefined || request.url === null || request.url === '') &&
+      !providerRequest) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
       'The message URL is required.'
     )
   }
 
-  if (!isHttpUrl(request.url)) {
+  if (request.url !== undefined && request.url !== null && request.url !== '' &&
+      !isHttpUrl(request.url)) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.INVALID_REQUEST,
       'The message URL must be an HTTP or HTTPS URL.'
     )
   }
 
-  if (request.method === undefined || request.method === null || request.method === '') {
+  if ((request.method === undefined || request.method === null || request.method === '') &&
+      !providerRequest) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
       'The message method is required.'
     )
   }
 
-  if (typeof request.method !== 'string') {
+  if (!providerRequest && typeof request.method !== 'string') {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.INVALID_REQUEST,
       'The message method must be a string.'
     )
   }
 
-  if (request.method.toUpperCase() !== expectedMethod(request.action)) {
+  if (!providerRequest && request.method.toUpperCase() !== expectedMethod(request.action)) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.INVALID_REQUEST,
       `The ${request.action} action requires ${expectedMethod(request.action)}.`
@@ -98,21 +113,21 @@ export function validateMessageRequest(request) {
     return null
   }
 
-  if (request.key === undefined || request.key === null || request.key === '') {
+  if (!providerRequest && (request.key === undefined || request.key === null || request.key === '')) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
       'The translation API key is required.'
     )
   }
 
-  if (typeof request.key !== 'string') {
+  if (!providerRequest && typeof request.key !== 'string') {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.INVALID_REQUEST,
       'The translation API key must be a string.'
     )
   }
 
-  if (!request.key.trim()) {
+  if (!providerRequest && !request.key.trim()) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
       'The translation API key is required.'
@@ -147,7 +162,8 @@ export function validateMessageRequest(request) {
     )
   }
 
-  if (typeof request.data.target_lang !== 'string' || !request.data.target_lang.trim()) {
+  const targetLanguage = request.data.targetLanguage ?? request.data.target_lang
+  if (typeof targetLanguage !== 'string' || !targetLanguage.trim()) {
     return createErrorResponse(
       MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
       'The translation target language is required.'
@@ -232,18 +248,6 @@ function responsePayloadError(action, data) {
     )
   }
 
-  if (action === MESSAGE_ACTIONS.TRANSLATION) {
-    const firstTranslation = data.translations?.[0]
-    if (!Array.isArray(data.translations) ||
-        !isRecord(firstTranslation) ||
-        typeof firstTranslation.text !== 'string') {
-      return createErrorResponse(
-        MESSAGE_ERROR_CODES.INVALID_RESPONSE,
-        'The translation response did not include translated text.'
-      )
-    }
-  }
-
   return null
 }
 
@@ -279,17 +283,109 @@ function networkErrorResponse(error) {
 }
 
 function requestOptions(request) {
-  if (request.action === MESSAGE_ACTIONS.DICTIONARY) {
-    return {method: request.method}
+  return {method: request.method}
+}
+
+function providerSecrets(provider, request) {
+  if (isRecord(request.secrets)) {
+    return request.secrets
   }
 
+  const secretField = provider.auth.secretRef?.split('.').pop() || 'apiKey'
   return {
-    method: request.method,
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `DeepL-Auth-Key ${request.key}`
-    },
-    body: JSON.stringify(request.data)
+    providers: {
+      [provider.id]: {
+        [secretField]: typeof request.key === 'string' ? request.key : ''
+      }
+    }
+  }
+}
+
+function providerErrorResponse(error) {
+  const code = error?.code
+  if (code === PROVIDER_ERROR_CODES.AUTH_REQUIRED) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.MISSING_PAYLOAD,
+      'The translation provider credential is required.'
+    )
+  }
+
+  if (code === PROVIDER_ERROR_CODES.PERMISSION_REQUIRED ||
+      code === PROVIDER_ERROR_CODES.INVALID_PROVIDER ||
+      code === PROVIDER_ERROR_CODES.INVALID_ENDPOINT ||
+      code === PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_REQUEST,
+      error.message
+    )
+  }
+
+  if (code === PROVIDER_ERROR_CODES.HTTP_ERROR) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.HTTP_ERROR,
+      'The translation provider request failed.',
+      {status: error.status}
+    )
+  }
+
+  if (code === PROVIDER_ERROR_CODES.INVALID_RESPONSE) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+      error.message
+    )
+  }
+
+  if (code === PROVIDER_ERROR_CODES.TIMEOUT) {
+    return createErrorResponse(
+      MESSAGE_ERROR_CODES.TIMEOUT,
+      'The translation provider request timed out.'
+    )
+  }
+
+  return createErrorResponse(
+    MESSAGE_ERROR_CODES.NETWORK_ERROR,
+    'The translation provider request could not be completed.'
+  )
+}
+
+async function handleProviderTranslation(request, {
+  fetchFn,
+  timeoutMs,
+  permissionApi,
+  allowedOrigins = [],
+  permissionChecker
+} = {}) {
+  const provider = request.provider
+    ? normalizeProviderDefinition(request.provider, {id: request.provider.id})
+    : getProviderPreset('deepl-free')
+
+  if (!provider) {
+    return providerErrorResponse({
+      code: PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      message: 'The translation provider configuration is invalid.'
+    })
+  }
+
+  const targetLanguage = request.data.targetLanguage ?? request.data.target_lang
+  const checker = permissionChecker || (async (_pattern, endpointUrl) => (
+    hasProviderOriginPermission(permissionApi, endpointUrl)
+  ))
+
+  try {
+    const result = await executeProviderTranslation(provider, {
+      text: request.data.text,
+      targetLanguage,
+      secrets: providerSecrets(provider, request),
+      allowedOrigins,
+      permissionChecker: checker,
+      fetchFn,
+      timeoutMs
+    })
+    // Keep the v6.6 response body stable for content.js while the provider
+    // engine exposes the normalized text to newer callers.
+    return createSuccessResponse(result.raw)
+  } catch (error) {
+    return providerErrorResponse(error)
   }
 }
 
@@ -299,11 +395,27 @@ function requestOptions(request) {
  */
 export async function handleBackgroundMessage(
   request,
-  {fetchFn = globalThis.fetch, timeoutMs = DEFAULT_MESSAGE_TIMEOUT_MS} = {}
+  {
+    fetchFn = globalThis.fetch,
+    timeoutMs = DEFAULT_MESSAGE_TIMEOUT_MS,
+    permissionApi = globalThis.chrome?.permissions,
+    allowedOrigins = [],
+    permissionChecker
+  } = {}
 ) {
   const validationError = validateMessageRequest(request)
   if (validationError) {
     return validationError
+  }
+
+  if (request.action === MESSAGE_ACTIONS.TRANSLATION) {
+    return handleProviderTranslation(request, {
+      fetchFn,
+      timeoutMs,
+      permissionApi,
+      allowedOrigins,
+      permissionChecker
+    })
   }
 
   if (typeof fetchFn !== 'function') {

--- a/src/content.js
+++ b/src/content.js
@@ -19,6 +19,7 @@ import {
   normalizeSettings,
   STORAGE_DEFAULTS
 } from './settings.mjs'
+import {getProviderPreset} from './translation-provider.mjs'
 
 export { DEFAULT_OPTIONS, STORAGE_DEFAULTS }
 
@@ -32,6 +33,7 @@ let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE
 
 let activeInteractionController = null
 let storageLifecycle = null
+const DEFAULT_TRANSLATION_PROVIDER = getProviderPreset('deepl-free')
 
 
 function appendTextWithLineBreaks(element, value) {
@@ -167,13 +169,10 @@ async function consultDic(e, word, top, left) {
 }
 
 async function translate(e, text, top, left, key) {
-  const url = 'https://api-free.deepl.com/v2/translate'
-
   const response = await sendRuntimeMessage(
     chrome.runtime,
     createTranslationRequest({
-      method: 'POST',
-      url,
+      provider: DEFAULT_TRANSLATION_PROVIDER,
       key,
       data: {
         text: [text],

--- a/src/messaging.mjs
+++ b/src/messaging.mjs
@@ -23,8 +23,10 @@ export const MESSAGE_ERROR_CODES = Object.freeze({
  * {ok: false, error: {code: string, message: string, ...details}}.
  *
  * endic request:       {action: 'endic', method: 'GET', url: string}
- * translation request: {action: 'translation', method: 'POST', url: string,
- *                        key: string, data: {text: string[], target_lang: string}}
+ * translation request: {action: 'translation', method: 'POST', url?: string,
+ *                        key?: string, provider?: ProviderDefinition,
+ *                        data: {text: string[], target_lang?: string,
+ *                        targetLanguage?: string}}
  */
 export const MESSAGE_CONTRACTS = Object.freeze({
   [MESSAGE_ACTIONS.DICTIONARY]: Object.freeze({
@@ -32,8 +34,8 @@ export const MESSAGE_CONTRACTS = Object.freeze({
     response: 'MessageResponse<NaverDictionaryResponse>'
   }),
   [MESSAGE_ACTIONS.TRANSLATION]: Object.freeze({
-    request: "{ action: 'translation', method: 'POST', url: string, key: string, data: TranslationRequest }",
-    response: 'MessageResponse<DeepLTranslationResponse>'
+    request: "{ action: 'translation', method: 'POST', url?: string, key?: string, provider?: ProviderDefinition, data: TranslationRequest }",
+    response: 'MessageResponse<TranslationResponse>'
   })
 })
 
@@ -59,14 +61,20 @@ export function createDictionaryRequest({url, method = 'GET'} = {}) {
   }
 }
 
-export function createTranslationRequest({url, method = 'POST', key, data} = {}) {
-  return {
+export function createTranslationRequest({url, method = 'POST', key, data, provider} = {}) {
+  const request = {
     action: MESSAGE_ACTIONS.TRANSLATION,
     method,
     url,
     key,
     data
   }
+
+  if (provider !== undefined) {
+    request.provider = provider
+  }
+
+  return request
 }
 
 export function createSuccessResponse(data) {

--- a/src/provider-permissions.mjs
+++ b/src/provider-permissions.mjs
@@ -1,0 +1,115 @@
+const HTTP_PROTOCOLS = new Set(['http:', 'https:'])
+
+function parseHttpUrl(value) {
+  try {
+    const url = new URL(value)
+    if (!HTTP_PROTOCOLS.has(url.protocol) || url.username || url.password) {
+      return null
+    }
+    return url
+  } catch (_error) {
+    return null
+  }
+}
+
+export function getProviderOrigin(value) {
+  const url = parseHttpUrl(value)
+  return url ? url.origin : ''
+}
+
+export function getProviderOriginPattern(value) {
+  const origin = getProviderOrigin(value)
+  return origin ? `${origin}/*` : ''
+}
+
+function patternParts(value) {
+  const match = /^(https?):\/\/([^/:*]+|\*|\*\.[^/:*]+)(?::(\*|\d+))?\/\*$/i.exec(
+    String(value ?? '').trim()
+  )
+
+  if (!match) {
+    return null
+  }
+
+  return {
+    protocol: `${match[1].toLowerCase()}:`,
+    host: match[2].toLowerCase(),
+    port: match[3] || ''
+  }
+}
+
+function hostMatchesPattern(host, pattern) {
+  if (pattern === '*') {
+    return true
+  }
+
+  if (pattern.startsWith('*.')) {
+    const base = pattern.slice(2)
+    return host === base || host.endsWith(`.${base}`)
+  }
+
+  return host === pattern
+}
+
+export function matchesProviderOriginPattern(value, pattern) {
+  const url = parseHttpUrl(value)
+  const parts = patternParts(pattern)
+  if (!url || !parts || url.protocol !== parts.protocol) {
+    return false
+  }
+
+  if (!hostMatchesPattern(url.hostname.toLowerCase(), parts.host)) {
+    return false
+  }
+
+  if (!parts.port || parts.port === '*') {
+    return true
+  }
+
+  return url.port === parts.port
+}
+
+export function isProviderOriginAllowed(value, allowedOrigins = []) {
+  return Array.isArray(allowedOrigins) && allowedOrigins.some(pattern => (
+    matchesProviderOriginPattern(value, pattern)
+  ))
+}
+
+function callPermissionApi(api, method, pattern) {
+  if (typeof api?.[method] !== 'function') {
+    return Promise.resolve(false)
+  }
+
+  return new Promise(resolve => {
+    let settled = false
+    const complete = value => {
+      if (!settled) {
+        settled = true
+        resolve(value === true)
+      }
+    }
+
+    try {
+      const result = api[method]({origins: [pattern]}, complete)
+      if (result && typeof result.then === 'function') {
+        result.then(complete).catch(() => complete(false))
+      }
+    } catch (_error) {
+      complete(false)
+    }
+  })
+}
+
+export function hasProviderOriginPermission(permissionsApi, endpointUrl) {
+  const pattern = getProviderOriginPattern(endpointUrl)
+  return pattern
+    ? callPermissionApi(permissionsApi, 'contains', pattern)
+    : Promise.resolve(false)
+}
+
+export function requestProviderOriginPermission(permissionsApi, endpointUrl) {
+  const pattern = getProviderOriginPattern(endpointUrl)
+  return pattern
+    ? callPermissionApi(permissionsApi, 'request', pattern)
+    : Promise.resolve(false)
+}

--- a/src/translation-engine.mjs
+++ b/src/translation-engine.mjs
@@ -525,13 +525,7 @@ export async function executeProviderTranslation(providerInput, {
     })
     const payload = await fetchProviderResponse(fetchFn, request, timeoutMs)
     const normalized = adapter.normalizeResponse(provider, payload)
-    return {
-      ...normalized,
-      request: {
-        url: request.url,
-        method: request.options.method
-      }
-    }
+    return normalized
   } catch (error) {
     throw normalizeProviderError(error, {secrets})
   }

--- a/src/translation-engine.mjs
+++ b/src/translation-engine.mjs
@@ -1,0 +1,548 @@
+import {
+  CHROME_TRANSLATOR_PROVIDER_ID,
+  PROVIDER_ADAPTERS,
+  PROVIDER_AUTH_MODES,
+  PROVIDER_EXECUTION_CONTEXTS,
+  PROVIDER_KINDS,
+  PROVIDER_SOURCES,
+  getProviderPreset,
+  isProviderDefinition,
+  normalizeProviderDefinition
+} from './translation-provider.mjs'
+import {
+  getProviderOriginPattern,
+  isProviderOriginAllowed
+} from './provider-permissions.mjs'
+
+export const PROVIDER_ERROR_CODES = Object.freeze({
+  INVALID_PROVIDER: 'INVALID_PROVIDER',
+  INVALID_ENDPOINT: 'INVALID_ENDPOINT',
+  PERMISSION_REQUIRED: 'PERMISSION_REQUIRED',
+  AUTH_REQUIRED: 'AUTH_REQUIRED',
+  UNSUPPORTED_CONTEXT: 'UNSUPPORTED_CONTEXT',
+  HTTP_ERROR: 'HTTP_ERROR',
+  INVALID_RESPONSE: 'INVALID_RESPONSE',
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  TIMEOUT: 'TIMEOUT'
+})
+
+const TEMPLATE_PATTERN = /\{\{([a-zA-Z][a-zA-Z0-9_.-]*)\}\}/g
+const PATH_PATTERN = /(?:^|\.)([^.[\]]+)|\[(\d+)\]/g
+const DEFAULT_TIMEOUT_MS = 10000
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function providerError(code, message, details = {}) {
+  const error = new Error(message)
+  error.name = 'ProviderError'
+  error.code = code
+  Object.entries(details).forEach(([key, value]) => {
+    if (value !== undefined) {
+      error[key] = value
+    }
+  })
+  return error
+}
+
+function providerDefinition(value) {
+  const normalized = normalizeProviderDefinition(value, {
+    id: value?.id || ''
+  })
+  return normalized && isProviderDefinition(normalized) ? normalized : null
+}
+
+function pathTokens(path) {
+  const tokens = []
+  String(path ?? '').replace(PATH_PATTERN, (_match, property, index) => {
+    tokens.push(index === undefined ? property : Number(index))
+    return _match
+  })
+  return tokens
+}
+
+export function getPathValue(value, path) {
+  if (!path) {
+    return value
+  }
+
+  return pathTokens(path).reduce((current, token) => current?.[token], value)
+}
+
+function setHeader(headers, name, value) {
+  const existing = Object.keys(headers).find(key => key.toLowerCase() === name.toLowerCase())
+  headers[existing || name] = value
+}
+
+function getSecretValue(secretRef, secrets) {
+  const value = getPathValue(secrets, secretRef)
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function collectSecretValues(value, output = []) {
+  if (Array.isArray(value)) {
+    value.forEach(child => collectSecretValues(child, output))
+    return output
+  }
+
+  if (!isRecord(value)) {
+    return output
+  }
+
+  Object.entries(value).forEach(([key, child]) => {
+    const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, '')
+    if (['apikey', 'token', 'authorization', 'secret', 'password'].includes(normalizedKey) &&
+        typeof child === 'string' && child.trim()) {
+      output.push(child.trim())
+    }
+    collectSecretValues(child, output)
+  })
+  return output
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function redactSecrets(value, secrets = {}, extraSecrets = []) {
+  let result = String(value ?? '')
+  const secretsToRedact = [
+    ...collectSecretValues(secrets),
+    ...(Array.isArray(extraSecrets) ? extraSecrets : [extraSecrets])
+  ]
+    .filter(secret => typeof secret === 'string' && secret.length >= 4)
+    .sort((left, right) => right.length - left.length)
+
+  secretsToRedact.forEach(secret => {
+    result = result.replace(new RegExp(escapeRegExp(secret), 'g'), '[REDACTED]')
+  })
+
+  return result
+}
+
+function templateValue(value, variables) {
+  if (Array.isArray(value)) {
+    return value.map(child => templateValue(child, variables))
+  }
+
+  if (isRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, child]) => [
+      key,
+      templateValue(child, variables)
+    ]))
+  }
+
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  const exact = /^\{\{([a-zA-Z][a-zA-Z0-9_.-]*)\}\}$/.exec(value)
+  if (exact) {
+    return variables[exact[1]] ?? ''
+  }
+
+  return value.replace(TEMPLATE_PATTERN, (_match, name) => {
+    const replacement = variables[name]
+    return replacement === undefined || replacement === null
+      ? ''
+      : String(replacement)
+  })
+}
+
+function normalizeTextInput(value) {
+  const values = Array.isArray(value) ? value : [value]
+  return values
+    .filter(item => typeof item === 'string')
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+function defaultAuthHeader(mode) {
+  if (mode === PROVIDER_AUTH_MODES.API_KEY) {
+    return 'X-API-Key'
+  }
+
+  return 'Authorization'
+}
+
+function resolveProviderSecret(provider, secrets) {
+  if (provider.auth.mode === PROVIDER_AUTH_MODES.NONE) {
+    return ''
+  }
+
+  const secret = getSecretValue(provider.auth.secretRef, secrets)
+  if (!secret) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.AUTH_REQUIRED,
+      'The translation provider credential is required.'
+    )
+  }
+  return secret
+}
+
+export function createProviderRequest(providerInput, {
+  text,
+  targetLanguage,
+  sourceLanguage = '',
+  secrets = {}
+} = {}) {
+  const provider = providerDefinition(providerInput)
+  if (!provider) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The translation provider configuration is invalid.'
+    )
+  }
+
+  if (provider.kind === PROVIDER_KINDS.BUILT_IN) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT,
+      'This translation provider must run in the content page.',
+      {context: PROVIDER_EXECUTION_CONTEXTS.CONTENT_PAGE}
+    )
+  }
+
+  const textValues = normalizeTextInput(text)
+  if (!textValues.length || typeof targetLanguage !== 'string' || !targetLanguage.trim()) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The translation input is incomplete.'
+    )
+  }
+
+  const authSecret = resolveProviderSecret(provider, secrets)
+  const variables = {
+    text: textValues.length === 1 ? textValues[0] : textValues.join('\n'),
+    texts: textValues,
+    targetLanguage: targetLanguage.trim(),
+    sourceLanguage: typeof sourceLanguage === 'string' ? sourceLanguage.trim() : '',
+    secret: authSecret,
+    apiKey: authSecret,
+    token: authSecret
+  }
+  const url = new URL(provider.endpoint.url)
+  const headers = {}
+
+  provider.request.headers.forEach(header => {
+    const headerSecret = getSecretValue(header.secretRef, secrets)
+    if (header.secretRef && !headerSecret) {
+      throw providerError(
+        PROVIDER_ERROR_CODES.AUTH_REQUIRED,
+        'The translation provider credential is required.'
+      )
+    }
+
+    const rendered = templateValue(header.valueTemplate, {
+      ...variables,
+      secret: headerSecret || authSecret,
+      apiKey: headerSecret || authSecret,
+      token: headerSecret || authSecret
+    })
+    if (typeof rendered === 'string' && rendered) {
+      setHeader(headers, header.name, rendered)
+    }
+  })
+
+  if (provider.auth.mode !== PROVIDER_AUTH_MODES.NONE) {
+    const authValue = `${provider.auth.prefix}${authSecret}`
+    if (provider.auth.location === 'query') {
+      url.searchParams.set(provider.auth.headerName || 'key', authValue)
+    } else {
+      setHeader(
+        headers,
+        provider.auth.headerName || defaultAuthHeader(provider.auth.mode),
+        authValue
+      )
+    }
+  }
+
+  const options = {
+    method: provider.endpoint.method,
+    headers
+  }
+  if (provider.endpoint.method !== 'GET' && provider.endpoint.method !== 'HEAD' &&
+      provider.request.bodyTemplate !== null) {
+    options.body = JSON.stringify(templateValue(provider.request.bodyTemplate, variables))
+    if (!Object.keys(headers).some(name => name.toLowerCase() === 'content-type')) {
+      setHeader(headers, 'Content-Type', 'application/json')
+    }
+  }
+
+  return {
+    url: url.toString(),
+    options
+  }
+}
+
+export const buildProviderRequest = createProviderRequest
+
+export function normalizeProviderResponse(providerInput, payload) {
+  const provider = providerDefinition(providerInput)
+  const translatedText = provider
+    ? getPathValue(payload, provider.response.textPath)
+    : null
+
+  if (!provider || typeof translatedText !== 'string' || !translatedText.trim()) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_RESPONSE,
+      'The translation provider response did not include translated text.'
+    )
+  }
+
+  return {
+    providerId: provider.id,
+    text: translatedText,
+    raw: payload
+  }
+}
+
+async function hasPermission(provider, {allowedOrigins = [], permissionChecker} = {}) {
+  if (provider.source === PROVIDER_SOURCES.PRESET) {
+    const preset = getProviderPreset(provider.presetId)
+    if (!preset || preset.endpoint?.url !== provider.endpoint?.url) {
+      throw providerError(
+        PROVIDER_ERROR_CODES.INVALID_ENDPOINT,
+        'The preset translation provider endpoint is invalid.'
+      )
+    }
+    return true
+  }
+
+  const pattern = getProviderOriginPattern(provider.endpoint.url)
+  if (!pattern) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_ENDPOINT,
+      'The translation provider endpoint must use HTTP or HTTPS.'
+    )
+  }
+
+  if (isProviderOriginAllowed(provider.endpoint.url, allowedOrigins)) {
+    return true
+  }
+
+  if (typeof permissionChecker === 'function' &&
+      await permissionChecker(pattern, provider.endpoint.url)) {
+    return true
+  }
+
+  throw providerError(
+    PROVIDER_ERROR_CODES.PERMISSION_REQUIRED,
+    'Permission for the translation provider domain is required.'
+  )
+}
+
+function effectiveTimeout(timeoutMs) {
+  const normalized = Number(timeoutMs)
+  return Number.isFinite(normalized) && normalized > 0 ? normalized : DEFAULT_TIMEOUT_MS
+}
+
+async function fetchProviderResponse(fetchFn, request, timeoutMs) {
+  if (typeof fetchFn !== 'function') {
+    throw providerError(
+      PROVIDER_ERROR_CODES.NETWORK_ERROR,
+      'The translation provider request could not be completed.'
+    )
+  }
+
+  const controller = typeof AbortController === 'function'
+    ? new AbortController()
+    : null
+  const options = {...request.options}
+  if (controller) {
+    options.signal = controller.signal
+  }
+
+  let timeoutId = null
+  let rejectTimeout
+  const timeout = new Promise((_resolve, reject) => {
+    rejectTimeout = reject
+    timeoutId = setTimeout(() => {
+      controller?.abort()
+      rejectTimeout(providerError(
+        PROVIDER_ERROR_CODES.TIMEOUT,
+        'The translation provider request timed out.'
+      ))
+    }, effectiveTimeout(timeoutMs))
+  })
+
+  try {
+    const response = await Promise.race([
+      Promise.resolve().then(() => fetchFn(request.url, options)),
+      timeout
+    ])
+
+    if (!response || typeof response.json !== 'function') {
+      throw providerError(
+        PROVIDER_ERROR_CODES.INVALID_RESPONSE,
+        'The translation provider response was invalid.'
+      )
+    }
+
+    if (response.ok === false || response.status >= 400) {
+      throw providerError(
+        PROVIDER_ERROR_CODES.HTTP_ERROR,
+        'The translation provider request failed.',
+        {status: Number.isFinite(response.status) ? response.status : undefined}
+      )
+    }
+
+    let payload
+    try {
+      payload = await Promise.race([
+        Promise.resolve().then(() => response.json()),
+        timeout
+      ])
+    } catch (error) {
+      if (error?.code === PROVIDER_ERROR_CODES.TIMEOUT) {
+        throw error
+      }
+      throw providerError(
+        PROVIDER_ERROR_CODES.INVALID_RESPONSE,
+        'The translation provider response was not valid JSON.'
+      )
+    }
+
+    return payload
+  } catch (error) {
+    if (error?.code) {
+      throw error
+    }
+
+    if (error?.name === 'AbortError') {
+      throw providerError(
+        PROVIDER_ERROR_CODES.TIMEOUT,
+        'The translation provider request timed out.'
+      )
+    }
+
+    throw providerError(
+      PROVIDER_ERROR_CODES.NETWORK_ERROR,
+      'The translation provider request could not be completed.'
+    )
+  } finally {
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId)
+    }
+  }
+}
+
+const HTTP_ADAPTER = Object.freeze({
+  id: PROVIDER_ADAPTERS.HTTP,
+  buildRequest: createProviderRequest,
+  normalizeResponse: normalizeProviderResponse
+})
+
+const DEEPL_ADAPTER = Object.freeze({
+  ...HTTP_ADAPTER,
+  id: PROVIDER_ADAPTERS.DEEPL
+})
+
+const GEMINI_ADAPTER = Object.freeze({
+  ...HTTP_ADAPTER,
+  id: PROVIDER_ADAPTERS.GEMINI
+})
+
+const CHROME_TRANSLATOR_ADAPTER = Object.freeze({
+  id: PROVIDER_ADAPTERS.CHROME_TRANSLATOR,
+  buildRequest() {
+    throw providerError(
+      PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT,
+      'This translation provider must run in the content page.',
+      {context: PROVIDER_EXECUTION_CONTEXTS.CONTENT_PAGE}
+    )
+  },
+  normalizeResponse: normalizeProviderResponse
+})
+
+export const TRANSLATION_ADAPTERS = Object.freeze({
+  [PROVIDER_ADAPTERS.HTTP]: HTTP_ADAPTER,
+  [PROVIDER_ADAPTERS.DEEPL]: DEEPL_ADAPTER,
+  [PROVIDER_ADAPTERS.GEMINI]: GEMINI_ADAPTER,
+  [PROVIDER_ADAPTERS.CHROME_TRANSLATOR]: CHROME_TRANSLATOR_ADAPTER
+})
+
+export function getTranslationAdapter(providerInput) {
+  const provider = providerDefinition(providerInput)
+  if (!provider) {
+    return null
+  }
+
+  return TRANSLATION_ADAPTERS[provider.execution.adapterId] || (
+    provider.kind === PROVIDER_KINDS.HTTP ? HTTP_ADAPTER : null
+  )
+}
+
+export function normalizeProviderError(error, {secrets = {}, extraSecrets = []} = {}) {
+  if (error?.name === 'ProviderError') {
+    error.message = redactSecrets(error.message, secrets, extraSecrets)
+    return error
+  }
+
+  const code = error?.name === 'AbortError'
+    ? PROVIDER_ERROR_CODES.TIMEOUT
+    : PROVIDER_ERROR_CODES.NETWORK_ERROR
+  const fallback = code === PROVIDER_ERROR_CODES.TIMEOUT
+    ? 'The translation provider request timed out.'
+    : 'The translation provider request could not be completed.'
+  const message = redactSecrets(error?.message || fallback, secrets, extraSecrets)
+  return providerError(code, message || fallback)
+}
+
+export async function executeProviderTranslation(providerInput, {
+  text,
+  targetLanguage,
+  sourceLanguage = '',
+  secrets = {},
+  allowedOrigins = [],
+  permissionChecker,
+  fetchFn = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS
+} = {}) {
+  const provider = providerDefinition(providerInput)
+  if (!provider) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The translation provider configuration is invalid.'
+    )
+  }
+
+  const adapter = getTranslationAdapter(provider)
+  if (!adapter) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The translation provider adapter is unavailable.'
+    )
+  }
+
+  try {
+    await hasPermission(provider, {allowedOrigins, permissionChecker})
+    const request = adapter.buildRequest(provider, {
+      text,
+      targetLanguage,
+      sourceLanguage,
+      secrets
+    })
+    const payload = await fetchProviderResponse(fetchFn, request, timeoutMs)
+    const normalized = adapter.normalizeResponse(provider, payload)
+    return {
+      ...normalized,
+      request: {
+        url: request.url,
+        method: request.options.method
+      }
+    }
+  } catch (error) {
+    throw normalizeProviderError(error, {secrets})
+  }
+}
+
+export function isBackgroundProvider(providerInput) {
+  const provider = providerDefinition(providerInput)
+  return Boolean(
+    provider &&
+    provider.kind === PROVIDER_KINDS.HTTP &&
+    provider.execution.context === PROVIDER_EXECUTION_CONTEXTS.BACKGROUND &&
+    provider.id !== CHROME_TRANSLATOR_PROVIDER_ID
+  )
+}

--- a/src/translation-provider.mjs
+++ b/src/translation-provider.mjs
@@ -38,7 +38,6 @@ export const PROVIDER_AUTH_MODES = Object.freeze({
 })
 
 export const PROVIDER_HTTP_METHODS = Object.freeze([
-  'GET',
   'POST',
   'PUT',
   'PATCH'
@@ -157,8 +156,12 @@ function isValidHeaderName(value) {
 }
 
 function normalizedMethod(value, fallback = 'POST') {
-  const method = normalizedString(value, fallback).toUpperCase()
-  return PROVIDER_HTTP_METHODS.includes(method) ? method : fallback
+  const method = normalizedString(value).toUpperCase()
+  if (!method) {
+    return fallback
+  }
+
+  return PROVIDER_HTTP_METHODS.includes(method) ? method : ''
 }
 
 function sanitizeTemplateValue(value, fieldName = '') {
@@ -291,7 +294,7 @@ const DEEPL_REQUEST = deepFreeze({
     {name: 'Content-Type', valueTemplate: 'application/json'}
   ],
   bodyTemplate: {
-    text: ['{{text}}'],
+    text: '{{texts}}',
     target_lang: '{{targetLanguage}}'
   },
   textPath: 'text',
@@ -462,6 +465,13 @@ export function normalizeProviderDefinition(input, {id: fallbackId = ''} = {}) {
     return null
   }
 
+  const method = kind === PROVIDER_KINDS.HTTP
+    ? normalizedMethod(endpointSource.method)
+    : null
+  if (kind === PROVIDER_KINDS.HTTP && !method) {
+    return null
+  }
+
   const requestSource = isRecord(input.request) ? input.request : {}
   const responseSource = isRecord(input.response) ? input.response : {}
   const authFallback = source === PROVIDER_SOURCES.PRESET && PROVIDER_PRESETS[presetId]
@@ -482,7 +492,7 @@ export function normalizeProviderDefinition(input, {id: fallbackId = ''} = {}) {
       ? null
       : {
         url,
-        method: normalizedMethod(endpointSource.method)
+        method
       },
     auth: kind === PROVIDER_KINDS.BUILT_IN
       ? normalizedAuth({mode: PROVIDER_AUTH_MODES.NONE}, id)

--- a/src/translation-provider.mjs
+++ b/src/translation-provider.mjs
@@ -25,6 +25,8 @@ export const PROVIDER_EXECUTION_CONTEXTS = Object.freeze({
 
 export const PROVIDER_ADAPTERS = Object.freeze({
   HTTP: 'http',
+  DEEPL: 'deepl',
+  GEMINI: 'gemini',
   CHROME_TRANSLATOR: 'chrome-translator'
 })
 
@@ -139,10 +141,19 @@ function normalizedHttpUrl(value) {
 
   try {
     const url = new URL(result)
-    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : ''
+    if ((url.protocol !== 'http:' && url.protocol !== 'https:') ||
+        url.username || url.password) {
+      return ''
+    }
+
+    return url.toString()
   } catch (_error) {
     return ''
   }
+}
+
+function isValidHeaderName(value) {
+  return /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/.test(value)
 }
 
 function normalizedMethod(value, fallback = 'POST') {
@@ -181,7 +192,7 @@ function normalizedHeader(header) {
     ''
   )
   const secretRef = normalizedSecretRef(header.secretRef)
-  if (!name) {
+  if (!name || !isValidHeaderName(name)) {
     return null
   }
 
@@ -291,6 +302,24 @@ const DEEPL_RESPONSE = deepFreeze({
   textPath: 'translations[0].text'
 })
 
+const GEMINI_REQUEST = deepFreeze({
+  headers: [
+    {name: 'Content-Type', valueTemplate: 'application/json'}
+  ],
+  bodyTemplate: {
+    contents: [{
+      role: 'user',
+      parts: [{text: 'Translate the following text to {{targetLanguage}}. Return only the translated text.\\n\\n{{text}}'}]
+    }]
+  },
+  textPath: 'text',
+  targetLanguagePath: 'targetLanguage'
+})
+
+const GEMINI_RESPONSE = deepFreeze({
+  textPath: 'candidates[0].content.parts[0].text'
+})
+
 const PRESET_DEFINITIONS = {
   'deepl-free': {
     modelVersion: TRANSLATION_PROVIDER_MODEL_VERSION,
@@ -311,7 +340,12 @@ const PRESET_DEFINITIONS = {
       secretRef: 'providers.deepl-free.apiKey'
     },
     request: DEEPL_REQUEST,
-    response: DEEPL_RESPONSE
+    response: DEEPL_RESPONSE,
+    execution: {
+      adapterId: PROVIDER_ADAPTERS.DEEPL,
+      context: PROVIDER_EXECUTION_CONTEXTS.BACKGROUND,
+      supportsWebWorker: true
+    }
   },
   'deepl-pro': {
     modelVersion: TRANSLATION_PROVIDER_MODEL_VERSION,
@@ -332,7 +366,38 @@ const PRESET_DEFINITIONS = {
       secretRef: 'providers.deepl-pro.apiKey'
     },
     request: DEEPL_REQUEST,
-    response: DEEPL_RESPONSE
+    response: DEEPL_RESPONSE,
+    execution: {
+      adapterId: PROVIDER_ADAPTERS.DEEPL,
+      context: PROVIDER_EXECUTION_CONTEXTS.BACKGROUND,
+      supportsWebWorker: true
+    }
+  },
+  gemini: {
+    modelVersion: TRANSLATION_PROVIDER_MODEL_VERSION,
+    id: 'gemini',
+    name: 'Gemini',
+    kind: PROVIDER_KINDS.HTTP,
+    source: PROVIDER_SOURCES.PRESET,
+    presetId: 'gemini',
+    endpoint: {
+      url: 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent',
+      method: 'POST'
+    },
+    auth: {
+      mode: PROVIDER_AUTH_MODES.API_KEY,
+      location: 'header',
+      headerName: 'x-goog-api-key',
+      prefix: '',
+      secretRef: 'providers.gemini.apiKey'
+    },
+    request: GEMINI_REQUEST,
+    response: GEMINI_RESPONSE,
+    execution: {
+      adapterId: PROVIDER_ADAPTERS.GEMINI,
+      context: PROVIDER_EXECUTION_CONTEXTS.BACKGROUND,
+      supportsWebWorker: true
+    }
   },
   [CHROME_TRANSLATOR_PROVIDER_ID]: {
     modelVersion: TRANSLATION_PROVIDER_MODEL_VERSION,

--- a/tests/messaging.test.mjs
+++ b/tests/messaging.test.mjs
@@ -20,6 +20,7 @@ import {
   registerBackgroundListener,
   validateMessageRequest
 } from '../src/background-handler.mjs'
+import {getProviderPreset} from '../src/translation-provider.mjs'
 
 function jsonResponse(data, overrides = {}) {
   return {
@@ -54,7 +55,7 @@ test('documents the existing actions and creates their request envelopes', () =>
     TRANSLATION: 'translation'
   })
   assert.ok(MESSAGE_CONTRACTS.endic.request.includes("action: 'endic'"))
-  assert.ok(MESSAGE_CONTRACTS.translation.response.includes('DeepLTranslationResponse'))
+  assert.ok(MESSAGE_CONTRACTS.translation.response.includes('TranslationResponse'))
 
   assert.deepEqual(dictionaryRequest(), {
     action: 'endic',
@@ -131,6 +132,28 @@ test('returns a shared success response for dictionary and translation requests'
   assert.deepEqual(JSON.parse(calls[1].options.body), {
     text: ['hello'],
     target_lang: 'ko'
+  })
+})
+
+test('routes provider-backed translation messages through the selected adapter', async () => {
+  const provider = getProviderPreset('gemini')
+  const response = await handleBackgroundMessage({
+    action: MESSAGE_ACTIONS.TRANSLATION,
+    provider,
+    key: 'gemini-secret',
+    data: {text: ['hello'], targetLanguage: 'ko'}
+  }, {
+    fetchFn: async (_url, options) => {
+      assert.equal(options.headers['x-goog-api-key'], 'gemini-secret')
+      return jsonResponse({
+        candidates: [{content: {parts: [{text: '안녕하세요'}]}}]
+      })
+    }
+  })
+
+  assert.deepEqual(response, {
+    ok: true,
+    data: {candidates: [{content: {parts: [{text: '안녕하세요'}]}}]}
   })
 })
 

--- a/tests/packaging.test.mjs
+++ b/tests/packaging.test.mjs
@@ -47,6 +47,7 @@ test('package validator follows raw background and content imports', () => {
     'content-storage.mjs',
     'messaging.mjs',
     'settings.mjs',
+    'translation-provider.mjs',
     'dictionary/parser.mjs',
     'dictionary/normalizer.mjs'
   ]) {

--- a/tests/translation-engine.test.mjs
+++ b/tests/translation-engine.test.mjs
@@ -75,7 +75,7 @@ test('builds and normalizes a DeepL fixture through the shared adapter', () => {
     'https://api.deepl.com/v2/translate'
   )
   const request = createProviderRequest(provider, {
-    text: 'hello',
+    text: ['hello', 'world'],
     targetLanguage: 'ko',
     secrets: secretStore('deepl-free', 'apiKey', 'deep-secret')
   })
@@ -83,7 +83,7 @@ test('builds and normalizes a DeepL fixture through the shared adapter', () => {
   assert.equal(request.url, 'https://api-free.deepl.com/v2/translate')
   assert.equal(request.options.headers.Authorization, 'DeepL-Auth-Key deep-secret')
   assert.deepEqual(JSON.parse(request.options.body), {
-    text: ['hello'],
+    text: ['hello', 'world'],
     target_lang: 'ko'
   })
   assert.deepEqual(normalizeProviderResponse(provider, {
@@ -168,6 +168,11 @@ test('rejects unsafe endpoints and keeps credentials out of errors', async () =>
     kind: 'custom',
     endpoint: {url: 'https://user:pass@example.test/translate', method: 'POST'}
   }), null)
+  assert.equal(normalizeProviderDefinition({
+    id: 'unsupported-get',
+    kind: 'custom',
+    endpoint: {url: 'https://api.example.test/translate', method: 'GET'}
+  }), null)
 
   const secret = 'custom-secret'
   const redacted = redactSecrets(
@@ -187,6 +192,34 @@ test('rejects unsafe endpoints and keeps credentials out of errors', async () =>
     error => error.code === PROVIDER_ERROR_CODES.HTTP_ERROR &&
       !error.message.includes(secret)
   )
+})
+
+test('does not return query authentication credentials in the normalized result', async () => {
+  const provider = customProvider({
+    auth: {
+      mode: 'api-key',
+      location: 'query',
+      headerName: 'key',
+      prefix: '',
+      secretRef: 'providers.custom-api.apiKey'
+    }
+  })
+  const secret = 'query-secret'
+
+  const result = await executeProviderTranslation(provider, {
+    text: 'hello',
+    targetLanguage: 'ko',
+    secrets: secretStore('custom-api', 'apiKey', secret),
+    allowedOrigins: ['https://api.example.test/*'],
+    fetchFn: async (url) => {
+      assert.match(url, /[?&]key=query-secret(?:&|$)/)
+      return jsonResponse({result: {text: '안녕'}})
+    }
+  })
+
+  assert.equal(result.text, '안녕')
+  assert.equal('request' in result, false)
+  assert.doesNotMatch(JSON.stringify(result), /query-secret/)
 })
 
 test('supports nested response paths and origin pattern boundaries', () => {

--- a/tests/translation-engine.test.mjs
+++ b/tests/translation-engine.test.mjs
@@ -1,0 +1,237 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createProviderRequest,
+  executeProviderTranslation,
+  getPathValue,
+  normalizeProviderResponse,
+  PROVIDER_ERROR_CODES,
+  redactSecrets
+} from '../src/translation-engine.mjs'
+import {
+  getProviderPreset,
+  normalizeProviderDefinition
+} from '../src/translation-provider.mjs'
+import {
+  getProviderOriginPattern,
+  hasProviderOriginPermission,
+  isProviderOriginAllowed,
+  matchesProviderOriginPattern,
+  requestProviderOriginPermission
+} from '../src/provider-permissions.mjs'
+
+function jsonResponse(data, overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+    ...overrides
+  }
+}
+
+function secretStore(providerId, field, value) {
+  return {providers: {[providerId]: {[field]: value}}}
+}
+
+function customProvider(overrides = {}) {
+  return normalizeProviderDefinition({
+    id: 'custom-api',
+    name: 'Custom API',
+    kind: 'custom',
+    endpoint: {
+      url: 'https://api.example.test/translate',
+      method: 'POST'
+    },
+    auth: {
+      mode: 'bearer',
+      location: 'header',
+      headerName: 'Authorization',
+      prefix: 'Bearer ',
+      secretRef: 'providers.custom-api.token'
+    },
+    request: {
+      headers: [
+        {name: 'Content-Type', valueTemplate: 'application/json'},
+        {
+          name: 'X-Provider',
+          valueTemplate: 'naverdic'
+        }
+      ],
+      bodyTemplate: {
+        input: '{{text}}',
+        language: '{{targetLanguage}}'
+      }
+    },
+    response: {textPath: 'result.text'},
+    ...overrides
+  })
+}
+
+test('builds and normalizes a DeepL fixture through the shared adapter', () => {
+  const provider = getProviderPreset('deepl-free')
+  assert.equal(
+    getProviderPreset('deepl-pro').endpoint.url,
+    'https://api.deepl.com/v2/translate'
+  )
+  const request = createProviderRequest(provider, {
+    text: 'hello',
+    targetLanguage: 'ko',
+    secrets: secretStore('deepl-free', 'apiKey', 'deep-secret')
+  })
+
+  assert.equal(request.url, 'https://api-free.deepl.com/v2/translate')
+  assert.equal(request.options.headers.Authorization, 'DeepL-Auth-Key deep-secret')
+  assert.deepEqual(JSON.parse(request.options.body), {
+    text: ['hello'],
+    target_lang: 'ko'
+  })
+  assert.deepEqual(normalizeProviderResponse(provider, {
+    translations: [{text: '안녕'}]
+  }), {
+    providerId: 'deepl-free',
+    text: '안녕',
+    raw: {translations: [{text: '안녕'}]}
+  })
+})
+
+test('builds the Gemini generateContent fixture with header authentication', async () => {
+  const provider = getProviderPreset('gemini')
+  const calls = []
+  const result = await executeProviderTranslation(provider, {
+    text: 'hello',
+    targetLanguage: 'ko',
+    secrets: secretStore('gemini', 'apiKey', 'gemini-secret'),
+    fetchFn: async (url, options) => {
+      calls.push({url, options})
+      return jsonResponse({
+        candidates: [{content: {parts: [{text: '안녕하세요'}]}}]
+      })
+    }
+  })
+
+  assert.equal(calls.length, 1)
+  assert.match(calls[0].url, /generativelanguage\.googleapis\.com\/v1beta\/models\/gemini-3\.5-flash:generateContent$/)
+  assert.equal(calls[0].options.headers['x-goog-api-key'], 'gemini-secret')
+  const geminiBody = JSON.parse(calls[0].options.body)
+  assert.equal(geminiBody.contents[0].role, 'user')
+  assert.match(geminiBody.contents[0].parts[0].text, /to ko/)
+  assert.match(geminiBody.contents[0].parts[0].text, /hello/)
+  assert.equal(result.text, '안녕하세요')
+})
+
+test('renders custom API templates only after origin permission is granted', async () => {
+  const provider = customProvider()
+  const secrets = secretStore('custom-api', 'token', 'custom-secret')
+  let fetchCalls = 0
+
+  await assert.rejects(
+    executeProviderTranslation(provider, {
+      text: 'hello',
+      targetLanguage: 'ko',
+      secrets,
+      fetchFn: async () => {
+        fetchCalls += 1
+        return jsonResponse({result: {text: 'should not run'}})
+      }
+    }),
+    error => error.code === PROVIDER_ERROR_CODES.PERMISSION_REQUIRED
+  )
+  assert.equal(fetchCalls, 0)
+
+  const result = await executeProviderTranslation(provider, {
+    text: 'hello',
+    targetLanguage: 'ko',
+    secrets,
+    allowedOrigins: ['https://api.example.test/*'],
+    fetchFn: async (_url, options) => {
+      assert.equal(options.headers.Authorization, 'Bearer custom-secret')
+      assert.deepEqual(JSON.parse(options.body), {
+        input: 'hello',
+        language: 'ko'
+      })
+      return jsonResponse({result: {text: '안녕'}})
+    }
+  })
+
+  assert.equal(result.text, '안녕')
+})
+
+test('rejects unsafe endpoints and keeps credentials out of errors', async () => {
+  assert.equal(normalizeProviderDefinition({
+    id: 'unsafe',
+    kind: 'custom',
+    endpoint: {url: 'javascript:alert(1)', method: 'POST'}
+  }), null)
+  assert.equal(normalizeProviderDefinition({
+    id: 'unsafe',
+    kind: 'custom',
+    endpoint: {url: 'https://user:pass@example.test/translate', method: 'POST'}
+  }), null)
+
+  const secret = 'custom-secret'
+  const redacted = redactSecrets(
+    `Authorization: Bearer ${secret}`,
+    secretStore('custom-api', 'token', secret)
+  )
+  assert.equal(redacted, 'Authorization: Bearer [REDACTED]')
+
+  await assert.rejects(
+    executeProviderTranslation(customProvider(), {
+      text: 'hello',
+      targetLanguage: 'ko',
+      secrets: secretStore('custom-api', 'token', secret),
+      allowedOrigins: ['https://api.example.test/*'],
+      fetchFn: async () => jsonResponse({}, {ok: false, status: 401})
+    }),
+    error => error.code === PROVIDER_ERROR_CODES.HTTP_ERROR &&
+      !error.message.includes(secret)
+  )
+})
+
+test('supports nested response paths and origin pattern boundaries', () => {
+  assert.equal(getPathValue({a: [{b: 'value'}]}, 'a[0].b'), 'value')
+  assert.equal(getProviderOriginPattern('https://api.example.test/v1/translate'), 'https://api.example.test/*')
+  assert.equal(matchesProviderOriginPattern('https://api.example.test/v1', 'https://api.example.test/*'), true)
+  assert.equal(matchesProviderOriginPattern('https://sub.example.test/v1', 'https://*.example.test/*'), true)
+  assert.equal(matchesProviderOriginPattern('https://not-example.test/v1', 'https://*.example.test/*'), false)
+  assert.equal(isProviderOriginAllowed('https://api.example.test/v1', ['https://api.example.test/*']), true)
+})
+
+test('uses Chrome permission APIs with the narrow provider origin pattern', async () => {
+  const calls = []
+  const permissions = {
+    contains(details, callback) {
+      calls.push(['contains', details])
+      callback(true)
+    },
+    request(details, callback) {
+      calls.push(['request', details])
+      callback(true)
+    }
+  }
+
+  assert.equal(
+    await hasProviderOriginPermission(permissions, 'https://api.example.test/v1'),
+    true
+  )
+  assert.equal(
+    await requestProviderOriginPermission(permissions, 'https://api.example.test/v1'),
+    true
+  )
+  assert.deepEqual(calls, [
+    ['contains', {origins: ['https://api.example.test/*']}],
+    ['request', {origins: ['https://api.example.test/*']}]
+  ])
+})
+
+test('keeps Chrome built-in Translator outside the background HTTP adapter', async () => {
+  await assert.rejects(
+    executeProviderTranslation(getProviderPreset('chrome-translator'), {
+      text: 'hello',
+      targetLanguage: 'ko',
+      fetchFn: async () => jsonResponse({result: 'should not run'})
+    }),
+    error => error.code === PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT
+  )
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -32,6 +32,18 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/translation-engine.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/provider-permissions.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/translation-provider.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/content.js',
           dest: '.'
         },


### PR DESCRIPTION
## Summary
- Replace the DeepL-only background request construction with a common provider adapter engine.
- Add DeepL Free/Pro presets and a Gemini `generateContent` adapter with provider-specific JSON request/response paths.
- Add Custom API URL, method, headers, body-template, auth, and response-path execution.
- Validate HTTP(S) endpoints, reject URL credentials, gate custom origins behind optional host permissions, and provide narrow Chrome permission helpers.
- Normalize provider errors and redact credentials from diagnostics while preserving the v6.6 translation response body.
- Route the existing content translation request through the DeepL provider preset without changing its user-visible behavior.

## Verification
- `npm test` — 76 passing
- `npm run build`
- `NAVERDIC_ZIP_DIR=/tmp/naverdic-task5-review2-package npm run package`
- `git diff --check`
- Provider fixtures cover DeepL multi-text preservation, DeepL Pro endpoint selection, Gemini JSON, Custom API permission gating, unsupported GET methods, unsafe endpoints, query-auth redaction, error redaction, and Chrome permission APIs.

Targets `firstlight` as TASK 5.