### PR TITLE
feat(stage2): TASK 6-2 Chrome Translator API service settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",
+    "@vue/test-utils": "2.4.6",
+    "jsdom": "24.1.3",
     "vite": "^6.4.3",
     "vite-plugin-static-copy": "^2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "naverdic",
   "private": true,
+  "type": "module",
   "version": "6.6.0",
   "scripts": {
     "dev": "vite",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,7 @@
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "messaging.mjs", "settings.mjs", "translation-provider.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
+      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content-settings.mjs", "chrome-translator.mjs", "messaging.mjs", "settings.mjs", "settings-v2.mjs", "settings-v2-storage.mjs", "settings-migration-v2.mjs", "translation-provider.mjs", "translation-engine.mjs", "translation-settings.mjs", "translation-testing.mjs", "provider-permissions.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -395,7 +395,7 @@
     "message": "Chrome built-in translation (Translator API)"
   },
   "SETTINGS_TRANSLATION_CHROME_DESCRIPTION": {
-    "message": "A free built-in translation service"
+    "message": "Free local translation provided by the browser"
   },
   "SETTINGS_TRANSLATION_CHROME_PREVIEW_DESCRIPTION": {
     "message": "The Chrome Translator API provided by the browser."
@@ -618,5 +618,140 @@
   },
   "SETTINGS_TRANSLATION_VALIDATION_INVALID": {
     "message": "Check the Custom API settings."
+  },
+  "SETTINGS_TRANSLATION_SELECTOR_TITLE": {
+    "message": "Translation services"
+  },
+  "SETTINGS_TRANSLATION_SELECTOR_HINT": {
+    "message": "Choose a service and manage its detailed settings."
+  },
+  "SETTINGS_TRANSLATION_DETAIL_TITLE": {
+    "message": "Service details"
+  },
+  "SETTINGS_TRANSLATION_DETAIL_HINT": {
+    "message": "Manage settings for the selected translation service."
+  },
+  "SETTINGS_TRANSLATION_STATUS_READY": {
+    "message": "Available"
+  },
+  "SETTINGS_TRANSLATION_STATUS_DOWNLOADING": {
+    "message": "Preparing"
+  },
+  "SETTINGS_TRANSLATION_STATUS_UNAVAILABLE": {
+    "message": "Unavailable"
+  },
+  "SETTINGS_TRANSLATION_STATUS_ERROR": {
+    "message": "Error"
+  },
+  "SETTINGS_TRANSLATION_STATUS_SETUP": {
+    "message": "Setup needed"
+  },
+  "SETTINGS_TRANSLATION_STATUS_CONNECTED": {
+    "message": "Connected"
+  },
+  "SETTINGS_TRANSLATION_STATUS_PERMISSION": {
+    "message": "Permission needed"
+  },
+  "SETTINGS_TRANSLATION_CONNECTED_BADGE": {
+    "message": "Connected"
+  },
+  "SETTINGS_TRANSLATION_ERROR_BADGE": {
+    "message": "Connection error"
+  },
+  "SETTINGS_TRANSLATION_REQUIRED_BADGE": {
+    "message": "Setup needed"
+  },
+  "SETTINGS_TRANSLATION_DELETE_KEY": {
+    "message": "Delete"
+  },
+  "SETTINGS_TRANSLATION_ACTIVATE": {
+    "message": "Use this service"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DETAIL_DESCRIPTION": {
+    "message": "Uses Chrome's official Translator API."
+  },
+  "SETTINGS_TRANSLATION_CHROME_LOCAL_BADGE": {
+    "message": "Free · Local processing"
+  },
+  "SETTINGS_TRANSLATION_CHROME_LANGUAGE_PAIR": {
+    "message": "Language pair"
+  },
+  "SETTINGS_TRANSLATION_CHROME_BROWSER": {
+    "message": "Browser support"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL": {
+    "message": "Translation model"
+  },
+  "SETTINGS_TRANSLATION_CHROME_SUPPORTED": {
+    "message": "Supported"
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNSUPPORTED": {
+    "message": "Not supported"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_NEEDED": {
+    "message": "Download needed"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_DOWNLOADING": {
+    "message": "Downloading"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_READY": {
+    "message": "Ready"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_UNAVAILABLE": {
+    "message": "Unavailable"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED": {
+    "message": "Download failed"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_BUTTON": {
+    "message": "Download model"
+  },
+  "SETTINGS_TRANSLATION_CHROME_RETRY": {
+    "message": "Try again"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS": {
+    "message": "Downloading"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS_HINT": {
+    "message": "Preparing the translation model."
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNSUPPORTED_GUIDANCE": {
+    "message": "Available in desktop Chrome 138 or later."
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNAVAILABLE_GUIDANCE": {
+    "message": "The en → ko model is unavailable in this environment."
+  },
+  "SETTINGS_TRANSLATION_CHROME_NETWORK_ERROR": {
+    "message": "The model download failed. Check your network connection."
+  },
+  "SETTINGS_TRANSLATION_CHROME_PERMISSION_ERROR": {
+    "message": "The browser did not allow the model download. Try again."
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED_HINT": {
+    "message": "The model could not be prepared. Try again."
+  },
+  "SETTINGS_TRANSLATION_CHROME_NOTE": {
+    "message": "No API key is needed. Translation runs through Chrome's Translator API in this page."
+  },
+  "SETTINGS_TRANSLATION_PERMISSION_BADGE": {
+    "message": "Permission needed"
+  },
+  "SETTINGS_TRANSLATION_PERMISSION_ALLOWED_BADGE": {
+    "message": "Permission allowed"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_TITLE": {
+    "message": "Host permission"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_HINT": {
+    "message": "Access to the API host is required for testing and use."
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_GRANTED": {
+    "message": "API host access has been allowed."
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_REQUEST": {
+    "message": "Request permission"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_TEST_REQUIRED": {
+    "message": "Allow host permission and pass a connection test before activating this service."
   }
 }

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -395,7 +395,7 @@
     "message": "Chrome 내장 번역 (Translator API)"
   },
   "SETTINGS_TRANSLATION_CHROME_DESCRIPTION": {
-    "message": "무료로 제공되는 기본 번역 서비스"
+    "message": "브라우저에서 무료로 제공되는 로컬 번역"
   },
   "SETTINGS_TRANSLATION_CHROME_PREVIEW_DESCRIPTION": {
     "message": "브라우저에서 제공하는 Chrome Translator API입니다."
@@ -618,5 +618,140 @@
   },
   "SETTINGS_TRANSLATION_VALIDATION_INVALID": {
     "message": "Custom API 설정을 확인하세요."
+  },
+  "SETTINGS_TRANSLATION_SELECTOR_TITLE": {
+    "message": "번역 서비스"
+  },
+  "SETTINGS_TRANSLATION_SELECTOR_HINT": {
+    "message": "사용할 서비스를 선택하고 세부 설정을 관리하세요."
+  },
+  "SETTINGS_TRANSLATION_DETAIL_TITLE": {
+    "message": "세부 설정"
+  },
+  "SETTINGS_TRANSLATION_DETAIL_HINT": {
+    "message": "선택한 번역 서비스의 설정을 관리하세요."
+  },
+  "SETTINGS_TRANSLATION_STATUS_READY": {
+    "message": "사용 가능"
+  },
+  "SETTINGS_TRANSLATION_STATUS_DOWNLOADING": {
+    "message": "준비 중"
+  },
+  "SETTINGS_TRANSLATION_STATUS_UNAVAILABLE": {
+    "message": "사용 불가"
+  },
+  "SETTINGS_TRANSLATION_STATUS_ERROR": {
+    "message": "오류"
+  },
+  "SETTINGS_TRANSLATION_STATUS_SETUP": {
+    "message": "설정 필요"
+  },
+  "SETTINGS_TRANSLATION_STATUS_CONNECTED": {
+    "message": "연결됨"
+  },
+  "SETTINGS_TRANSLATION_STATUS_PERMISSION": {
+    "message": "권한 필요"
+  },
+  "SETTINGS_TRANSLATION_CONNECTED_BADGE": {
+    "message": "연결됨"
+  },
+  "SETTINGS_TRANSLATION_ERROR_BADGE": {
+    "message": "연결 오류"
+  },
+  "SETTINGS_TRANSLATION_REQUIRED_BADGE": {
+    "message": "설정 필요"
+  },
+  "SETTINGS_TRANSLATION_DELETE_KEY": {
+    "message": "삭제"
+  },
+  "SETTINGS_TRANSLATION_ACTIVATE": {
+    "message": "이 서비스 사용"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DETAIL_DESCRIPTION": {
+    "message": "Chrome에서 제공하는 Translator API를 사용합니다."
+  },
+  "SETTINGS_TRANSLATION_CHROME_LOCAL_BADGE": {
+    "message": "무료 · 로컬 처리"
+  },
+  "SETTINGS_TRANSLATION_CHROME_LANGUAGE_PAIR": {
+    "message": "지원 언어쌍"
+  },
+  "SETTINGS_TRANSLATION_CHROME_BROWSER": {
+    "message": "브라우저 지원"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL": {
+    "message": "번역 모델"
+  },
+  "SETTINGS_TRANSLATION_CHROME_SUPPORTED": {
+    "message": "지원됨"
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNSUPPORTED": {
+    "message": "지원 안 함"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_NEEDED": {
+    "message": "다운로드 필요"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_DOWNLOADING": {
+    "message": "다운로드 중"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_READY": {
+    "message": "준비 완료"
+  },
+  "SETTINGS_TRANSLATION_CHROME_MODEL_UNAVAILABLE": {
+    "message": "사용 불가"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED": {
+    "message": "다운로드 실패"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_BUTTON": {
+    "message": "모델 다운로드"
+  },
+  "SETTINGS_TRANSLATION_CHROME_RETRY": {
+    "message": "다시 시도"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS": {
+    "message": "다운로드 중"
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS_HINT": {
+    "message": "번역 모델을 준비하고 있습니다."
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNSUPPORTED_GUIDANCE": {
+    "message": "Chrome 138 이상 데스크톱 브라우저에서 사용할 수 있습니다."
+  },
+  "SETTINGS_TRANSLATION_CHROME_UNAVAILABLE_GUIDANCE": {
+    "message": "현재 환경에서는 en → ko 모델을 사용할 수 없습니다."
+  },
+  "SETTINGS_TRANSLATION_CHROME_NETWORK_ERROR": {
+    "message": "모델 다운로드에 실패했습니다. 네트워크 연결을 확인하세요."
+  },
+  "SETTINGS_TRANSLATION_CHROME_PERMISSION_ERROR": {
+    "message": "브라우저가 모델 다운로드를 허용하지 않았습니다. 다시 시도하세요."
+  },
+  "SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED_HINT": {
+    "message": "모델을 준비하지 못했습니다. 다시 시도하세요."
+  },
+  "SETTINGS_TRANSLATION_CHROME_NOTE": {
+    "message": "API 키가 필요하지 않습니다. 번역은 이 페이지의 Chrome Translator API에서 처리됩니다."
+  },
+  "SETTINGS_TRANSLATION_PERMISSION_BADGE": {
+    "message": "권한 필요"
+  },
+  "SETTINGS_TRANSLATION_PERMISSION_ALLOWED_BADGE": {
+    "message": "권한 허용됨"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_TITLE": {
+    "message": "호스트 권한"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_HINT": {
+    "message": "연결 테스트와 사용을 위해 API 호스트 접근 권한이 필요합니다."
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_GRANTED": {
+    "message": "API 호스트 접근 권한이 허용되었습니다."
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_PERMISSION_REQUEST": {
+    "message": "권한 요청"
+  },
+  "SETTINGS_TRANSLATION_CUSTOM_TEST_REQUIRED": {
+    "message": "활성화하려면 호스트 권한을 허용하고 연결 테스트를 성공시켜야 합니다."
   }
 }

--- a/src/chrome-translator.mjs
+++ b/src/chrome-translator.mjs
@@ -1,0 +1,529 @@
+/**
+ * Content-page runtime for Chrome's built-in Translator API.
+ *
+ * Translator is deliberately resolved from the supplied document-like scope
+ * and never from a worker. The runtime owns one Translator instance per
+ * document, which keeps model creation out of every individual translation
+ * request and makes its lifecycle explicit for both the options page and the
+ * content script.
+ */
+
+export const CHROME_TRANSLATOR_LANGUAGE_PAIR = Object.freeze({
+  sourceLanguage: 'en',
+  targetLanguage: 'ko'
+})
+
+export const CHROME_TRANSLATOR_AVAILABILITY = Object.freeze([
+  'unavailable',
+  'downloadable',
+  'downloading',
+  'available'
+])
+
+export const CHROME_TRANSLATOR_PHASES = Object.freeze({
+  CHECKING: 'checking',
+  UNSUPPORTED: 'unsupported',
+  UNAVAILABLE: 'unavailable',
+  DOWNLOADABLE: 'downloadable',
+  DOWNLOADING: 'downloading',
+  AVAILABLE: 'available',
+  FAILED: 'failed'
+})
+
+export const CHROME_TRANSLATOR_ERROR_CODES = Object.freeze({
+  UNSUPPORTED: 'TRANSLATOR_UNSUPPORTED',
+  UNAVAILABLE: 'TRANSLATOR_UNAVAILABLE',
+  MODEL_NOT_READY: 'TRANSLATOR_MODEL_NOT_READY',
+  USER_ACTIVATION_REQUIRED: 'TRANSLATOR_USER_ACTIVATION_REQUIRED',
+  NETWORK: 'TRANSLATOR_NETWORK_ERROR',
+  NOT_ALLOWED: 'TRANSLATOR_NOT_ALLOWED',
+  NOT_SUPPORTED: 'TRANSLATOR_NOT_SUPPORTED',
+  OPERATION: 'TRANSLATOR_OPERATION_ERROR',
+  INVALID_RESPONSE: 'TRANSLATOR_INVALID_RESPONSE',
+  DOWNLOAD_FAILED: 'TRANSLATOR_DOWNLOAD_FAILED',
+  TRANSLATE_FAILED: 'TRANSLATOR_TRANSLATE_FAILED',
+  UNKNOWN: 'TRANSLATOR_UNKNOWN_ERROR'
+})
+
+function clampProgress(value) {
+  const number = Number(value)
+  if (!Number.isFinite(number)) {
+    return null
+  }
+
+  const normalized = number > 1 ? number / 100 : number
+  return Math.max(0, Math.min(1, normalized))
+}
+
+function getScope(scope) {
+  if (scope !== undefined && scope !== null) {
+    return scope.self && typeof scope.self === 'object'
+      ? scope.self
+      : scope
+  }
+
+  return typeof self !== 'undefined' ? self : globalThis
+}
+
+function resolveTranslatorApi(scope, translatorApi) {
+  if (translatorApi !== undefined) {
+    return translatorApi
+  }
+
+  const documentScope = getScope(scope)
+  return documentScope && 'Translator' in documentScope
+    ? documentScope.Translator
+    : null
+}
+
+function errorMessage(error, fallback) {
+  return typeof error?.message === 'string' && error.message.trim()
+    ? error.message.trim()
+    : fallback
+}
+
+function errorCodeFor(error, operation) {
+  switch (error?.name) {
+    case 'NetworkError':
+      return CHROME_TRANSLATOR_ERROR_CODES.NETWORK
+    case 'NotAllowedError':
+      return CHROME_TRANSLATOR_ERROR_CODES.NOT_ALLOWED
+    case 'NotSupportedError':
+      return CHROME_TRANSLATOR_ERROR_CODES.NOT_SUPPORTED
+    case 'OperationError':
+      return CHROME_TRANSLATOR_ERROR_CODES.OPERATION
+    default:
+      return operation === 'download'
+        ? CHROME_TRANSLATOR_ERROR_CODES.DOWNLOAD_FAILED
+        : operation === 'translate'
+          ? CHROME_TRANSLATOR_ERROR_CODES.TRANSLATE_FAILED
+          : CHROME_TRANSLATOR_ERROR_CODES.UNKNOWN
+  }
+}
+
+export class ChromeTranslatorError extends Error {
+  constructor(code, message, {cause, name: errorName} = {}) {
+    super(message)
+    this.name = 'ChromeTranslatorError'
+    this.code = code
+    this.errorName = errorName || cause?.name || ''
+    if (cause !== undefined) {
+      this.cause = cause
+    }
+  }
+}
+
+export function normalizeChromeTranslatorError(error, operation = 'translate') {
+  if (error instanceof ChromeTranslatorError) {
+    return error
+  }
+
+  const code = errorCodeFor(error, operation)
+  const fallback = operation === 'download'
+    ? 'The Chrome Translator model could not be downloaded.'
+    : 'The Chrome Translator request could not be completed.'
+  return new ChromeTranslatorError(code, errorMessage(error, fallback), {
+    cause: error,
+    name: error?.name
+  })
+}
+
+function initialState(api) {
+  return {
+    supported: Boolean(api),
+    availability: null,
+    phase: api ? CHROME_TRANSLATOR_PHASES.CHECKING : CHROME_TRANSLATOR_PHASES.UNSUPPORTED,
+    progress: null,
+    indeterminate: false,
+    errorCode: null,
+    errorName: '',
+    errorMessage: ''
+  }
+}
+
+function publicState(state) {
+  return Object.freeze({
+    ...state,
+    status: state.availability
+  })
+}
+
+function availabilityPhase(availability) {
+  switch (availability) {
+    case 'unavailable':
+      return CHROME_TRANSLATOR_PHASES.UNAVAILABLE
+    case 'downloadable':
+      return CHROME_TRANSLATOR_PHASES.DOWNLOADABLE
+    case 'downloading':
+      return CHROME_TRANSLATOR_PHASES.DOWNLOADING
+    case 'available':
+      return CHROME_TRANSLATOR_PHASES.AVAILABLE
+    default:
+      return CHROME_TRANSLATOR_PHASES.UNAVAILABLE
+  }
+}
+
+function availabilityError(message, code = CHROME_TRANSLATOR_ERROR_CODES.UNAVAILABLE) {
+  return new ChromeTranslatorError(code, message)
+}
+
+/**
+ * Create one Translator API lifecycle for one document.
+ *
+ * `download()` intentionally calls Translator.create() before awaiting
+ * anything. Call it directly from a user click handler so Chrome's user
+ * activation requirement remains intact.
+ */
+export function createChromeTranslatorRuntime({
+  scope,
+  translatorApi,
+  onStateChange
+} = {}) {
+  const api = resolveTranslatorApi(scope, translatorApi)
+  let state = initialState(api)
+  let translator = null
+  let availabilityPromise = null
+  let createPromise = null
+  let destroyed = false
+  const listeners = new Set()
+
+  if (typeof onStateChange === 'function') {
+    listeners.add(onStateChange)
+  }
+
+  function currentState() {
+    return publicState(state)
+  }
+
+  function emit() {
+    const nextState = currentState()
+    listeners.forEach(listener => {
+      try {
+        listener(nextState)
+      } catch (_error) {
+        // A UI subscriber must not break the Translator lifecycle.
+      }
+    })
+    return nextState
+  }
+
+  function updateState(patch) {
+    state = {...state, ...patch}
+    return emit()
+  }
+
+  function ensureActive() {
+    if (destroyed) {
+      throw new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.UNKNOWN,
+        'The Chrome Translator runtime has been destroyed.'
+      )
+    }
+  }
+
+  function ensureApi({requireAvailability = false} = {}) {
+    ensureActive()
+    if (!api || typeof api.create !== 'function' ||
+        (requireAvailability && typeof api.availability !== 'function')) {
+      updateState({
+        supported: false,
+        phase: CHROME_TRANSLATOR_PHASES.UNSUPPORTED,
+        errorCode: CHROME_TRANSLATOR_ERROR_CODES.UNSUPPORTED,
+        errorName: 'NotSupportedError',
+        errorMessage: 'The Translator API is not supported in this document.'
+      })
+      throw new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.UNSUPPORTED,
+        'The Translator API is not supported in this document.'
+      )
+    }
+    return api
+  }
+
+  function setDownloadProgress(loaded) {
+    const progress = clampProgress(loaded)
+    if (progress === null) {
+      updateState({
+        phase: CHROME_TRANSLATOR_PHASES.DOWNLOADING,
+        availability: 'downloading',
+        progress: null,
+        indeterminate: true,
+        errorCode: null,
+        errorName: '',
+        errorMessage: ''
+      })
+      return
+    }
+
+    updateState({
+      phase: CHROME_TRANSLATOR_PHASES.DOWNLOADING,
+      availability: 'downloading',
+      progress,
+      indeterminate: false,
+      errorCode: null,
+      errorName: '',
+      errorMessage: ''
+    })
+  }
+
+  function attachDownloadMonitor(monitor) {
+    if (!monitor || typeof monitor.addEventListener !== 'function') {
+      updateState({
+        phase: CHROME_TRANSLATOR_PHASES.DOWNLOADING,
+        availability: 'downloading',
+        progress: null,
+        indeterminate: true
+      })
+      return
+    }
+
+    monitor.addEventListener('downloadprogress', event => {
+      setDownloadProgress(event?.loaded)
+    })
+  }
+
+  function createTranslator({monitor = false, operation = 'download'} = {}) {
+    ensureApi()
+
+    if (translator) {
+      return Promise.resolve(translator)
+    }
+    if (createPromise) {
+      return createPromise
+    }
+
+    const options = {
+      ...CHROME_TRANSLATOR_LANGUAGE_PAIR
+    }
+    if (monitor) {
+      options.monitor = attachDownloadMonitor
+    }
+
+    updateState({
+      phase: CHROME_TRANSLATOR_PHASES.DOWNLOADING,
+      availability: 'downloading',
+      progress: monitor ? null : state.progress,
+      indeterminate: monitor,
+      errorCode: null,
+      errorName: '',
+      errorMessage: ''
+    })
+
+    let result
+    try {
+      // Do not add an await before this call. Chrome checks user activation at
+      // Translator.create() time when a model download is required.
+      result = api.create(options)
+    } catch (error) {
+      result = Promise.reject(error)
+    }
+
+    createPromise = Promise.resolve(result)
+      .then(createdTranslator => {
+        if (!createdTranslator || typeof createdTranslator.translate !== 'function') {
+          throw new ChromeTranslatorError(
+            CHROME_TRANSLATOR_ERROR_CODES.INVALID_RESPONSE,
+            'Translator.create() did not return a usable translator.'
+          )
+        }
+
+        if (destroyed) {
+          return Promise.resolve(createdTranslator.destroy?.()).then(() => {
+            throw new ChromeTranslatorError(
+              CHROME_TRANSLATOR_ERROR_CODES.UNKNOWN,
+              'The Chrome Translator runtime has been destroyed.'
+            )
+          })
+        }
+
+        translator = createdTranslator
+        updateState({
+          phase: CHROME_TRANSLATOR_PHASES.AVAILABLE,
+          availability: 'available',
+          progress: 1,
+          indeterminate: false,
+          errorCode: null,
+          errorName: '',
+          errorMessage: ''
+        })
+        return translator
+      })
+      .catch(error => {
+        const normalized = normalizeChromeTranslatorError(error, operation)
+        updateState({
+          phase: CHROME_TRANSLATOR_PHASES.FAILED,
+          availability: operation === 'download' ? 'downloadable' : state.availability,
+          progress: null,
+          indeterminate: false,
+          errorCode: normalized.code,
+          errorName: normalized.errorName,
+          errorMessage: normalized.message
+        })
+        throw normalized
+      })
+      .finally(() => {
+        createPromise = null
+      })
+
+    return createPromise
+  }
+
+  async function refreshAvailability() {
+    ensureActive()
+    if (!api || typeof api.availability !== 'function') {
+      ensureApi({requireAvailability: true})
+    }
+    if (availabilityPromise) {
+      return availabilityPromise
+    }
+
+    availabilityPromise = Promise.resolve()
+      .then(() => api.availability({...CHROME_TRANSLATOR_LANGUAGE_PAIR}))
+      .then(availability => {
+        if (!CHROME_TRANSLATOR_AVAILABILITY.includes(availability)) {
+          throw availabilityError(
+            'The Translator API returned an unknown availability state.'
+          )
+        }
+
+        if (createPromise || translator) {
+          return currentState()
+        }
+
+        updateState({
+          availability,
+          phase: availabilityPhase(availability),
+          progress: availability === 'available' ? 1 : null,
+          indeterminate: availability === 'downloading',
+          errorCode: null,
+          errorName: '',
+          errorMessage: ''
+        })
+        return currentState()
+      })
+      .catch(error => {
+        const normalized = normalizeChromeTranslatorError(error, 'availability')
+        updateState({
+          phase: CHROME_TRANSLATOR_PHASES.UNAVAILABLE,
+          availability: 'unavailable',
+          progress: null,
+          indeterminate: false,
+          errorCode: normalized.code,
+          errorName: normalized.errorName,
+          errorMessage: normalized.message
+        })
+        throw normalized
+      })
+      .finally(() => {
+        availabilityPromise = null
+      })
+
+    return availabilityPromise
+  }
+
+  function download() {
+    ensureApi()
+    if (translator) {
+      return Promise.resolve(translator)
+    }
+    if (state.availability === 'unavailable') {
+      return Promise.reject(availabilityError(
+        'The English to Korean Translator model is unavailable.'
+      ))
+    }
+    if (state.availability === 'downloading' && !createPromise) {
+      return Promise.reject(new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.MODEL_NOT_READY,
+        'The English to Korean Translator model is already downloading.'
+      ))
+    }
+    // This is intentionally not async and does not await availability(). The
+    // caller must invoke it from the click handler that starts the download.
+    return createTranslator({monitor: true, operation: 'download'})
+  }
+
+  async function getTranslatorForTranslation() {
+    ensureApi()
+    if (translator) {
+      return translator
+    }
+
+    if (!state.availability) {
+      await refreshAvailability()
+    }
+
+    if (state.availability === 'unavailable') {
+      throw new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.UNAVAILABLE,
+        'The English to Korean Translator model is unavailable.'
+      )
+    }
+    if (state.availability === 'downloadable' ||
+        state.availability === 'downloading' ||
+        state.phase === CHROME_TRANSLATOR_PHASES.FAILED) {
+      throw new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.MODEL_NOT_READY,
+        'The English to Korean Translator model is not ready.'
+      )
+    }
+
+    return createTranslator({monitor: false, operation: 'translate'})
+  }
+
+  async function translate(text) {
+    const value = typeof text === 'string' ? text.trim() : ''
+    if (!value) {
+      throw new ChromeTranslatorError(
+        CHROME_TRANSLATOR_ERROR_CODES.INVALID_RESPONSE,
+        'The translation text is empty.'
+      )
+    }
+
+    const currentTranslator = await getTranslatorForTranslation()
+    try {
+      const result = await currentTranslator.translate(value)
+      if (typeof result !== 'string' || !result.trim()) {
+        throw new ChromeTranslatorError(
+          CHROME_TRANSLATOR_ERROR_CODES.INVALID_RESPONSE,
+          'Translator.translate() did not return translated text.'
+        )
+      }
+      return result
+    } catch (error) {
+      throw normalizeChromeTranslatorError(error, 'translate')
+    }
+  }
+
+  async function destroy() {
+    destroyed = true
+    listeners.clear()
+    availabilityPromise = null
+    createPromise = null
+    const currentTranslator = translator
+    translator = null
+    if (typeof currentTranslator?.destroy === 'function') {
+      await currentTranslator.destroy()
+    }
+  }
+
+  return {
+    getState: currentState,
+    subscribe(listener) {
+      if (typeof listener !== 'function') {
+        return () => {}
+      }
+      listeners.add(listener)
+      listener(currentState())
+      return () => listeners.delete(listener)
+    },
+    refreshAvailability,
+    download,
+    translate,
+    destroy,
+    getTranslator() {
+      return translator
+    }
+  }
+}
+
+export const createChromeTranslator = createChromeTranslatorRuntime

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -170,7 +170,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
     </section>
 
     <section
-      v-else-if="pageId === 'double-click'"
+      v-if="pageId === 'double-click'"
       class="settings-card"
       data-testid="settings-double-click-form"
     >
@@ -237,7 +237,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
     </section>
 
     <section
-      v-else-if="pageId === 'behavior'"
+      v-if="pageId === 'behavior'"
       class="settings-card"
       data-testid="settings-behavior-form"
     >
@@ -284,7 +284,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
     </section>
 
     <section
-      v-else-if="pageId === 'blocked-sites'"
+      v-if="pageId === 'blocked-sites'"
       class="settings-card"
       data-testid="settings-blocked-sites-form"
     >
@@ -358,8 +358,9 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
       </div>
     </section>
 
-    <KeepAlive v-else-if="pageId === 'translation-service'">
+    <KeepAlive>
       <TranslationSettings
+        v-if="pageId === 'translation-service'"
         :draft="draft"
         :draft-secrets="draftSecrets"
         :draft-revision="draftRevision"
@@ -369,7 +370,10 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
       />
     </KeepAlive>
 
-    <section v-else class="settings-card settings-card--placeholder">
+    <section
+      v-if="!['appearance', 'double-click', 'behavior', 'blocked-sites', 'translation-service'].includes(pageId)"
+      class="settings-card settings-card--placeholder"
+    >
       <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>
       <p>{{ text('SETTINGS_SHELL_PLACEHOLDER_DESCRIPTION') }}</p>
       <div class="settings-placeholder-card__note">

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -26,6 +26,10 @@ const props = defineProps({
     type: Number,
     default: 0
   },
+  draftResetRevision: {
+    type: Number,
+    default: 0
+  },
   isLoading: {
     type: Boolean,
     default: false
@@ -364,6 +368,7 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
         :draft="draft"
         :draft-secrets="draftSecrets"
         :draft-revision="draftRevision"
+        :draft-reset-revision="draftResetRevision"
         :is-loading="isLoading"
         :is-saving="isSaving"
         :on-pending-change="translationPendingChange"

--- a/src/components/SettingsPage.vue
+++ b/src/components/SettingsPage.vue
@@ -37,6 +37,10 @@ const props = defineProps({
   resetDraft: {
     type: Function,
     default: null
+  },
+  translationPendingChange: {
+    type: Function,
+    default: null
   }
 })
 
@@ -354,14 +358,16 @@ watch(() => props.draftRevision, syncSiteInput, {immediate: true})
       </div>
     </section>
 
-    <TranslationSettings
-      v-else-if="pageId === 'translation-service'"
-      :draft="draft"
-      :draft-secrets="draftSecrets"
-      :draft-revision="draftRevision"
-      :is-loading="isLoading"
-      :is-saving="isSaving"
-    />
+    <KeepAlive v-else-if="pageId === 'translation-service'">
+      <TranslationSettings
+        :draft="draft"
+        :draft-secrets="draftSecrets"
+        :draft-revision="draftRevision"
+        :is-loading="isLoading"
+        :is-saving="isSaving"
+        :on-pending-change="translationPendingChange"
+      />
+    </KeepAlive>
 
     <section v-else class="settings-card settings-card--placeholder">
       <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>

--- a/src/components/SettingsPreview.vue
+++ b/src/components/SettingsPreview.vue
@@ -95,12 +95,14 @@ const translationHasCredential = computed(() => {
       <span class="settings-translation-preview__service-button">
         {{ text('SETTINGS_TRANSLATION_SERVICE_SETTINGS') }}
       </span>
-      <label class="settings-translation-preview__label">
-        {{ text('SETTINGS_TRANSLATION_API_KEY') }}
-      </label>
-      <div class="settings-translation-preview__secret">
-        {{ translationHasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_EMPTY') }}
-      </div>
+      <template v-if="translationProvider?.id !== 'chrome-translator'">
+        <label class="settings-translation-preview__label">
+          {{ text('SETTINGS_TRANSLATION_API_KEY') }}
+        </label>
+        <div class="settings-translation-preview__secret">
+          {{ translationHasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_EMPTY') }}
+        </div>
+      </template>
       <p class="settings-translation-preview__hint">
         {{ translationProvider?.id === 'chrome-translator'
           ? text('SETTINGS_TRANSLATION_CHROME_PREVIEW_HINT')

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -30,6 +30,7 @@ const isLoading = ref(true)
 const isSaving = ref(false)
 const migrationPending = ref(false)
 const draftRevision = ref(0)
+const draftResetRevision = ref(0)
 const hasLoadError = ref(false)
 const saveState = ref('idle')
 const translationEditorDirty = ref(false)
@@ -111,6 +112,7 @@ function resetDraft() {
 
   replaceReactive(draftSettings, defaultSettings)
   replaceReactive(draftSecrets, defaultSecrets)
+  draftResetRevision.value += 1
   draftRevision.value += 1
   setTranslationEditorDirty(false)
   saveState.value = 'reset'
@@ -237,6 +239,7 @@ defineExpose({
   draftSettings,
   draftSecrets,
   draftRevision,
+  draftResetRevision,
   hasPendingChanges,
   initializeSettings,
   isLoading,
@@ -367,6 +370,7 @@ onBeforeUnmount(() => {
             :draft="draftSettings"
             :draft-secrets="draftSecrets"
             :draft-revision="draftRevision"
+            :draft-reset-revision="draftResetRevision"
             :is-loading="isLoading"
             :is-saving="isSaving"
             :reset-draft="resetDraft"

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -13,6 +13,7 @@ import {
   saveSettingsV2,
   shouldWarnBeforeUnload
 } from '/src/settings-v2-storage.mjs'
+import {hasPendingTranslationChanges} from '/src/translation-settings-state.mjs'
 
 const navigation = SETTINGS_NAVIGATION
 const activeNavigationId = ref(navigation[0].id)
@@ -31,6 +32,7 @@ const migrationPending = ref(false)
 const draftRevision = ref(0)
 const hasLoadError = ref(false)
 const saveState = ref('idle')
+const translationEditorDirty = ref(false)
 
 const currentNavigation = computed(() => navigation.find(item => (
   item.id === activeNavigationId.value
@@ -49,11 +51,12 @@ function replaceReactive(target, source) {
   Object.assign(target, cloneValue(source))
 }
 
-const hasPendingChanges = computed(() => (
+const hasPendingChanges = computed(() => hasPendingTranslationChanges(
   hasPendingSettingsChanges(
     {settings: persistedSettings, secrets: persistedSecrets},
     {settings: draftSettings, secrets: draftSecrets}
-  )
+  ),
+  translationEditorDirty.value
 ))
 
 const canSave = computed(() => (
@@ -95,6 +98,10 @@ function text(key, placeholders = undefined) {
   return getText(key, placeholders)
 }
 
+function setTranslationEditorDirty(value) {
+  translationEditorDirty.value = Boolean(value)
+}
+
 function resetDraft() {
   const confirmMessage = text('SETTINGS_SHELL_RESET_CONFIRM')
   const confirmFn = globalThis.confirm
@@ -105,6 +112,7 @@ function resetDraft() {
   replaceReactive(draftSettings, defaultSettings)
   replaceReactive(draftSecrets, defaultSecrets)
   draftRevision.value += 1
+  setTranslationEditorDirty(false)
   saveState.value = 'reset'
 }
 
@@ -155,6 +163,10 @@ async function saveDraft() {
     replaceReactive(draftSettings, saved.settings)
     replaceReactive(draftSecrets, saved.secrets)
     draftRevision.value += 1
+    // A Custom provider editor only reports dirty until its own validated
+    // form save commits the provider into draftSettings/draftSecrets. Keep
+    // this flag intact here so a top-level save cannot silently discard an
+    // editor that has not been committed yet.
     migrationPending.value = false
     hasLoadError.value = false
     saveState.value = 'success'
@@ -235,7 +247,9 @@ defineExpose({
   persistedSecrets,
   resetDraft,
   saveDraft,
-  selectNavigation
+  selectNavigation,
+  setTranslationEditorDirty,
+  translationEditorDirty
 })
 
 onMounted(() => {
@@ -356,6 +370,7 @@ onBeforeUnmount(() => {
             :is-loading="isLoading"
             :is-saving="isSaving"
             :reset-draft="resetDraft"
+            :translation-pending-change="setTranslationEditorDirty"
           >
             <div class="settings-placeholder-card" data-testid="settings-page-placeholder">
               <h3>{{ text('SETTINGS_SHELL_PLACEHOLDER_TITLE') }}</h3>

--- a/src/components/SettingsShell.vue
+++ b/src/components/SettingsShell.vue
@@ -336,10 +336,11 @@ onBeforeUnmount(() => {
 
       <section
         class="settings-content"
+        :class="{'settings-content--translation': currentNavigation.id === 'translation-service'}"
         :aria-labelledby="`settings-page-title-${currentNavigation.id}`"
       >
         <div class="settings-form-column">
-          <div class="settings-page-heading">
+          <div v-if="currentNavigation.id !== 'translation-service'" class="settings-page-heading">
             <h2 :id="`settings-page-title-${currentNavigation.id}`">
               {{ text(currentNavigation.titleKey) }}
             </h2>
@@ -381,6 +382,7 @@ onBeforeUnmount(() => {
         </div>
 
         <aside
+          v-if="currentNavigation.id !== 'translation-service'"
           class="settings-preview-column"
           :aria-label="text('SETTINGS_SHELL_PREVIEW_TITLE')"
         >
@@ -596,6 +598,15 @@ a {
   background: var(--naverdic-settings-page);
 }
 
+.settings-content--translation {
+  grid-template-columns: minmax(0, 300px) minmax(0, 556px);
+  gap: 28px;
+}
+
+.settings-content--translation .settings-form-column {
+  grid-column: 1 / -1;
+}
+
 .settings-form-column,
 .settings-preview-column {
   min-width: 0;
@@ -689,6 +700,10 @@ a {
 @media (max-width: 1050px) {
   .settings-content {
     grid-template-columns: minmax(0, 556px);
+  }
+
+  .settings-content--translation {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .settings-preview-column {

--- a/src/components/TranslationSettings.vue
+++ b/src/components/TranslationSettings.vue
@@ -20,6 +20,7 @@ import {
 import {
   canActivateTranslationProvider,
   getTranslationSettingsPanel,
+  isTranslationConnectionLocked,
   TRANSLATION_SETTINGS_PANELS
 } from '/src/translation-settings-state.mjs'
 import {
@@ -759,7 +760,7 @@ watch(() => props.draftRevision, () => {
   loadEditorDraft(selectedProviderId.value)
 })
 
-if (ownsChromeRuntime && typeof chromeRuntime.subscribe === 'function') {
+if (typeof chromeRuntime.subscribe === 'function') {
   chromeRuntime.subscribe(state => {
     chromeState.value = state
   })

--- a/src/components/TranslationSettings.vue
+++ b/src/components/TranslationSettings.vue
@@ -1,6 +1,11 @@
 <script setup>
-import { computed, reactive, ref, watch } from 'vue'
-import { getText } from '/src/text.js'
+import {computed, onBeforeUnmount, reactive, ref, watch} from 'vue'
+import {getText} from '/src/text.js'
+import {
+  CHROME_TRANSLATOR_ERROR_CODES,
+  CHROME_TRANSLATOR_PHASES,
+  createChromeTranslatorRuntime
+} from '/src/chrome-translator.mjs'
 import {
   PROVIDER_AUTH_MODES,
   PROVIDER_SOURCES,
@@ -13,102 +18,139 @@ import {
   validateCustomProviderForm
 } from '/src/translation-settings.mjs'
 import {
+  hasTranslationProviderPermission,
   requestTranslationProviderPermission,
   testTranslationProvider
 } from '/src/translation-testing.mjs'
+import {getProviderOriginPattern} from '/src/provider-permissions.mjs'
 
 const props = defineProps({
-  draft: {
-    type: Object,
-    required: true
-  },
-  draftSecrets: {
-    type: Object,
-    required: true
-  },
-  draftRevision: {
-    type: Number,
-    default: 0
-  },
-  isLoading: {
-    type: Boolean,
-    default: false
-  },
-  isSaving: {
-    type: Boolean,
-    default: false
-  }
+  draft: {type: Object, required: true},
+  draftSecrets: {type: Object, required: true},
+  draftRevision: {type: Number, default: 0},
+  isLoading: {type: Boolean, default: false},
+  isSaving: {type: Boolean, default: false},
+  // Tests can inject a fake runtime without changing the production
+  // document-bound Translator lifecycle.
+  translatorRuntime: {type: Object, default: null}
 })
 
-const presetCards = Object.freeze([
+const CHROME_ID = 'chrome-translator'
+const CUSTOM_NEW_ID = '__new-custom-api__'
+const PRESET_IDS = new Set(['deepl-free', 'deepl-pro', 'gemini'])
+const serviceDefinitions = Object.freeze([
+  Object.freeze({
+    id: CHROME_ID,
+    providerIds: Object.freeze([CHROME_ID]),
+    nameKey: 'SETTINGS_TRANSLATION_CHROME_NAME',
+    descriptionKey: 'SETTINGS_TRANSLATION_CHROME_DESCRIPTION',
+    icon: 'C'
+  }),
   Object.freeze({
     id: 'deepl',
     providerIds: Object.freeze(['deepl-free', 'deepl-pro']),
     nameKey: 'SETTINGS_TRANSLATION_DEEPL_NAME',
-    descriptionKey: 'SETTINGS_TRANSLATION_DEEPL_DESCRIPTION'
+    descriptionKey: 'SETTINGS_TRANSLATION_DEEPL_DESCRIPTION',
+    icon: 'D'
   }),
   Object.freeze({
     id: 'gemini',
     providerIds: Object.freeze(['gemini']),
     nameKey: 'SETTINGS_TRANSLATION_GEMINI_NAME',
-    descriptionKey: 'SETTINGS_TRANSLATION_GEMINI_DESCRIPTION'
+    descriptionKey: 'SETTINGS_TRANSLATION_GEMINI_DESCRIPTION',
+    icon: 'G'
   })
 ])
 
-const editorMode = ref('')
-const editorProviderId = ref('')
-const editorForm = reactive(createCustomProviderForm())
-const formErrors = ref([])
-const showApiKey = ref(false)
-const connectionState = ref('idle')
-const connectionMessageKey = ref('')
-const providerSelectionState = ref('idle')
-const providerSelectionMessageKey = ref('')
-let connectionRequestId = 0
-let providerSelectionRequestId = 0
-
-const controlsDisabled = computed(() => props.isLoading || props.isSaving)
-const connectionTesting = computed(() => connectionState.value === 'testing')
-const interactionDisabled = computed(() => (
-  controlsDisabled.value ||
-  connectionTesting.value ||
-  providerSelectionState.value === 'requesting'
-))
-const editorControlsDisabled = computed(() => (
-  controlsDisabled.value ||
-  connectionTesting.value ||
-  providerSelectionState.value === 'requesting'
-))
 const translation = computed(() => props.draft.translation || {})
 const customProviders = computed(() => props.draft.customProviders || {})
 const activeProviderId = computed(() => translation.value.providerId || 'deepl-free')
-const editorProvider = computed(() => {
-  if (!editorProviderId.value) {
+const selectedProviderId = ref(activeProviderId.value)
+const selectedPresetId = computed(() => (
+  PRESET_IDS.has(selectedProviderId.value) ? selectedProviderId.value : ''
+))
+const selectedProvider = computed(() => {
+  if (selectedProviderId.value === CUSTOM_NEW_ID) {
     return null
   }
-
-  return getProviderPreset(editorProviderId.value) ||
-    customProviders.value[editorProviderId.value] ||
+  return getProviderPreset(selectedProviderId.value) ||
+    customProviders.value[selectedProviderId.value] ||
     null
 })
-const isEditingCustom = computed(() => editorMode.value === 'custom')
-const editorHasCredential = computed(() => Boolean(
-  editorProvider.value && getProviderCredential(editorProvider.value, props.draftSecrets)
+const selectedIsChrome = computed(() => selectedProviderId.value === CHROME_ID)
+const selectedIsCustom = computed(() => (
+  selectedProviderId.value === CUSTOM_NEW_ID ||
+  customProviders.value[selectedProviderId.value]?.source === PROVIDER_SOURCES.CUSTOM
 ))
-const customProviderIds = computed(() => Object.keys(customProviders.value))
-const providerCards = computed(() => [
-  ...presetCards,
-  ...customProviderIds.value.map(id => ({
-    id,
-    providerIds: [id],
-    name: customProviders.value[id]?.name || id,
-    descriptionKey: 'SETTINGS_TRANSLATION_CUSTOM_DESCRIPTION',
-    custom: true
-  }))
-])
+const customPermissionPattern = computed(() => getProviderOriginPattern(editorForm.url))
+const isDeepL = computed(() => selectedProviderId.value === 'deepl-free' || selectedProviderId.value === 'deepl-pro')
+const controlsDisabled = computed(() => props.isLoading || props.isSaving)
+
+const connectionStates = reactive({})
+const permissionStates = reactive({})
+const customDrafts = reactive({})
+const editorForm = reactive(createCustomProviderForm())
+const editorProviderId = ref('')
+const editorBaseline = ref('')
+const editorDirty = ref(false)
+const formErrors = ref([])
+const showApiKey = ref(false)
+const permissionRequestState = ref('idle')
+let connectionRequestId = 0
+let permissionRequestId = 0
+
+const chromeState = ref({
+  supported: false,
+  availability: null,
+  phase: CHROME_TRANSLATOR_PHASES.CHECKING,
+  progress: null,
+  indeterminate: false,
+  errorCode: null,
+  errorName: '',
+  errorMessage: ''
+})
+const chromeRuntime = props.translatorRuntime || createChromeTranslatorRuntime({
+  scope: globalThis,
+  onStateChange: state => {
+    chromeState.value = state
+  }
+})
+const ownsChromeRuntime = !props.translatorRuntime
 
 function text(key, placeholders = undefined) {
   return getText(key, placeholders)
+}
+
+function providerForId(providerId) {
+  return getProviderPreset(providerId) || customProviders.value[providerId] || null
+}
+
+function stateFor(providerId) {
+  return connectionStates[providerId] || {status: 'idle', messageKey: '', signature: ''}
+}
+
+function providerCredential(provider) {
+  return getProviderCredential(provider, props.draftSecrets)
+}
+
+function providerSignature(provider, providerId = provider?.id || '') {
+  if (!provider) {
+    return `${providerId}:empty`
+  }
+  return JSON.stringify({provider, credential: providerCredential(provider)})
+}
+
+function formSignature(provider, credential = '') {
+  return JSON.stringify({provider, credential})
+}
+
+function isConnectionSuccess(providerId) {
+  const state = stateFor(providerId)
+  return state.status === 'success' && state.signature === providerSignature(providerForId(providerId), providerId)
+}
+
+function selectedConnectionState() {
+  return stateFor(selectedProviderId.value)
 }
 
 function ensureDraftProviders() {
@@ -125,170 +167,122 @@ function ensureDraftSecrets() {
   return props.draftSecrets.providers
 }
 
-function providerForId(providerId) {
-  return getProviderPreset(providerId) || customProviders.value[providerId] || null
+function setConnectionState(providerId, patch) {
+  connectionStates[providerId] = {...stateFor(providerId), ...patch}
 }
 
-function isCardActive(card) {
-  return card.providerIds.includes(activeProviderId.value)
+function invalidateConnectionState(providerId = selectedProviderId.value) {
+  connectionRequestId += 1
+  setConnectionState(providerId, {status: 'idle', messageKey: '', signature: ''})
+}
+
+function serviceCards() {
+  return [
+    ...serviceDefinitions,
+    ...Object.keys(customProviders.value).map(id => ({
+      id,
+      providerIds: [id],
+      name: customProviders.value[id]?.name || id,
+      descriptionKey: 'SETTINGS_TRANSLATION_CUSTOM_DESCRIPTION',
+      icon: 'A',
+      custom: true
+    }))
+  ]
 }
 
 function cardProviderId(card) {
   if (card.id === 'deepl' && card.providerIds.includes(activeProviderId.value)) {
     return activeProviderId.value
   }
-
   return card.providerIds[0]
 }
 
-function providerName(card) {
+function cardName(card) {
   return card.name || text(card.nameKey)
 }
 
-async function requestCustomProviderAccess(provider) {
-  if (provider?.source !== PROVIDER_SOURCES.CUSTOM) {
-    return true
-  }
-
-  const requestId = ++providerSelectionRequestId
-  providerSelectionState.value = 'requesting'
-  providerSelectionMessageKey.value = 'SETTINGS_TRANSLATION_PERMISSION_REQUESTING'
-  const granted = await requestTranslationProviderPermission(provider)
-
-  if (requestId !== providerSelectionRequestId) {
-    return false
-  }
-
-  if (!granted) {
-    providerSelectionState.value = 'error'
-    providerSelectionMessageKey.value = 'SETTINGS_TRANSLATION_PERMISSION_REQUIRED'
-    return false
-  }
-
-  providerSelectionState.value = 'idle'
-  providerSelectionMessageKey.value = ''
-  return true
+function cardIsSelected(card) {
+  return card.providerIds.includes(selectedProviderId.value)
 }
 
-async function selectProvider(providerId) {
-  if (interactionDisabled.value || !providerForId(providerId)) {
-    return false
-  }
-
-  const provider = providerForId(providerId)
-  providerSelectionState.value = 'idle'
-  providerSelectionMessageKey.value = ''
-
-  if (!await requestCustomProviderAccess(provider)) {
-    return false
-  }
-
-  props.draft.translation.providerId = providerId
-  providerSelectionState.value = 'idle'
-  providerSelectionMessageKey.value = ''
-  invalidateConnectionState()
-  return true
+function cardIsActive(card) {
+  return card.providerIds.includes(activeProviderId.value)
 }
 
-function selectProviderFromControl(event) {
-  selectProvider(event.target.value)
+function cardStatusKey(card) {
+  const providerId = cardProviderId(card)
+  if (providerId === CHROME_ID) {
+    if (chromeState.value.phase === CHROME_TRANSLATOR_PHASES.AVAILABLE) {
+      return 'SETTINGS_TRANSLATION_STATUS_READY'
+    }
+    if (chromeState.value.phase === CHROME_TRANSLATOR_PHASES.DOWNLOADING) {
+      return 'SETTINGS_TRANSLATION_STATUS_DOWNLOADING'
+    }
+    if (chromeState.value.phase === CHROME_TRANSLATOR_PHASES.UNSUPPORTED ||
+        chromeState.value.phase === CHROME_TRANSLATOR_PHASES.UNAVAILABLE) {
+      return 'SETTINGS_TRANSLATION_STATUS_UNAVAILABLE'
+    }
+    if (chromeState.value.phase === CHROME_TRANSLATOR_PHASES.FAILED) {
+      return 'SETTINGS_TRANSLATION_STATUS_ERROR'
+    }
+    return 'SETTINGS_TRANSLATION_STATUS_SETUP'
+  }
+
+  const state = stateFor(providerId)
+  if (state.status === 'success' && isConnectionSuccess(providerId)) {
+    return 'SETTINGS_TRANSLATION_STATUS_CONNECTED'
+  }
+  if (state.status === 'error') {
+    return 'SETTINGS_TRANSLATION_STATUS_ERROR'
+  }
+  if (card.custom && permissionStates[providerId] !== 'allowed') {
+    return 'SETTINGS_TRANSLATION_STATUS_PERMISSION'
+  }
+  if (providerCredential(providerForId(providerId))) {
+    return 'SETTINGS_TRANSLATION_STATUS_SETUP'
+  }
+  return 'SETTINGS_TRANSLATION_STATUS_SETUP'
+}
+
+function cardStatusClass(card) {
+  const key = cardStatusKey(card)
+  return key.endsWith('CONNECTED') || key.endsWith('READY')
+    ? 'connected'
+    : key.endsWith('ERROR') || key.endsWith('UNAVAILABLE') ? 'error' : 'setup'
+}
+
+function selectService(providerId) {
+  if (controlsDisabled.value) {
+    return
+  }
+  if (providerId !== CUSTOM_NEW_ID && !providerForId(providerId)) {
+    return
+  }
+  selectedProviderId.value = providerId
 }
 
 function selectCard(card) {
-  selectProvider(cardProviderId(card))
+  selectService(cardProviderId(card))
 }
 
 function toggleTranslation(event) {
-  if (!interactionDisabled.value) {
+  if (!controlsDisabled.value) {
     props.draft.translation.enabled = event.target.checked
   }
 }
 
-function openPresetEditor(providerId) {
-  if (interactionDisabled.value) {
-    return
-  }
-
-  editorMode.value = 'preset'
-  editorProviderId.value = providerId
-  formErrors.value = []
-  showApiKey.value = false
-  connectionState.value = 'idle'
-  connectionMessageKey.value = ''
-}
-
-function openCustomEditor(providerId) {
-  if (interactionDisabled.value) {
-    return
-  }
-
-  const provider = customProviders.value[providerId]
-  if (!provider) {
-    return
-  }
-
-  Object.assign(editorForm, createCustomProviderForm(provider, props.draftSecrets))
-  editorMode.value = 'custom'
-  editorProviderId.value = providerId
-  formErrors.value = []
-  showApiKey.value = false
-  connectionState.value = 'idle'
-  connectionMessageKey.value = ''
-}
-
-function openProviderSettings(card) {
-  if (card.custom) {
-    openCustomEditor(card.id)
-    return
-  }
-
-  openPresetEditor(cardProviderId(card))
-}
-
-function startCustomProvider() {
-  if (interactionDisabled.value) {
-    return
-  }
-
-  Object.assign(editorForm, createCustomProviderForm())
-  editorMode.value = 'custom'
-  editorProviderId.value = ''
-  formErrors.value = []
-  showApiKey.value = false
-  connectionState.value = 'idle'
-  connectionMessageKey.value = ''
-}
-
-function closeEditor() {
-  connectionRequestId += 1
-  providerSelectionRequestId += 1
-  editorMode.value = ''
-  editorProviderId.value = ''
-  formErrors.value = []
-  showApiKey.value = false
-  connectionState.value = 'idle'
-  connectionMessageKey.value = ''
-  providerSelectionState.value = 'idle'
-  providerSelectionMessageKey.value = ''
-}
-
 function setProviderSecret(provider, value) {
+  if (!provider?.id) {
+    return
+  }
   const providers = ensureDraftSecrets()
-  const secretField = provider?.auth?.secretRef?.split('.').pop() || 'apiKey'
+  const secretField = provider.auth?.secretRef?.split('.').pop() || 'apiKey'
   const current = providers[provider.id] || {}
-
-  if (value.trim()) {
-    providers[provider.id] = {
-      ...current,
-      [secretField]: value.trim()
-    }
+  const normalized = String(value || '').trim()
+  if (normalized) {
+    providers[provider.id] = {...current, [secretField]: normalized}
     return
   }
-
-  if (!current[secretField]) {
-    return
-  }
-
   const next = {...current}
   delete next[secretField]
   if (Object.keys(next).length) {
@@ -298,19 +292,70 @@ function setProviderSecret(provider, value) {
   }
 }
 
-function presetCredentialValue(provider) {
-  return provider ? getProviderCredential(provider, props.draftSecrets) : ''
-}
-
 function updatePresetCredential(event) {
-  setProviderSecret(editorProvider.value, event.target.value)
-  invalidateConnectionState()
+  setProviderSecret(selectedProvider.value, event.target.value)
+  invalidateConnectionState(selectedProviderId.value)
 }
 
-function switchDeepLVariant(event) {
-  const providerId = event.target.value
-  selectProvider(providerId)
-  editorProviderId.value = providerId
+function deletePresetCredential() {
+  setProviderSecret(selectedProvider.value, '')
+  invalidateConnectionState(selectedProviderId.value)
+  showApiKey.value = false
+}
+
+function switchDeepLVariant(providerId) {
+  selectService(providerId)
+}
+
+function customDraftKey() {
+  return editorProviderId.value || CUSTOM_NEW_ID
+}
+
+function cacheEditorDraft(providerId = selectedProviderId.value) {
+  if (!editorDirty.value || (
+    providerId !== CUSTOM_NEW_ID &&
+    customProviders.value[providerId]?.source !== PROVIDER_SOURCES.CUSTOM
+  )) {
+    return
+  }
+  customDrafts[providerId] = cloneProvider(editorForm)
+}
+
+function loadEditorDraft(providerId) {
+  const provider = providerId === CUSTOM_NEW_ID ? null : customProviders.value[providerId]
+  const form = customDrafts[providerId] || createCustomProviderForm(provider, props.draftSecrets)
+  Object.assign(editorForm, form)
+  editorProviderId.value = providerId === CUSTOM_NEW_ID ? '' : providerId
+  editorBaseline.value = JSON.stringify(editorForm)
+  editorDirty.value = false
+  formErrors.value = []
+  showApiKey.value = false
+}
+
+function startCustomProvider() {
+  cacheEditorDraft()
+  selectService(CUSTOM_NEW_ID)
+}
+
+function cancelCustomDraft() {
+  delete customDrafts[customDraftKey()]
+  if (editorProviderId.value) {
+    loadEditorDraft(editorProviderId.value)
+    return
+  }
+  selectService(activeProviderId.value)
+}
+
+function syncAuthDefaults() {
+  if (editorForm.authMode === PROVIDER_AUTH_MODES.BEARER &&
+      (!editorForm.authHeaderName || editorForm.authHeaderName === 'X-API-Key')) {
+    editorForm.authHeaderName = 'Authorization'
+    editorForm.authPrefix = 'Bearer '
+  } else if (editorForm.authMode === PROVIDER_AUTH_MODES.API_KEY &&
+      editorForm.authHeaderName === 'Authorization') {
+    editorForm.authHeaderName = 'X-API-Key'
+    editorForm.authPrefix = ''
+  }
 }
 
 function errorTextKey(error) {
@@ -327,968 +372,698 @@ function errorTextKey(error) {
     'invalid-auth-location': 'SETTINGS_TRANSLATION_VALIDATION_AUTH',
     'invalid-auth-header': 'SETTINGS_TRANSLATION_VALIDATION_AUTH',
     'required-response-path': 'SETTINGS_TRANSLATION_VALIDATION_RESPONSE',
-    'invalid-provider': 'SETTINGS_TRANSLATION_VALIDATION_INVALID'
+    'invalid-provider': 'SETTINGS_TRANSLATION_VALIDATION_INVALID',
+    'permission-or-test-required': 'SETTINGS_TRANSLATION_CUSTOM_TEST_REQUIRED'
   }
   return keys[error?.code] || 'SETTINGS_TRANSLATION_VALIDATION_INVALID'
 }
 
-function applyCustomCredential(provider, result, previousProvider = null) {
-  const providers = ensureDraftSecrets()
-  const previousValue = previousProvider
-    ? getProviderCredential(previousProvider, props.draftSecrets)
-    : ''
-  const value = result.credentialValue || previousValue
-
-  if (previousProvider && previousProvider.id !== result.provider.id) {
-    delete providers[previousProvider.id]
-  }
-
-  if (result.provider.auth.mode === PROVIDER_AUTH_MODES.NONE || result.clearCredential) {
-    delete providers[result.provider.id]
-    return
-  }
-
-  if (value) {
-    providers[result.provider.id] = {
-      [result.credentialField]: value
-    }
-  }
-}
-
-async function saveCustomProvider() {
-  if (editorControlsDisabled.value) {
-    return
-  }
-
-  const existingIds = customProviderIds.value
-  const result = validateCustomProviderForm(editorForm, {
-    existingIds,
+function currentCustomFormResult() {
+  return validateCustomProviderForm(editorForm, {
+    existingIds: Object.keys(customProviders.value),
     editingId: editorProviderId.value
   })
-  if (!result.valid) {
-    formErrors.value = result.errors
-    return
-  }
-
-  const providers = ensureDraftProviders()
-  const previousProvider = editorProviderId.value
-    ? providers[editorProviderId.value]
-    : null
-  const wasActive = activeProviderId.value === previousProvider?.id
-  if (wasActive && !await requestCustomProviderAccess(result.provider)) {
-    return
-  }
-
-  if (previousProvider && previousProvider.id !== result.provider.id) {
-    delete providers[previousProvider.id]
-  }
-  providers[result.provider.id] = result.provider
-  if (wasActive) {
-    props.draft.translation.providerId = result.provider.id
-  }
-  applyCustomCredential(result.provider, result, previousProvider)
-  closeEditor()
 }
 
-function deleteCustomProvider(providerId) {
-  if (interactionDisabled.value) {
-    return
-  }
-
-  const confirmFn = globalThis.confirm
-  const confirmed = typeof confirmFn !== 'function' || confirmFn(
-    text('SETTINGS_TRANSLATION_CUSTOM_DELETE_CONFIRM')
-  )
-  if (!confirmed) {
-    return
-  }
-
-  const providers = ensureDraftProviders()
-  delete providers[providerId]
-  const secrets = ensureDraftSecrets()
-  delete secrets[providerId]
-  if (props.draft.translation.providerId === providerId) {
-    props.draft.translation.providerId = 'deepl-free'
-  }
-  if (editorProviderId.value === providerId) {
-    closeEditor()
-  }
-}
-
-function customTestSecrets(result) {
+function customSecretsFor(result) {
   const secrets = cloneProvider(props.draftSecrets)
   if (!secrets.providers) {
     secrets.providers = {}
   }
-
-  const previousProvider = editorProviderId.value
-    ? customProviders.value[editorProviderId.value]
-    : null
-  const previousValue = previousProvider
-    ? getProviderCredential(previousProvider, props.draftSecrets)
-    : ''
+  const previousProvider = editorProviderId.value ? customProviders.value[editorProviderId.value] : null
+  const previousValue = previousProvider ? getProviderCredential(previousProvider, props.draftSecrets) : ''
   const value = result.credentialValue || previousValue
   if (previousProvider && previousProvider.id !== result.provider.id) {
     delete secrets.providers[previousProvider.id]
   }
-  if (result.provider.auth.mode !== PROVIDER_AUTH_MODES.NONE && value && !result.clearCredential) {
-    secrets.providers[result.provider.id] = {
-      [result.credentialField]: value
-    }
-  } else if (result.clearCredential || result.provider.auth.mode === PROVIDER_AUTH_MODES.NONE) {
+  if (result.provider.auth.mode === PROVIDER_AUTH_MODES.NONE || result.clearCredential) {
     delete secrets.providers[result.provider.id]
+  } else if (value) {
+    secrets.providers[result.provider.id] = {[result.credentialField]: value}
   }
   return secrets
 }
 
-async function runConnectionTest(provider, secrets = props.draftSecrets) {
-  if (!provider || controlsDisabled.value || connectionState.value === 'testing') {
+function applyCustomCredential(result, previousProvider = null) {
+  const providers = ensureDraftSecrets()
+  const previousValue = previousProvider ? getProviderCredential(previousProvider, props.draftSecrets) : ''
+  const value = result.credentialValue || previousValue
+  if (previousProvider && previousProvider.id !== result.provider.id) {
+    delete providers[previousProvider.id]
+  }
+  if (result.provider.auth.mode === PROVIDER_AUTH_MODES.NONE || result.clearCredential) {
+    delete providers[result.provider.id]
     return
   }
+  if (value) {
+    providers[result.provider.id] = {[result.credentialField]: value}
+  }
+}
 
-  if (provider.auth.mode !== PROVIDER_AUTH_MODES.NONE &&
-      !getProviderCredential(provider, secrets)) {
-    connectionState.value = 'error'
-    connectionMessageKey.value = 'SETTINGS_TRANSLATION_API_KEY_MISSING'
+function customProviderForTest(result) {
+  const existing = editorProviderId.value ? customProviders.value[editorProviderId.value] : null
+  return {
+    provider: result.provider,
+    credential: result.credentialValue || getProviderCredential(existing, props.draftSecrets)
+  }
+}
+
+async function refreshCustomPermission(provider, providerId = selectedProviderId.value) {
+  if (!provider || provider.source !== PROVIDER_SOURCES.CUSTOM) {
+    return true
+  }
+  const allowed = await hasTranslationProviderPermission(provider)
+  permissionStates[providerId] = allowed ? 'allowed' : 'required'
+  return allowed
+}
+
+async function requestCustomAccess(provider, providerId = selectedProviderId.value) {
+  if (!provider || provider.source !== PROVIDER_SOURCES.CUSTOM || controlsDisabled.value) {
+    return false
+  }
+  const requestId = ++permissionRequestId
+  permissionRequestState.value = 'requesting'
+  permissionStates[providerId] = 'requesting'
+  try {
+    const granted = await requestTranslationProviderPermission(provider)
+    if (requestId !== permissionRequestId) {
+      return false
+    }
+    permissionStates[providerId] = granted ? 'allowed' : 'required'
+    permissionRequestState.value = granted ? 'idle' : 'error'
+    return granted
+  } catch (_error) {
+    if (requestId === permissionRequestId) {
+      permissionStates[providerId] = 'required'
+      permissionRequestState.value = 'error'
+    }
+    return false
+  }
+}
+
+async function requestCustomPermissionFromForm() {
+  const result = currentCustomFormResult()
+  if (result.valid) {
+    await requestCustomAccess(result.provider, selectedProviderId.value)
+  } else {
+    formErrors.value = result.errors
+  }
+}
+
+async function runConnectionTest(provider, {
+  providerId = provider?.id || selectedProviderId.value,
+  secrets = props.draftSecrets,
+  signature = providerSignature(provider, providerId)
+} = {}) {
+  if (!provider || controlsDisabled.value || stateFor(providerId).status === 'testing') {
     return
   }
-
+  const credential = getProviderCredential(provider, secrets)
+  if (provider.auth.mode !== PROVIDER_AUTH_MODES.NONE && !credential) {
+    setConnectionState(providerId, {
+      status: 'error',
+      messageKey: 'SETTINGS_TRANSLATION_API_KEY_MISSING',
+      signature: ''
+    })
+    return
+  }
   const requestId = ++connectionRequestId
-  connectionState.value = 'testing'
-  connectionMessageKey.value = ''
+  setConnectionState(providerId, {status: 'testing', messageKey: '', signature})
   try {
     await testTranslationProvider(provider, {
       secrets,
       targetLanguage: translation.value.targetLanguage
     })
-    if (requestId !== connectionRequestId) {
+    if (requestId !== connectionRequestId || signature !== providerSignature(provider, providerId)) {
       return
     }
-    connectionState.value = 'success'
-    connectionMessageKey.value = 'SETTINGS_TRANSLATION_TEST_SUCCESS'
+    setConnectionState(providerId, {
+      status: 'success',
+      messageKey: 'SETTINGS_TRANSLATION_TEST_SUCCESS',
+      signature
+    })
   } catch (error) {
     if (requestId !== connectionRequestId) {
       return
     }
-    connectionState.value = 'error'
-    connectionMessageKey.value = error?.code === 'UNSUPPORTED_CONTEXT'
-      ? 'SETTINGS_TRANSLATION_TEST_UNSUPPORTED'
-      : 'SETTINGS_TRANSLATION_TEST_FAILURE'
+    setConnectionState(providerId, {
+      status: 'error',
+      messageKey: error?.code === 'PERMISSION_REQUIRED'
+        ? 'SETTINGS_TRANSLATION_PERMISSION_REQUIRED'
+        : 'SETTINGS_TRANSLATION_TEST_FAILURE',
+      signature: ''
+    })
   }
 }
 
 function testPresetConnection() {
-  runConnectionTest(editorProvider.value)
+  runConnectionTest(selectedProvider.value, {
+    providerId: selectedProviderId.value,
+    signature: providerSignature(selectedProvider.value, selectedProviderId.value)
+  })
 }
 
-function testCustomConnection() {
-  if (editorControlsDisabled.value) {
+async function testCustomConnection() {
+  if (controlsDisabled.value || selectedConnectionState().status === 'testing') {
     return
   }
-
-  const result = validateCustomProviderForm(editorForm, {
-    existingIds: customProviderIds.value,
-    editingId: editorProviderId.value
-  })
+  const result = currentCustomFormResult()
   if (!result.valid) {
     formErrors.value = result.errors
     return
   }
-
   formErrors.value = []
-  runConnectionTest(result.provider, customTestSecrets(result))
+  const testTarget = customProviderForTest(result)
+  const providerId = selectedProviderId.value
+  if (!await refreshCustomPermission(testTarget.provider, providerId)) {
+    setConnectionState(providerId, {
+      status: 'error',
+      messageKey: 'SETTINGS_TRANSLATION_PERMISSION_REQUIRED',
+      signature: ''
+    })
+    return
+  }
+  await runConnectionTest(testTarget.provider, {
+    providerId,
+    secrets: customSecretsFor(result),
+    signature: formSignature(testTarget.provider, testTarget.credential)
+  })
 }
 
-function invalidateConnectionState() {
-  if (connectionState.value === 'testing') {
+async function saveCustomProvider() {
+  if (controlsDisabled.value || selectedConnectionState().status === 'testing') {
+    return
+  }
+  const result = currentCustomFormResult()
+  if (!result.valid) {
+    formErrors.value = result.errors
+    return
+  }
+  const existingProvider = editorProviderId.value ? customProviders.value[editorProviderId.value] : null
+  const wasActive = activeProviderId.value === existingProvider?.id
+  const currentState = stateFor(selectedProviderId.value)
+  const testedSignature = formSignature(
+    result.provider,
+    result.credentialValue || getProviderCredential(existingProvider, props.draftSecrets)
+  )
+  if (wasActive && (currentState.status !== 'success' || currentState.signature !== testedSignature)) {
+    formErrors.value = [{code: 'permission-or-test-required'}]
     return
   }
 
-  connectionRequestId += 1
-  connectionState.value = 'idle'
-  connectionMessageKey.value = ''
+  const providers = ensureDraftProviders()
+  if (existingProvider && existingProvider.id !== result.provider.id) {
+    delete providers[existingProvider.id]
+  }
+  providers[result.provider.id] = result.provider
+  applyCustomCredential(result, existingProvider)
+  delete customDrafts[customDraftKey()]
+  customDrafts[result.provider.id] = cloneProvider(editorForm)
+  selectedProviderId.value = result.provider.id
+  loadEditorDraft(result.provider.id)
+  if (currentState.status === 'success' && currentState.signature === testedSignature) {
+    connectionStates[result.provider.id] = {
+      ...currentState,
+      signature: providerSignature(result.provider, result.provider.id)
+    }
+  } else {
+    invalidateConnectionState(result.provider.id)
+  }
+  await refreshCustomPermission(result.provider, result.provider.id)
 }
 
-function syncAuthDefaults() {
-  if (editorForm.authMode === PROVIDER_AUTH_MODES.BEARER &&
-      (!editorForm.authHeaderName || editorForm.authHeaderName === 'X-API-Key')) {
-    editorForm.authHeaderName = 'Authorization'
-    editorForm.authPrefix = 'Bearer '
-  } else if (editorForm.authMode === PROVIDER_AUTH_MODES.API_KEY &&
-      editorForm.authHeaderName === 'Authorization') {
-    editorForm.authHeaderName = 'X-API-Key'
-    editorForm.authPrefix = ''
+function deleteCustomProvider(providerId) {
+  if (controlsDisabled.value) {
+    return
+  }
+  const confirmFn = globalThis.confirm
+  const confirmed = typeof confirmFn !== 'function' || confirmFn(text('SETTINGS_TRANSLATION_CUSTOM_DELETE_CONFIRM'))
+  if (!confirmed) {
+    return
+  }
+  delete ensureDraftProviders()[providerId]
+  delete ensureDraftSecrets()[providerId]
+  delete customDrafts[providerId]
+  delete connectionStates[providerId]
+  delete permissionStates[providerId]
+  if (activeProviderId.value === providerId) {
+    props.draft.translation.providerId = 'deepl-free'
+  }
+  if (selectedProviderId.value === providerId) {
+    selectedProviderId.value = activeProviderId.value === providerId ? 'deepl-free' : activeProviderId.value
   }
 }
 
-watch(() => props.draftRevision, () => {
-  if (editorMode.value !== 'custom' || !editorProviderId.value) {
+function canActivateSelected() {
+  if (selectedIsChrome.value) {
+    return chromeState.value.phase === CHROME_TRANSLATOR_PHASES.AVAILABLE
+  }
+  if (selectedIsCustom.value) {
+    return Boolean(
+      selectedProvider.value &&
+      permissionStates[selectedProviderId.value] === 'allowed' &&
+      stateFor(selectedProviderId.value).status === 'success' &&
+      isConnectionSuccess(selectedProviderId.value)
+    )
+  }
+  return Boolean(
+    selectedProvider.value &&
+    providerCredential(selectedProvider.value) &&
+    stateFor(selectedProviderId.value).status === 'success' &&
+    isConnectionSuccess(selectedProviderId.value)
+  )
+}
+
+function activateSelectedProvider() {
+  if (controlsDisabled.value || !canActivateSelected()) {
     return
   }
+  props.draft.translation.providerId = selectedProviderId.value
+  if (selectedIsChrome.value) {
+    props.draft.translation.targetLanguage = 'ko'
+  }
+}
 
-  const provider = customProviders.value[editorProviderId.value]
-  if (!provider) {
-    closeEditor()
+function chromeStatusTextKey() {
+  switch (chromeState.value.phase) {
+    case CHROME_TRANSLATOR_PHASES.UNSUPPORTED:
+      return 'SETTINGS_TRANSLATION_CHROME_UNSUPPORTED'
+    case CHROME_TRANSLATOR_PHASES.UNAVAILABLE:
+      return 'SETTINGS_TRANSLATION_CHROME_MODEL_UNAVAILABLE'
+    case CHROME_TRANSLATOR_PHASES.DOWNLOADING:
+      return 'SETTINGS_TRANSLATION_CHROME_MODEL_DOWNLOADING'
+    case CHROME_TRANSLATOR_PHASES.AVAILABLE:
+      return 'SETTINGS_TRANSLATION_CHROME_MODEL_READY'
+    case CHROME_TRANSLATOR_PHASES.FAILED:
+      return 'SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED'
+    default:
+      return 'SETTINGS_TRANSLATION_CHROME_MODEL_NEEDED'
+  }
+}
+
+function chromeErrorTextKey() {
+  if (chromeState.value.errorCode === CHROME_TRANSLATOR_ERROR_CODES.NETWORK) {
+    return 'SETTINGS_TRANSLATION_CHROME_NETWORK_ERROR'
+  }
+  if (chromeState.value.errorCode === CHROME_TRANSLATOR_ERROR_CODES.NOT_ALLOWED) {
+    return 'SETTINGS_TRANSLATION_CHROME_PERMISSION_ERROR'
+  }
+  if (chromeState.value.errorCode === CHROME_TRANSLATOR_ERROR_CODES.NOT_SUPPORTED) {
+    return 'SETTINGS_TRANSLATION_CHROME_UNSUPPORTED'
+  }
+  return 'SETTINGS_TRANSLATION_CHROME_DOWNLOAD_FAILED_HINT'
+}
+
+function refreshChromeAvailability() {
+  if (!selectedIsChrome.value || typeof chromeRuntime.refreshAvailability !== 'function') {
     return
   }
+  chromeRuntime.refreshAvailability().catch(() => {})
+}
 
-  const persistedForm = createCustomProviderForm(provider, props.draftSecrets)
-  if (JSON.stringify(editorForm) === JSON.stringify(persistedForm)) {
-    Object.assign(editorForm, persistedForm)
+// Keep this click handler synchronous through runtime.download(): Chrome ties
+// Translator.create() to the current user activation when downloading.
+function downloadChromeModel() {
+  if (controlsDisabled.value || chromeState.value.phase === CHROME_TRANSLATOR_PHASES.DOWNLOADING) {
+    return
   }
-})
+  if (![CHROME_TRANSLATOR_PHASES.DOWNLOADABLE, CHROME_TRANSLATOR_PHASES.FAILED].includes(chromeState.value.phase)) {
+    return
+  }
+  try {
+    const promise = chromeRuntime.download()
+    promise?.catch?.(() => {})
+  } catch (_error) {
+    // The runtime publishes a retryable failure state.
+  }
+}
+
+function progressPercent() {
+  return chromeState.value.progress === null ? 0 : Math.round(chromeState.value.progress * 100)
+}
+
+watch(selectedProviderId, (providerId, previousProviderId) => {
+  if (previousProviderId !== undefined && (
+    previousProviderId === CUSTOM_NEW_ID ||
+    customProviders.value[previousProviderId]?.source === PROVIDER_SOURCES.CUSTOM
+  )) {
+    cacheEditorDraft(previousProviderId)
+  }
+  if (providerId === CUSTOM_NEW_ID || customProviders.value[providerId]) {
+    loadEditorDraft(providerId)
+    refreshCustomPermission(providerId === CUSTOM_NEW_ID ? null : customProviders.value[providerId], providerId)
+  } else if (providerId === CHROME_ID) {
+    refreshChromeAvailability()
+  }
+}, {immediate: true})
 
 watch(editorForm, () => {
-  invalidateConnectionState()
+  const next = JSON.stringify(editorForm)
+  editorDirty.value = next !== editorBaseline.value
+  if (editorDirty.value) {
+    invalidateConnectionState(selectedProviderId.value)
+  }
 }, {deep: true})
+
+watch(() => props.draftRevision, () => {
+  if (!selectedIsCustom.value || editorDirty.value) {
+    return
+  }
+  loadEditorDraft(selectedProviderId.value)
+})
+
+if (ownsChromeRuntime && typeof chromeRuntime.subscribe === 'function') {
+  chromeRuntime.subscribe(state => {
+    chromeState.value = state
+  })
+}
+
+onBeforeUnmount(() => {
+  permissionRequestId += 1
+  connectionRequestId += 1
+  if (ownsChromeRuntime) {
+    chromeRuntime.destroy?.()
+  }
+})
 </script>
 
 <template>
-  <section class="settings-card translation-settings" data-testid="settings-translation-form">
-    <div class="settings-card__heading">
-      <h3>{{ text('SETTINGS_TRANSLATION_CARD_TITLE') }}</h3>
-      <p>{{ text('SETTINGS_TRANSLATION_CARD_DESCRIPTION') }}</p>
-    </div>
-
-    <label class="settings-switch" for="settings-translation-enabled">
-      <input
-        id="settings-translation-enabled"
-        type="checkbox"
-        :checked="translation.enabled"
-        :disabled="interactionDisabled"
-        data-testid="settings-translation-enabled"
-        @change="toggleTranslation"
-      >
-      <span class="settings-switch__track" aria-hidden="true">
-        <span class="settings-switch__thumb" />
-      </span>
-      <span class="settings-switch__label">
-        {{ text('SETTINGS_TRANSLATION_ENABLED') }}
-      </span>
-    </label>
-
-    <div class="translation-settings__general">
-      <div class="translation-settings__field">
-        <label for="settings-translation-target-language">
-          {{ text('SETTINGS_TRANSLATION_TARGET_LANGUAGE') }}
-        </label>
-        <span>{{ text('SETTINGS_TRANSLATION_TARGET_LANGUAGE_HINT') }}</span>
-        <input
-          id="settings-translation-target-language"
-          v-model="draft.translation.targetLanguage"
-          type="text"
-          inputmode="text"
-          autocomplete="off"
-          spellcheck="false"
-          maxlength="12"
-          :disabled="interactionDisabled"
-          data-testid="settings-translation-target-language"
-        >
-      </div>
-      <div class="translation-settings__field">
-        <label for="settings-translation-provider">
-          {{ text('SETTINGS_TRANSLATION_PROVIDER') }}
-        </label>
-        <span>{{ text('SETTINGS_TRANSLATION_PROVIDER_HINT') }}</span>
-        <select
-          id="settings-translation-provider"
-          :value="activeProviderId"
-          :disabled="interactionDisabled"
-          @change="selectProviderFromControl"
-          data-testid="settings-translation-provider"
-        >
-          <option value="deepl-free">DeepL Free</option>
-          <option value="deepl-pro">DeepL Pro</option>
-          <option value="gemini">Gemini</option>
-          <option
-            v-for="(provider, providerId) in customProviders"
-            :key="providerId"
-            :value="providerId"
-          >
-            {{ provider.name || providerId }}
-          </option>
-        </select>
-      </div>
-    </div>
-
-    <p
-      v-if="providerSelectionMessageKey"
-      class="translation-settings__selection-status"
-      :class="`translation-settings__selection-status--${providerSelectionState}`"
-      role="status"
-      data-testid="settings-translation-permission-status"
-    >
-      {{ text(providerSelectionMessageKey) }}
-    </p>
-
-    <div class="translation-settings__services">
-      <div class="translation-settings__services-heading">
-        <h4>{{ text('SETTINGS_TRANSLATION_AVAILABLE_SERVICES') }}</h4>
-        <p>{{ text('SETTINGS_TRANSLATION_AVAILABLE_SERVICES_HINT') }}</p>
-      </div>
-
-      <article
-        v-for="card in providerCards"
-        :key="card.id"
-        class="translation-provider-card"
-        :class="{
-          'translation-provider-card--active': isCardActive(card),
-          'translation-provider-card--custom': card.custom
-        }"
-        :data-provider-id="card.id"
-      >
-        <div class="translation-provider-card__copy">
-          <h5>{{ providerName(card) }}</h5>
-          <p>{{ text(card.descriptionKey) }}</p>
+  <section class="translation-settings" data-testid="settings-translation-form">
+    <div class="translation-settings__layout">
+      <aside class="translation-settings__selector" aria-labelledby="translation-selector-title">
+        <div class="translation-settings__heading">
+          <h2 id="translation-selector-title">{{ text('SETTINGS_TRANSLATION_SELECTOR_TITLE') }}</h2>
+          <p>{{ text('SETTINGS_TRANSLATION_SELECTOR_HINT') }}</p>
         </div>
-        <span v-if="card.badgeKey" class="translation-provider-card__badge">
-          {{ text(card.badgeKey) }}
-        </span>
-        <div class="translation-provider-card__actions">
-          <span
-            v-if="isCardActive(card)"
-            class="translation-provider-card__active"
-          >
-            {{ text('SETTINGS_TRANSLATION_ACTIVE') }}
-          </span>
-          <button
-            type="button"
-            class="translation-provider-card__action"
-            :disabled="interactionDisabled"
-            @click="openProviderSettings(card)"
-          >
-            {{ text('SETTINGS_TRANSLATION_CONFIGURE') }}
-          </button>
-          <button
-            v-if="!isCardActive(card)"
-            type="button"
-            class="translation-provider-card__use"
-            :disabled="interactionDisabled"
-            @click="selectCard(card)"
-          >
-            {{ text('SETTINGS_TRANSLATION_USE') }}
-          </button>
-          <button
-            v-if="card.custom"
-            type="button"
-            class="translation-provider-card__delete"
-            :disabled="interactionDisabled"
-            :aria-label="text('SETTINGS_TRANSLATION_CUSTOM_DELETE')"
-            @click="deleteCustomProvider(card.id)"
-          >
-            {{ text('SETTINGS_TRANSLATION_CUSTOM_DELETE') }}
-          </button>
-        </div>
-      </article>
 
-      <button
-        type="button"
-        class="translation-settings__add"
-        :disabled="interactionDisabled"
-        data-testid="settings-translation-add-custom"
-        @click="startCustomProvider"
-      >
-        + {{ text('SETTINGS_TRANSLATION_CUSTOM_ADD') }}
-      </button>
-
-      <p class="translation-settings__note">
-        {{ text('SETTINGS_TRANSLATION_EXTERNAL_NOTE') }}
-      </p>
-    </div>
-
-    <section
-      v-if="editorMode === 'preset' && editorProvider"
-      class="translation-provider-editor"
-      data-testid="settings-translation-preset-editor"
-    >
-      <div class="translation-provider-editor__heading">
-        <div>
-          <h4>{{ editorProvider.name }}</h4>
-          <p>{{ text('SETTINGS_TRANSLATION_PRESET_DESCRIPTION') }}</p>
-        </div>
-        <button type="button" class="translation-provider-editor__close" :disabled="interactionDisabled" @click="closeEditor">
-          ×
-        </button>
-      </div>
-
-      <div v-if="editorProviderId === 'deepl-free' || editorProviderId === 'deepl-pro'" class="translation-provider-editor__field">
-        <label for="settings-translation-deepl-variant">
-          {{ text('SETTINGS_TRANSLATION_DEEPL_VARIANT') }}
-        </label>
-        <select
-          id="settings-translation-deepl-variant"
-          :value="editorProviderId"
-          :disabled="editorControlsDisabled"
-          data-testid="settings-translation-deepl-variant"
-          @change="switchDeepLVariant"
-        >
-          <option value="deepl-free">{{ text('SETTINGS_TRANSLATION_DEEPL_FREE') }}</option>
-          <option value="deepl-pro">{{ text('SETTINGS_TRANSLATION_DEEPL_PRO') }}</option>
-        </select>
-      </div>
-
-      <div v-if="editorProvider.auth.mode !== PROVIDER_AUTH_MODES.NONE" class="translation-provider-editor__field">
-        <label for="settings-translation-preset-api-key">
-          {{ text('SETTINGS_TRANSLATION_API_KEY') }}
-        </label>
-        <div class="translation-provider-editor__secret">
-          <input
-            id="settings-translation-preset-api-key"
-            :type="showApiKey ? 'text' : 'password'"
-            :value="presetCredentialValue(editorProvider)"
-            autocomplete="new-password"
-            :disabled="editorControlsDisabled"
-            :placeholder="editorHasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')"
-            data-testid="settings-translation-preset-api-key"
-            @input="updatePresetCredential"
-          >
-          <button
-            type="button"
-            class="translation-provider-editor__show-secret"
-            :disabled="editorControlsDisabled"
-            :aria-label="text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY')"
-            @click="showApiKey = !showApiKey"
-          >
-            {{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}
-          </button>
-        </div>
-        <span>{{ text('SETTINGS_TRANSLATION_API_KEY_HINT') }}</span>
-        <p v-if="!presetCredentialValue(editorProvider)" class="translation-provider-editor__warning" role="alert">
-          {{ text('SETTINGS_TRANSLATION_API_KEY_MISSING') }}
-        </p>
-      </div>
-
-      <div class="translation-provider-editor__actions">
-        <button
-          type="button"
-          class="translation-provider-editor__test"
-          :disabled="editorControlsDisabled"
-          data-testid="settings-translation-test"
-          @click="testPresetConnection"
-        >
-          {{ text(connectionState === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}
-        </button>
-        <button type="button" class="translation-provider-editor__cancel" :disabled="interactionDisabled" @click="closeEditor">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_CANCEL') }}
-        </button>
-      </div>
-      <p
-        v-if="connectionMessageKey"
-        class="translation-provider-editor__result"
-        :class="`translation-provider-editor__result--${connectionState}`"
-        role="status"
-        data-testid="settings-translation-test-result"
-      >
-        {{ text(connectionMessageKey) }}
-      </p>
-    </section>
-
-    <form
-      v-if="isEditingCustom"
-      class="translation-provider-editor translation-provider-editor--custom"
-      data-testid="settings-translation-custom-editor"
-      @submit.prevent="saveCustomProvider"
-    >
-      <div class="translation-provider-editor__heading">
-        <div>
-          <h4>{{ text(editorProviderId ? 'SETTINGS_TRANSLATION_CUSTOM_EDIT' : 'SETTINGS_TRANSLATION_CUSTOM_TITLE') }}</h4>
-          <p>{{ text('SETTINGS_TRANSLATION_CUSTOM_DESCRIPTION') }}</p>
-        </div>
-        <button type="button" class="translation-provider-editor__close" :disabled="interactionDisabled" @click="closeEditor">
-          ×
-        </button>
-      </div>
-
-      <div class="translation-provider-editor__grid">
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_NAME_LABEL') }}
-          <input v-model="editorForm.name" type="text" autocomplete="off" :disabled="editorControlsDisabled" data-testid="settings-custom-name">
-          <span>{{ text('SETTINGS_TRANSLATION_CUSTOM_NAME_HINT') }}</span>
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_URL') }}
-          <input v-model="editorForm.url" type="url" autocomplete="off" placeholder="https://api.example.com/translate" :disabled="editorControlsDisabled" data-testid="settings-custom-url">
-          <span>{{ text('SETTINGS_TRANSLATION_CUSTOM_URL_HINT') }}</span>
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_METHOD') }}
-          <select v-model="editorForm.method" :disabled="editorControlsDisabled" data-testid="settings-custom-method">
-            <option value="POST">POST</option>
-            <option value="PUT">PUT</option>
-            <option value="PATCH">PATCH</option>
-          </select>
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_MODE') }}
-          <select v-model="editorForm.authMode" :disabled="editorControlsDisabled" data-testid="settings-custom-auth-mode" @change="syncAuthDefaults">
-            <option value="none">{{ text('SETTINGS_TRANSLATION_AUTH_NONE') }}</option>
-            <option value="api-key">{{ text('SETTINGS_TRANSLATION_AUTH_API_KEY') }}</option>
-            <option value="bearer">{{ text('SETTINGS_TRANSLATION_AUTH_BEARER') }}</option>
-            <option value="custom">{{ text('SETTINGS_TRANSLATION_AUTH_CUSTOM') }}</option>
-          </select>
-        </label>
-      </div>
-
-      <div v-if="editorForm.authMode !== 'none'" class="translation-provider-editor__grid">
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_LOCATION') }}
-          <select v-model="editorForm.authLocation" :disabled="editorControlsDisabled" data-testid="settings-custom-auth-location">
-            <option value="header">{{ text('SETTINGS_TRANSLATION_AUTH_HEADER') }}</option>
-            <option value="query">{{ text('SETTINGS_TRANSLATION_AUTH_QUERY') }}</option>
-          </select>
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_HEADER') }}
-          <input v-model="editorForm.authHeaderName" type="text" autocomplete="off" :disabled="editorControlsDisabled" data-testid="settings-custom-auth-header">
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_PREFIX') }}
-          <input v-model="editorForm.authPrefix" type="text" autocomplete="off" :disabled="editorControlsDisabled" data-testid="settings-custom-auth-prefix">
-        </label>
-
-        <label class="translation-provider-editor__field">
-          {{ text('SETTINGS_TRANSLATION_API_KEY') }}
-          <div class="translation-provider-editor__secret">
-            <input
-              v-model="editorForm.apiKey"
-              :type="showApiKey ? 'text' : 'password'"
-              autocomplete="new-password"
-              :disabled="editorControlsDisabled"
-              :placeholder="editorForm.hasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')"
-              data-testid="settings-custom-api-key"
-            >
+        <div class="translation-settings__selector-card">
+          <div class="translation-settings__selector-card-heading">
+            <h3>{{ text('SETTINGS_TRANSLATION_AVAILABLE_SERVICES') }}</h3>
+            <label class="settings-switch settings-switch--compact" for="settings-translation-enabled">
+              <input
+                id="settings-translation-enabled"
+                type="checkbox"
+                :checked="translation.enabled"
+                :disabled="controlsDisabled"
+                data-testid="settings-translation-enabled"
+                @change="toggleTranslation"
+              >
+              <span class="settings-switch__track" aria-hidden="true"><span class="settings-switch__thumb" /></span>
+              <span class="settings-switch__label">{{ text('SETTINGS_TRANSLATION_ENABLED') }}</span>
+            </label>
+          </div>
+          <div class="translation-settings__service-list">
             <button
+              v-for="card in serviceCards()"
+              :key="card.id"
               type="button"
-              class="translation-provider-editor__show-secret"
-              :disabled="editorControlsDisabled"
-              @click="showApiKey = !showApiKey"
+              class="translation-service-row"
+              :class="{
+                'translation-service-row--selected': cardIsSelected(card),
+                'translation-service-row--active': cardIsActive(card)
+              }"
+              :disabled="controlsDisabled"
+              :data-provider-id="card.id"
+              @click="selectCard(card)"
             >
-              {{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}
+              <span class="translation-service-row__icon" aria-hidden="true">{{ card.icon }}</span>
+              <span class="translation-service-row__copy">
+                <strong>{{ cardName(card) }}</strong>
+                <small>{{ text(card.descriptionKey) }}</small>
+              </span>
+              <span
+                class="translation-service-row__status"
+                :class="`translation-service-row__status--${cardStatusClass(card)}`"
+              >{{ text(cardStatusKey(card)) }}</span>
+              <span v-if="cardIsActive(card)" class="translation-service-row__active" aria-label="active">●</span>
             </button>
           </div>
-          <span>{{ text('SETTINGS_TRANSLATION_API_KEY_HINT') }}</span>
-          <label v-if="editorForm.hasCredential" class="translation-provider-editor__clear-secret">
-            <input v-model="editorForm.clearCredential" type="checkbox" :disabled="editorControlsDisabled">
-            {{ text('SETTINGS_TRANSLATION_CUSTOM_CLEAR_KEY') }}
+          <button
+            type="button"
+            class="translation-settings__add"
+            :disabled="controlsDisabled"
+            data-testid="settings-translation-add-custom"
+            @click="startCustomProvider"
+          >+ {{ text('SETTINGS_TRANSLATION_CUSTOM_ADD') }}</button>
+        </div>
+
+        <div v-if="!selectedIsChrome" class="translation-settings__general">
+          <label class="translation-settings__field" for="settings-translation-target-language">
+            <span>{{ text('SETTINGS_TRANSLATION_TARGET_LANGUAGE') }}</span>
+            <input
+              id="settings-translation-target-language"
+              v-model="draft.translation.targetLanguage"
+              type="text"
+              inputmode="text"
+              autocomplete="off"
+              spellcheck="false"
+              maxlength="12"
+              :disabled="controlsDisabled"
+              data-testid="settings-translation-target-language"
+            >
+            <small>{{ text('SETTINGS_TRANSLATION_TARGET_LANGUAGE_HINT') }}</small>
           </label>
-        </label>
-      </div>
+        </div>
+      </aside>
 
-      <label class="translation-provider-editor__field">
-        {{ text('SETTINGS_TRANSLATION_CUSTOM_HEADERS') }}
-        <textarea v-model="editorForm.headersText" rows="3" spellcheck="false" :disabled="editorControlsDisabled" data-testid="settings-custom-headers" />
-        <span>{{ text('SETTINGS_TRANSLATION_CUSTOM_HEADERS_HINT') }}</span>
-      </label>
+      <section class="translation-settings__detail" aria-labelledby="translation-detail-title">
+        <div class="translation-settings__heading translation-settings__heading--detail">
+          <h2 id="translation-detail-title">{{ text('SETTINGS_TRANSLATION_DETAIL_TITLE') }}</h2>
+          <p>{{ text('SETTINGS_TRANSLATION_DETAIL_HINT') }}</p>
+        </div>
 
-      <label class="translation-provider-editor__field">
-        {{ text('SETTINGS_TRANSLATION_CUSTOM_BODY') }}
-        <textarea v-model="editorForm.bodyTemplateText" rows="6" spellcheck="false" :disabled="editorControlsDisabled" data-testid="settings-custom-body" />
-        <span>{{ text('SETTINGS_TRANSLATION_CUSTOM_BODY_HINT') }}</span>
-      </label>
+        <div class="translation-settings__detail-card">
+          <template v-if="selectedIsChrome">
+            <div class="translation-detail-header">
+              <div>
+                <h3>{{ text('SETTINGS_TRANSLATION_CHROME_NAME') }}</h3>
+                <p>{{ text('SETTINGS_TRANSLATION_CHROME_DETAIL_DESCRIPTION') }}</p>
+              </div>
+              <span class="translation-detail-badge translation-detail-badge--local">{{ text('SETTINGS_TRANSLATION_CHROME_LOCAL_BADGE') }}</span>
+            </div>
+            <div class="translation-fixed-pair">
+              <span>{{ text('SETTINGS_TRANSLATION_CHROME_LANGUAGE_PAIR') }}</span>
+              <strong><code>en</code> → <code>ko</code></strong>
+            </div>
+            <dl class="translation-status-list">
+              <div>
+                <dt>{{ text('SETTINGS_TRANSLATION_CHROME_BROWSER') }}</dt>
+                <dd :class="chromeState.supported ? 'is-ready' : 'is-error'">{{ chromeState.supported ? text('SETTINGS_TRANSLATION_CHROME_SUPPORTED') : text('SETTINGS_TRANSLATION_CHROME_UNSUPPORTED') }}</dd>
+              </div>
+              <div>
+                <dt>{{ text('SETTINGS_TRANSLATION_CHROME_MODEL') }}</dt>
+                <dd :class="chromeState.phase === 'available' ? 'is-ready' : 'is-error'">{{ text(chromeStatusTextKey()) }}</dd>
+              </div>
+            </dl>
+            <div v-if="chromeState.phase === 'downloading'" class="translation-download-progress" role="status">
+              <div class="translation-download-progress__labels">
+                <span>{{ text('SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS') }}</span>
+                <strong v-if="!chromeState.indeterminate">{{ progressPercent() }}%</strong><strong v-else>…</strong>
+              </div>
+              <div class="translation-download-progress__track">
+                <span
+                  class="translation-download-progress__bar"
+                  :class="{'translation-download-progress__bar--indeterminate': chromeState.indeterminate}"
+                  :style="chromeState.indeterminate ? undefined : {width: `${progressPercent()}%` }"
+                />
+              </div>
+              <p>{{ text('SETTINGS_TRANSLATION_CHROME_DOWNLOAD_PROGRESS_HINT') }}</p>
+            </div>
+            <p v-if="chromeState.phase === 'unsupported' || chromeState.phase === 'unavailable'" class="translation-detail-callout translation-detail-callout--warning" role="status">{{ text(chromeState.phase === 'unsupported' ? 'SETTINGS_TRANSLATION_CHROME_UNSUPPORTED_GUIDANCE' : 'SETTINGS_TRANSLATION_CHROME_UNAVAILABLE_GUIDANCE') }}</p>
+            <p v-if="chromeState.phase === 'failed'" class="translation-detail-callout translation-detail-callout--error" role="alert">{{ text(chromeErrorTextKey()) }}<span v-if="chromeState.errorMessage"> {{ chromeState.errorMessage }}</span></p>
+            <button
+              v-if="chromeState.phase === 'downloadable' || chromeState.phase === 'failed'"
+              type="button"
+              class="translation-primary-button"
+              :disabled="controlsDisabled"
+              data-testid="settings-translation-chrome-download"
+              @click="downloadChromeModel"
+            >{{ text(chromeState.phase === 'failed' ? 'SETTINGS_TRANSLATION_CHROME_RETRY' : 'SETTINGS_TRANSLATION_CHROME_DOWNLOAD_BUTTON') }}</button>
+            <p class="translation-detail-note">{{ text('SETTINGS_TRANSLATION_CHROME_NOTE') }}</p>
+            <button
+              v-if="activeProviderId !== CHROME_ID"
+              type="button"
+              class="translation-secondary-button"
+              :disabled="controlsDisabled || !canActivateSelected()"
+              data-testid="settings-translation-activate"
+              @click="activateSelectedProvider"
+            >{{ text('SETTINGS_TRANSLATION_ACTIVATE') }}</button>
+            <span v-else class="translation-active-label">{{ text('SETTINGS_TRANSLATION_ACTIVE') }}</span>
+          </template>
 
-      <label class="translation-provider-editor__field">
-        {{ text('SETTINGS_TRANSLATION_CUSTOM_RESPONSE_PATH') }}
-        <input v-model="editorForm.responsePath" type="text" autocomplete="off" :disabled="editorControlsDisabled" data-testid="settings-custom-response-path">
-        <span>{{ text('SETTINGS_TRANSLATION_CUSTOM_RESPONSE_PATH_HINT') }}</span>
-      </label>
+          <template v-else-if="selectedPresetId">
+            <div class="translation-detail-header">
+              <div>
+                <h3>{{ isDeepL ? text('SETTINGS_TRANSLATION_DEEPL_NAME') : text('SETTINGS_TRANSLATION_GEMINI_NAME') }}</h3>
+                <p>{{ text(isDeepL ? 'SETTINGS_TRANSLATION_DEEPL_DESCRIPTION' : 'SETTINGS_TRANSLATION_GEMINI_DESCRIPTION') }}</p>
+              </div>
+              <span class="translation-detail-badge" :class="stateFor(selectedProviderId).status === 'success' ? 'translation-detail-badge--connected' : stateFor(selectedProviderId).status === 'error' ? 'translation-detail-badge--error' : 'translation-detail-badge--required'">{{ text(stateFor(selectedProviderId).status === 'success' ? 'SETTINGS_TRANSLATION_CONNECTED_BADGE' : stateFor(selectedProviderId).status === 'error' ? 'SETTINGS_TRANSLATION_ERROR_BADGE' : 'SETTINGS_TRANSLATION_REQUIRED_BADGE') }}</span>
+            </div>
+            <div v-if="isDeepL" class="translation-plan-switch" aria-label="DeepL plan">
+              <button type="button" :class="{'is-selected': selectedProviderId === 'deepl-free'}" :disabled="controlsDisabled" @click="switchDeepLVariant('deepl-free')">{{ text('SETTINGS_TRANSLATION_DEEPL_FREE') }}</button>
+              <button type="button" :class="{'is-selected': selectedProviderId === 'deepl-pro'}" :disabled="controlsDisabled" @click="switchDeepLVariant('deepl-pro')">{{ text('SETTINGS_TRANSLATION_DEEPL_PRO') }}</button>
+            </div>
+            <label class="translation-detail-field" for="settings-translation-preset-api-key">
+              <span>{{ text('SETTINGS_TRANSLATION_API_KEY') }}</span>
+              <div class="translation-secret-field">
+                <input
+                  id="settings-translation-preset-api-key"
+                  :type="showApiKey ? 'text' : 'password'"
+                  :value="providerCredential(selectedProvider)"
+                  autocomplete="new-password"
+                  :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'"
+                  :placeholder="providerCredential(selectedProvider) ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')"
+                  data-testid="settings-translation-preset-api-key"
+                  @input="updatePresetCredential"
+                >
+                <button type="button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button>
+              </div>
+              <small>{{ text('SETTINGS_TRANSLATION_API_KEY_HINT') }}</small>
+              <button v-if="providerCredential(selectedProvider)" type="button" class="translation-text-button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" @click="deletePresetCredential">{{ text('SETTINGS_TRANSLATION_DELETE_KEY') }}</button>
+            </label>
+            <p v-if="stateFor(selectedProviderId).messageKey" class="translation-detail-result" :class="`translation-detail-result--${stateFor(selectedProviderId).status}`" role="status">{{ text(stateFor(selectedProviderId).messageKey) }}</p>
+            <div class="translation-detail-actions">
+              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" data-testid="settings-translation-test" @click="testPresetConnection">{{ text(stateFor(selectedProviderId).status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
+              <button v-if="activeProviderId !== selectedProviderId" type="button" class="translation-primary-button" :disabled="controlsDisabled || !canActivateSelected()" data-testid="settings-translation-activate" @click="activateSelectedProvider">{{ text('SETTINGS_TRANSLATION_ACTIVATE') }}</button>
+              <span v-else class="translation-active-label">{{ text('SETTINGS_TRANSLATION_ACTIVE') }}</span>
+            </div>
+          </template>
 
-      <ul v-if="formErrors.length" class="translation-provider-editor__errors" role="alert" data-testid="settings-custom-errors">
-        <li v-for="(error, index) in formErrors" :key="`${error.code}-${index}`">
-          {{ text(errorTextKey(error)) }}
-        </li>
-      </ul>
-
-      <div class="translation-provider-editor__actions">
-        <button type="submit" class="translation-provider-editor__save" :disabled="editorControlsDisabled" data-testid="settings-custom-save">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_SAVE') }}
-        </button>
-        <button type="button" class="translation-provider-editor__test" :disabled="editorControlsDisabled" data-testid="settings-custom-test" @click="testCustomConnection">
-          {{ text(connectionState === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}
-        </button>
-        <button type="button" class="translation-provider-editor__cancel" :disabled="interactionDisabled" @click="closeEditor">
-          {{ text('SETTINGS_TRANSLATION_CUSTOM_CANCEL') }}
-        </button>
-      </div>
-      <p
-        v-if="connectionMessageKey"
-        class="translation-provider-editor__result"
-        :class="`translation-provider-editor__result--${connectionState}`"
-        role="status"
-        data-testid="settings-translation-test-result"
-      >
-        {{ text(connectionMessageKey) }}
-      </p>
-    </form>
+          <form v-else class="translation-custom-editor" data-testid="settings-translation-custom-editor" @submit.prevent="saveCustomProvider">
+            <div class="translation-detail-header">
+              <div>
+                <h3>{{ text(editorProviderId ? 'SETTINGS_TRANSLATION_CUSTOM_EDIT' : 'SETTINGS_TRANSLATION_CUSTOM_TITLE') }}</h3>
+                <p>{{ text('SETTINGS_TRANSLATION_CUSTOM_DESCRIPTION') }}</p>
+              </div>
+              <span class="translation-detail-badge" :class="permissionStates[selectedProviderId] === 'allowed' ? 'translation-detail-badge--connected' : 'translation-detail-badge--required'">{{ text(permissionStates[selectedProviderId] === 'allowed' ? 'SETTINGS_TRANSLATION_PERMISSION_ALLOWED_BADGE' : 'SETTINGS_TRANSLATION_PERMISSION_BADGE') }}</span>
+            </div>
+            <div class="translation-custom-grid">
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_NAME') }}</span><input v-model="editorForm.name" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-name"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_URL') }}</span><input v-model="editorForm.url" type="url" autocomplete="off" placeholder="https://api.example.com/translate" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-url"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_METHOD') }}</span><select v-model="editorForm.method" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-method"><option value="POST">POST</option><option value="PUT">PUT</option><option value="PATCH">PATCH</option></select></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_MODE') }}</span><select v-model="editorForm.authMode" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-mode" @change="syncAuthDefaults"><option value="none">{{ text('SETTINGS_TRANSLATION_AUTH_NONE') }}</option><option value="api-key">{{ text('SETTINGS_TRANSLATION_AUTH_API_KEY') }}</option><option value="bearer">{{ text('SETTINGS_TRANSLATION_AUTH_BEARER') }}</option><option value="custom">{{ text('SETTINGS_TRANSLATION_AUTH_CUSTOM') }}</option></select></label>
+            </div>
+            <div v-if="editorForm.authMode !== 'none'" class="translation-custom-grid">
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_LOCATION') }}</span><select v-model="editorForm.authLocation" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-location"><option value="header">{{ text('SETTINGS_TRANSLATION_AUTH_HEADER') }}</option><option value="query">{{ text('SETTINGS_TRANSLATION_AUTH_QUERY') }}</option></select></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_HEADER') }}</span><input v-model="editorForm.authHeaderName" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-header"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_PREFIX') }}</span><input v-model="editorForm.authPrefix" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-prefix"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_API_KEY') }}</span><div class="translation-secret-field"><input v-model="editorForm.apiKey" :type="showApiKey ? 'text' : 'password'" autocomplete="new-password" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" :placeholder="editorForm.hasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')" data-testid="settings-custom-api-key"><button type="button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button></div></label>
+            </div>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_HEADERS') }}</span><textarea v-model="editorForm.headersText" rows="3" spellcheck="false" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-headers" /></label>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_BODY') }}</span><textarea v-model="editorForm.bodyTemplateText" rows="5" spellcheck="false" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-body" /></label>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_RESPONSE_PATH') }}</span><input v-model="editorForm.responsePath" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-response-path"></label>
+            <div class="translation-permission-box" :class="{'translation-permission-box--allowed': permissionStates[selectedProviderId] === 'allowed'}">
+              <strong>{{ text('SETTINGS_TRANSLATION_CUSTOM_PERMISSION_TITLE') }}</strong>
+              <code v-if="customPermissionPattern">{{ customPermissionPattern }}</code>
+              <p>{{ text(permissionStates[selectedProviderId] === 'allowed' ? 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_GRANTED' : 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_HINT') }}</p>
+              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || permissionRequestState === 'requesting' || selectedConnectionState().status === 'testing'" data-testid="settings-custom-request-permission" @click="requestCustomPermissionFromForm">{{ text(permissionRequestState === 'requesting' ? 'SETTINGS_TRANSLATION_PERMISSION_REQUESTING' : 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_REQUEST') }}</button>
+            </div>
+            <ul v-if="formErrors.length" class="translation-form-errors" role="alert" data-testid="settings-custom-errors"><li v-for="(error, index) in formErrors" :key="`${error.code}-${index}`">{{ text(errorTextKey(error)) }}</li></ul>
+            <p v-if="selectedConnectionState().messageKey" class="translation-detail-result" :class="`translation-detail-result--${selectedConnectionState().status}`" role="status" data-testid="settings-translation-test-result">{{ text(selectedConnectionState().messageKey) }}</p>
+            <div class="translation-detail-actions">
+              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-test" @click="testCustomConnection">{{ text(selectedConnectionState().status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
+              <button type="submit" class="translation-primary-button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-save">{{ text('SETTINGS_TRANSLATION_CUSTOM_SAVE') }}</button>
+              <button v-if="editorProviderId" type="button" class="translation-danger-button" :disabled="controlsDisabled" @click="deleteCustomProvider(editorProviderId)">{{ text('SETTINGS_TRANSLATION_CUSTOM_DELETE') }}</button>
+              <button v-else type="button" class="translation-text-button" :disabled="controlsDisabled" @click="cancelCustomDraft">{{ text('SETTINGS_TRANSLATION_CUSTOM_CANCEL') }}</button>
+              <button v-if="activeProviderId !== selectedProviderId" type="button" class="translation-secondary-button" :disabled="controlsDisabled || !canActivateSelected()" data-testid="settings-translation-activate" @click="activateSelectedProvider">{{ text('SETTINGS_TRANSLATION_ACTIVATE') }}</button>
+              <span v-else class="translation-active-label">{{ text('SETTINGS_TRANSLATION_ACTIVE') }}</span>
+            </div>
+          </form>
+        </div>
+      </section>
+    </div>
   </section>
 </template>
 
 <style scoped>
-.translation-settings {
-  overflow: visible;
-}
-
-.translation-settings__general {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-  gap: 16px;
-  padding: 20px 0;
-  border-bottom: 1px solid var(--naverdic-settings-divider);
-}
-
-.translation-settings__field,
-.translation-provider-editor__field {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-  min-width: 0;
-  color: var(--naverdic-settings-text);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 20px;
-}
-
-.translation-settings__field > span,
-.translation-provider-editor__field > span {
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  font-weight: 400;
-  line-height: 17px;
-}
-
-.translation-settings__field input,
-.translation-settings__field select,
-.translation-provider-editor__field input,
-.translation-provider-editor__field select,
-.translation-provider-editor__field textarea {
-  width: 100%;
-  min-height: 36px;
-  padding: 7px 10px;
-  color: var(--naverdic-settings-text);
-  background: var(--naverdic-input-background-default);
-  border: 1px solid var(--naverdic-input-border-default);
-  border-radius: var(--naverdic-radius-sm);
-  font: inherit;
-  font-size: 12px;
-  font-weight: 400;
-  line-height: 20px;
-}
-
-.translation-provider-editor__field textarea {
-  min-height: 90px;
-  resize: vertical;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 11px;
-  line-height: 18px;
-}
-
-.translation-settings__field input:focus-visible,
-.translation-settings__field select:focus-visible,
-.translation-provider-editor__field input:focus-visible,
-.translation-provider-editor__field select:focus-visible,
-.translation-provider-editor__field textarea:focus-visible,
-.translation-provider-editor__show-secret:focus-visible,
-.translation-provider-editor__close:focus-visible,
-.translation-provider-editor__actions button:focus-visible,
-.translation-settings__add:focus-visible,
-.translation-provider-card button:focus-visible {
-  outline: 2px solid var(--naverdic-color-focus);
-  outline-offset: 2px;
-  box-shadow: var(--naverdic-input-focus-ring);
-}
-
-.translation-settings__services {
-  padding-top: 20px;
-}
-
-.translation-settings__selection-status {
-  margin: 12px 0 0;
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  line-height: 17px;
-}
-
-.translation-settings__selection-status--error {
-  color: var(--naverdic-color-danger);
-}
-
-.translation-settings__services-heading h4 {
-  margin: 0;
-  color: var(--naverdic-settings-text);
-  font-size: 15px;
-  font-weight: 700;
-  line-height: 24px;
-}
-
-.translation-settings__services-heading p {
-  margin: 4px 0 16px;
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  line-height: 17px;
-}
-
-.translation-provider-card {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-height: 92px;
-  margin-bottom: 14px;
-  padding: 12px 15px;
-  background: var(--naverdic-settings-surface);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: 8px;
-}
-
-.translation-provider-card--active {
-  background: var(--naverdic-settings-info);
-}
-
-.translation-provider-card__copy {
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
-.translation-provider-card__copy h5 {
-  margin: 0;
-  color: var(--naverdic-settings-text);
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 20px;
-}
-
-.translation-provider-card__copy p {
-  margin: 5px 0 0;
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  line-height: 17px;
-}
-
-.translation-provider-card__badge,
-.translation-provider-card__active {
-  flex: 0 0 auto;
-  padding: 3px 9px;
-  color: var(--naverdic-settings-primary-text);
-  background: var(--naverdic-settings-nav-active);
-  border-radius: 999px;
-  font-size: 10px;
-  font-weight: 700;
-  line-height: 18px;
-}
-
-.translation-provider-card__actions {
-  display: flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 6px;
-}
-
-.translation-provider-card button,
-.translation-settings__add,
-.translation-provider-editor__actions button {
-  min-height: 28px;
-  padding: 0 10px;
-  border-radius: 7px;
-  font-size: 11px;
-  font-weight: 700;
-  cursor: pointer;
-}
-
-.translation-provider-card button:disabled,
-.translation-settings__add:disabled,
-.translation-provider-editor__actions button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.translation-provider-card__action,
-.translation-provider-card__use,
-.translation-provider-card__delete {
-  color: var(--naverdic-settings-primary-text);
-  background: var(--naverdic-settings-surface);
-  border: 1px solid var(--naverdic-settings-border);
-}
-
-.translation-provider-card__use {
-  background: var(--naverdic-settings-nav-active);
-  border-color: transparent;
-}
-
-.translation-provider-card__delete {
-  color: var(--naverdic-color-danger);
-}
-
-.translation-settings__add {
-  color: var(--naverdic-settings-primary-text);
-  background: var(--naverdic-settings-surface);
-  border: 1px dashed var(--naverdic-settings-primary);
-}
-
-.translation-settings__note {
-  margin: 14px 0 0;
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  line-height: 17px;
-}
-
-.translation-provider-editor {
-  margin-top: 20px;
-  padding: 20px;
-  background: var(--naverdic-settings-info);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: 10px;
-}
-
-.translation-provider-editor__heading {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
-}
-
-.translation-provider-editor__heading h4 {
-  margin: 0;
-  color: var(--naverdic-settings-text);
-  font-size: 15px;
-  font-weight: 700;
-  line-height: 24px;
-}
-
-.translation-provider-editor__heading p {
-  margin: 4px 0 0;
-  color: var(--naverdic-settings-text-muted);
-  font-size: 11px;
-  line-height: 17px;
-}
-
-.translation-provider-editor__close {
-  width: 28px;
-  height: 28px;
-  padding: 0;
-  color: var(--naverdic-settings-text-muted);
-  background: transparent;
-  border: 0;
-  font-size: 20px;
-  line-height: 28px;
-  cursor: pointer;
-}
-
-.translation-provider-editor__field {
-  margin-bottom: 14px;
-}
-
-.translation-provider-editor__grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0 14px;
-}
-
-.translation-provider-editor__secret {
-  display: flex;
-  gap: 6px;
-}
-
-.translation-provider-editor__secret input {
-  min-width: 0;
-  flex: 1 1 auto;
-}
-
-.translation-provider-editor__show-secret {
-  flex: 0 0 auto;
-  min-height: 36px;
-  padding: 0 8px;
-  color: var(--naverdic-settings-primary-text);
-  background: var(--naverdic-settings-surface);
-  border: 1px solid var(--naverdic-settings-border);
-  border-radius: var(--naverdic-radius-sm);
-  font-size: 10px;
-  cursor: pointer;
-}
-
-.translation-provider-editor__clear-secret {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  color: var(--naverdic-color-danger);
-  font-size: 11px;
-  font-weight: 400;
-}
-
-.translation-provider-editor__clear-secret input {
-  width: auto;
-  min-height: auto;
-}
-
-.translation-provider-editor__warning,
-.translation-provider-editor__errors {
-  margin: 5px 0 0;
-  color: var(--naverdic-color-danger);
-  font-size: 11px;
-  font-weight: 400;
-  line-height: 17px;
-}
-
-.translation-provider-editor__errors {
-  padding: 10px 12px 10px 28px;
-  background: #fff5f5;
-  border-radius: var(--naverdic-radius-sm);
-}
-
-.translation-provider-editor__actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  margin-top: 16px;
-}
-
-.translation-provider-editor__test,
-.translation-provider-editor__save {
-  color: var(--naverdic-button-text-default);
-  background: var(--naverdic-button-background-default);
-  border: 0;
-}
-
-.translation-provider-editor__cancel {
-  color: var(--naverdic-settings-primary-text);
-  background: var(--naverdic-settings-surface);
-  border: 1px solid var(--naverdic-settings-border);
-}
-
-.translation-provider-editor__result {
-  margin: 12px 0 0;
-  font-size: 11px;
-  font-weight: 600;
-  line-height: 18px;
-}
-
-.translation-provider-editor__result--success {
-  color: var(--naverdic-settings-success);
-}
-
-.translation-provider-editor__result--error {
-  color: var(--naverdic-color-danger);
-}
-
-@media (max-width: 600px) {
-  .translation-settings__general,
-  .translation-provider-editor__grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .translation-provider-card {
-    align-items: flex-start;
-    flex-wrap: wrap;
-  }
-
-  .translation-provider-card__actions {
-    width: 100%;
-    justify-content: flex-end;
-  }
-}
+.translation-settings { min-width: 0; }
+.translation-settings__layout { display: grid; grid-template-columns: minmax(0, 300px) minmax(0, 556px); gap: 28px; align-items: start; }
+.translation-settings__heading { min-height: 66px; }
+.translation-settings__heading h2 { margin: 0; color: var(--naverdic-settings-text); font-size: 22px; font-weight: 700; line-height: 32px; }
+.translation-settings__heading p { margin: 2px 0 0; color: var(--naverdic-settings-text-muted); font-size: 12px; line-height: 20px; }
+.translation-settings__selector-card, .translation-settings__detail-card { padding: 18px; background: var(--naverdic-settings-surface); border: 1px solid var(--naverdic-settings-border); border-radius: var(--naverdic-radius-md); box-shadow: var(--naverdic-card-shadow-default); }
+.translation-settings__selector-card-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--naverdic-settings-divider); }
+.translation-settings__selector-card-heading h3 { margin: 0; color: var(--naverdic-settings-text); font-size: 14px; line-height: 22px; }
+.settings-switch--compact { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 6px; cursor: pointer; }
+.settings-switch--compact input { position: absolute; width: 1px; height: 1px; opacity: 0; pointer-events: none; }
+.settings-switch--compact .settings-switch__track { position: relative; display: inline-flex; align-items: center; padding: 2px; background: var(--naverdic-settings-divider); border-radius: 99px; transition: background 120ms ease; }
+.settings-switch--compact .settings-switch__thumb { display: block; background: var(--naverdic-settings-surface); border-radius: 50%; box-shadow: 0 1px 2px rgb(0 0 0 / 16%); transition: transform 120ms ease; }
+.settings-switch--compact input:checked + .settings-switch__track { background: var(--naverdic-settings-primary); }
+.settings-switch--compact .settings-switch__label { font-size: 10px; line-height: 16px; }
+.settings-switch--compact .settings-switch__track { width: 28px; height: 16px; }
+.settings-switch--compact .settings-switch__thumb { width: 12px; height: 12px; }
+.settings-switch--compact input:checked + .settings-switch__track .settings-switch__thumb { transform: translateX(12px); }
+.translation-settings__service-list { display: flex; flex-direction: column; gap: 4px; padding: 8px 0; }
+.translation-service-row { position: relative; display: grid; grid-template-columns: 30px minmax(0, 1fr) auto 8px; gap: 9px; align-items: center; min-height: 58px; padding: 8px 9px; color: var(--naverdic-settings-text); background: transparent; border: 1px solid transparent; border-radius: 8px; text-align: left; cursor: pointer; }
+.translation-service-row:hover { background: var(--naverdic-settings-nav-hover); }
+.translation-service-row--selected { background: var(--naverdic-settings-nav-active); border-color: var(--naverdic-settings-primary-light, #dbeafe); }
+.translation-service-row:focus-visible, .translation-settings button:focus-visible, .translation-settings input:focus-visible, .translation-settings select:focus-visible, .translation-settings textarea:focus-visible { outline: 2px solid var(--naverdic-color-focus); outline-offset: 2px; }
+.translation-service-row__icon { display: grid; width: 30px; height: 30px; place-items: center; color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-info); border-radius: 8px; font-size: 12px; font-weight: 800; }
+.translation-service-row__copy { display: flex; min-width: 0; flex-direction: column; gap: 2px; }
+.translation-service-row__copy strong { overflow: hidden; color: var(--naverdic-settings-text); font-size: 12px; line-height: 18px; text-overflow: ellipsis; white-space: nowrap; }
+.translation-service-row__copy small { overflow: hidden; color: var(--naverdic-settings-text-muted); font-size: 10px; line-height: 15px; text-overflow: ellipsis; white-space: nowrap; }
+.translation-service-row__status, .translation-detail-badge { display: inline-flex; align-items: center; min-height: 22px; padding: 0 8px; border-radius: 999px; font-size: 9px; font-weight: 700; line-height: 16px; white-space: nowrap; }
+.translation-service-row__status--connected, .translation-service-row__status--setup { color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-info); }
+.translation-service-row__status--error { color: var(--naverdic-color-danger); background: var(--naverdic-settings-danger-hover); }
+.translation-service-row__active { color: var(--naverdic-settings-primary); font-size: 10px; }
+.translation-settings__add { width: 100%; min-height: 34px; color: var(--naverdic-settings-primary-text); background: transparent; border: 1px dashed var(--naverdic-settings-primary-light, #bfdbfe); border-radius: 7px; font-size: 11px; font-weight: 700; cursor: pointer; }
+.translation-settings__add:hover { background: var(--naverdic-settings-info); }
+.translation-settings__general { margin-top: 16px; padding: 14px 2px 0; border-top: 1px solid var(--naverdic-settings-divider); }
+.translation-settings__field, .translation-detail-field { display: flex; min-width: 0; flex-direction: column; gap: 5px; color: var(--naverdic-settings-text); font-size: 11px; font-weight: 700; line-height: 18px; }
+.translation-settings__field small, .translation-detail-field small { color: var(--naverdic-settings-text-muted); font-size: 10px; font-weight: 400; line-height: 16px; }
+.translation-settings__field input, .translation-detail-field input, .translation-detail-field select, .translation-detail-field textarea { width: 100%; min-height: 36px; padding: 7px 10px; color: var(--naverdic-settings-text); background: var(--naverdic-input-background-default); border: 1px solid var(--naverdic-input-border-default); border-radius: var(--naverdic-radius-sm); font: inherit; font-size: 11px; font-weight: 400; line-height: 18px; }
+.translation-detail-field textarea { min-height: 80px; resize: vertical; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; line-height: 16px; }
+.translation-settings__detail-card { min-height: 460px; }
+.translation-detail-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding-bottom: 18px; border-bottom: 1px solid var(--naverdic-settings-divider); }
+.translation-detail-header h3 { margin: 0; color: var(--naverdic-settings-text); font-size: 16px; line-height: 24px; }
+.translation-detail-header p { margin: 4px 0 0; color: var(--naverdic-settings-text-muted); font-size: 11px; line-height: 17px; }
+.translation-detail-badge--local, .translation-detail-badge--connected { color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-info); }
+.translation-detail-badge--required { color: var(--naverdic-settings-text-muted); background: var(--naverdic-settings-divider); }
+.translation-detail-badge--error { color: var(--naverdic-color-danger); background: var(--naverdic-settings-danger-hover); }
+.translation-fixed-pair { display: flex; align-items: center; justify-content: space-between; margin-top: 18px; padding: 12px 14px; color: var(--naverdic-settings-text-muted); background: var(--naverdic-settings-page); border-radius: 8px; font-size: 11px; }
+.translation-fixed-pair strong { color: var(--naverdic-settings-text); font-size: 13px; }
+.translation-fixed-pair code { padding: 2px 5px; color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-info); border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 11px; }
+.translation-status-list { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin: 18px 0 0; }
+.translation-status-list > div { padding: 12px 13px; background: var(--naverdic-settings-page); border-radius: 8px; }
+.translation-status-list dt { color: var(--naverdic-settings-text-muted); font-size: 10px; line-height: 16px; }
+.translation-status-list dd { margin: 4px 0 0; color: var(--naverdic-settings-text); font-size: 12px; font-weight: 700; line-height: 18px; }
+.translation-status-list dd.is-ready { color: var(--naverdic-settings-primary-text); }
+.translation-status-list dd.is-error { color: var(--naverdic-color-danger); }
+.translation-download-progress { margin-top: 18px; }
+.translation-download-progress__labels { display: flex; justify-content: space-between; color: var(--naverdic-settings-text); font-size: 11px; line-height: 18px; }
+.translation-download-progress__track { height: 8px; margin-top: 7px; overflow: hidden; background: var(--naverdic-settings-divider); border-radius: 99px; }
+.translation-download-progress__bar { display: block; height: 100%; background: var(--naverdic-settings-primary); border-radius: inherit; transition: width 160ms ease; }
+.translation-download-progress__bar--indeterminate { width: 45%; animation: translation-progress 1.2s ease-in-out infinite; }
+.translation-download-progress p { margin: 7px 0 0; color: var(--naverdic-settings-text-muted); font-size: 10px; line-height: 16px; }
+@keyframes translation-progress { from { transform: translateX(-100%); } to { transform: translateX(230%); } }
+.translation-detail-callout, .translation-permission-box { margin: 18px 0 0; padding: 12px 14px; border-radius: 8px; font-size: 10px; line-height: 17px; }
+.translation-detail-callout--warning, .translation-permission-box { color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-info); }
+.translation-detail-callout--error { color: var(--naverdic-color-danger); background: var(--naverdic-settings-danger-hover); }
+.translation-detail-note { margin: 18px 0 0; color: var(--naverdic-settings-text-muted); font-size: 10px; line-height: 17px; }
+.translation-primary-button, .translation-secondary-button, .translation-danger-button, .translation-text-button { min-height: 34px; padding: 0 13px; border-radius: var(--naverdic-radius-sm); font-size: 11px; font-weight: 700; cursor: pointer; }
+.translation-primary-button { color: #fff; background: var(--naverdic-settings-primary); border: 1px solid var(--naverdic-settings-primary); }
+.translation-secondary-button { color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-surface); border: 1px solid var(--naverdic-settings-primary-light, #bfdbfe); }
+.translation-danger-button { color: var(--naverdic-color-danger); background: transparent; border: 1px solid currentColor; }
+.translation-text-button { padding: 0 5px; color: var(--naverdic-settings-primary-text); background: transparent; border: 0; }
+.translation-primary-button:disabled, .translation-secondary-button:disabled, .translation-danger-button:disabled, .translation-text-button:disabled, .translation-settings__add:disabled, .translation-service-row:disabled { opacity: .55; cursor: not-allowed; }
+.translation-detail-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 20px; }
+.translation-active-label { color: var(--naverdic-settings-primary-text); font-size: 11px; font-weight: 700; }
+.translation-plan-switch { display: inline-flex; margin-top: 18px; padding: 3px; background: var(--naverdic-settings-page); border-radius: 7px; }
+.translation-plan-switch button { min-height: 28px; padding: 0 10px; color: var(--naverdic-settings-text-muted); background: transparent; border: 0; border-radius: 5px; font-size: 10px; font-weight: 700; cursor: pointer; }
+.translation-plan-switch button.is-selected { color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-surface); box-shadow: var(--naverdic-card-shadow-default); }
+.translation-detail-field { margin-top: 18px; }
+.translation-secret-field { display: flex; gap: 7px; }
+.translation-secret-field input { flex: 1 1 auto; min-width: 0; }
+.translation-secret-field button { flex: 0 0 auto; min-width: 48px; padding: 0 8px; color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-surface); border: 1px solid var(--naverdic-input-border-default); border-radius: var(--naverdic-radius-sm); font-size: 10px; cursor: pointer; }
+.translation-detail-field .translation-text-button { align-self: flex-start; margin-top: 2px; }
+.translation-detail-result { margin: 14px 0 0; font-size: 10px; line-height: 17px; }
+.translation-detail-result--success { color: var(--naverdic-settings-primary-text); }
+.translation-detail-result--error { color: var(--naverdic-color-danger); }
+.translation-custom-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0 12px; }
+.translation-permission-box strong { display: block; color: var(--naverdic-settings-text); font-size: 11px; }
+.translation-permission-box code { display: inline-block; margin-top: 5px; padding: 2px 5px; color: var(--naverdic-settings-primary-text); background: var(--naverdic-settings-surface); border-radius: 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 10px; }
+.translation-permission-box p { margin: 4px 0 10px; color: var(--naverdic-settings-text-muted); }
+.translation-form-errors { margin: 14px 0 0; padding: 10px 12px 10px 28px; color: var(--naverdic-color-danger); background: var(--naverdic-settings-danger-hover); border-radius: 7px; font-size: 10px; line-height: 17px; }
+@media (max-width: 1050px) { .translation-settings__layout { grid-template-columns: minmax(0, 1fr); } }
+@media (max-width: 600px) { .translation-detail-header, .translation-settings__selector-card-heading { flex-direction: column; } .translation-custom-grid, .translation-status-list { grid-template-columns: minmax(0, 1fr); } .translation-service-row { grid-template-columns: 30px minmax(0, 1fr) 8px; } .translation-service-row__status { display: none; } }
 </style>

--- a/src/components/TranslationSettings.vue
+++ b/src/components/TranslationSettings.vue
@@ -18,6 +18,11 @@ import {
   validateCustomProviderForm
 } from '/src/translation-settings.mjs'
 import {
+  canActivateTranslationProvider,
+  getTranslationSettingsPanel,
+  TRANSLATION_SETTINGS_PANELS
+} from '/src/translation-settings-state.mjs'
+import {
   hasTranslationProviderPermission,
   requestTranslationProviderPermission,
   testTranslationProvider
@@ -30,6 +35,7 @@ const props = defineProps({
   draftRevision: {type: Number, default: 0},
   isLoading: {type: Boolean, default: false},
   isSaving: {type: Boolean, default: false},
+  onPendingChange: {type: Function, default: null},
   // Tests can inject a fake runtime without changing the production
   // document-bound Translator lifecycle.
   translatorRuntime: {type: Object, default: null}
@@ -66,6 +72,10 @@ const translation = computed(() => props.draft.translation || {})
 const customProviders = computed(() => props.draft.customProviders || {})
 const activeProviderId = computed(() => translation.value.providerId || 'deepl-free')
 const selectedProviderId = ref(activeProviderId.value)
+const selectedPanel = computed(() => getTranslationSettingsPanel(
+  selectedProviderId.value,
+  customProviders.value
+))
 const selectedPresetId = computed(() => (
   PRESET_IDS.has(selectedProviderId.value) ? selectedProviderId.value : ''
 ))
@@ -77,11 +87,8 @@ const selectedProvider = computed(() => {
     customProviders.value[selectedProviderId.value] ||
     null
 })
-const selectedIsChrome = computed(() => selectedProviderId.value === CHROME_ID)
-const selectedIsCustom = computed(() => (
-  selectedProviderId.value === CUSTOM_NEW_ID ||
-  customProviders.value[selectedProviderId.value]?.source === PROVIDER_SOURCES.CUSTOM
-))
+const selectedIsChrome = computed(() => selectedPanel.value === TRANSLATION_SETTINGS_PANELS.CHROME)
+const selectedIsCustom = computed(() => selectedPanel.value === TRANSLATION_SETTINGS_PANELS.CUSTOM)
 const customPermissionPattern = computed(() => getProviderOriginPattern(editorForm.url))
 const isDeepL = computed(() => selectedProviderId.value === 'deepl-free' || selectedProviderId.value === 'deepl-pro')
 const controlsDisabled = computed(() => props.isLoading || props.isSaving)
@@ -89,6 +96,7 @@ const controlsDisabled = computed(() => props.isLoading || props.isSaving)
 const connectionStates = reactive({})
 const permissionStates = reactive({})
 const customDrafts = reactive({})
+const customDraftDirty = reactive({})
 const editorForm = reactive(createCustomProviderForm())
 const editorProviderId = ref('')
 const editorBaseline = ref('')
@@ -121,6 +129,15 @@ function text(key, placeholders = undefined) {
   return getText(key, placeholders)
 }
 
+function setEditorDirty(value) {
+  const next = Boolean(value)
+  if (editorDirty.value === next) {
+    return
+  }
+  editorDirty.value = next
+  props.onPendingChange?.(next)
+}
+
 function providerForId(providerId) {
   return getProviderPreset(providerId) || customProviders.value[providerId] || null
 }
@@ -151,6 +168,13 @@ function isConnectionSuccess(providerId) {
 
 function selectedConnectionState() {
   return stateFor(selectedProviderId.value)
+}
+
+function connectionControlsDisabled(providerId = selectedProviderId.value) {
+  return isTranslationConnectionLocked({
+    globallyDisabled: controlsDisabled.value,
+    connectionStatus: stateFor(providerId).status
+  })
 }
 
 function ensureDraftProviders() {
@@ -319,15 +343,18 @@ function cacheEditorDraft(providerId = selectedProviderId.value) {
     return
   }
   customDrafts[providerId] = cloneProvider(editorForm)
+  customDraftDirty[providerId] = true
 }
 
 function loadEditorDraft(providerId) {
   const provider = providerId === CUSTOM_NEW_ID ? null : customProviders.value[providerId]
-  const form = customDrafts[providerId] || createCustomProviderForm(provider, props.draftSecrets)
+  const persistedForm = createCustomProviderForm(provider, props.draftSecrets)
+  const hasCachedEdits = Boolean(customDrafts[providerId] && customDraftDirty[providerId])
+  const form = customDrafts[providerId] || persistedForm
   Object.assign(editorForm, form)
   editorProviderId.value = providerId === CUSTOM_NEW_ID ? '' : providerId
-  editorBaseline.value = JSON.stringify(editorForm)
-  editorDirty.value = false
+  editorBaseline.value = JSON.stringify(hasCachedEdits ? persistedForm : form)
+  setEditorDirty(hasCachedEdits)
   formErrors.value = []
   showApiKey.value = false
 }
@@ -339,6 +366,7 @@ function startCustomProvider() {
 
 function cancelCustomDraft() {
   delete customDrafts[customDraftKey()]
+  delete customDraftDirty[customDraftKey()]
   if (editorProviderId.value) {
     loadEditorDraft(editorProviderId.value)
     return
@@ -475,7 +503,7 @@ async function runConnectionTest(provider, {
   secrets = props.draftSecrets,
   signature = providerSignature(provider, providerId)
 } = {}) {
-  if (!provider || controlsDisabled.value || stateFor(providerId).status === 'testing') {
+  if (!provider || connectionControlsDisabled(providerId)) {
     return
   }
   const credential = getProviderCredential(provider, secrets)
@@ -524,7 +552,7 @@ function testPresetConnection() {
 }
 
 async function testCustomConnection() {
-  if (controlsDisabled.value || selectedConnectionState().status === 'testing') {
+  if (connectionControlsDisabled()) {
     return
   }
   const result = currentCustomFormResult()
@@ -551,7 +579,7 @@ async function testCustomConnection() {
 }
 
 async function saveCustomProvider() {
-  if (controlsDisabled.value || selectedConnectionState().status === 'testing') {
+  if (connectionControlsDisabled()) {
     return
   }
   const result = currentCustomFormResult()
@@ -578,7 +606,9 @@ async function saveCustomProvider() {
   providers[result.provider.id] = result.provider
   applyCustomCredential(result, existingProvider)
   delete customDrafts[customDraftKey()]
-  customDrafts[result.provider.id] = cloneProvider(editorForm)
+  delete customDraftDirty[customDraftKey()]
+  delete customDrafts[result.provider.id]
+  delete customDraftDirty[result.provider.id]
   selectedProviderId.value = result.provider.id
   loadEditorDraft(result.provider.id)
   if (currentState.status === 'success' && currentState.signature === testedSignature) {
@@ -604,6 +634,7 @@ function deleteCustomProvider(providerId) {
   delete ensureDraftProviders()[providerId]
   delete ensureDraftSecrets()[providerId]
   delete customDrafts[providerId]
+  delete customDraftDirty[providerId]
   delete connectionStates[providerId]
   delete permissionStates[providerId]
   if (activeProviderId.value === providerId) {
@@ -615,22 +646,17 @@ function deleteCustomProvider(providerId) {
 }
 
 function canActivateSelected() {
-  if (selectedIsChrome.value) {
-    return chromeState.value.phase === CHROME_TRANSLATOR_PHASES.AVAILABLE
-  }
-  if (selectedIsCustom.value) {
-    return Boolean(
-      selectedProvider.value &&
-      permissionStates[selectedProviderId.value] === 'allowed' &&
-      stateFor(selectedProviderId.value).status === 'success' &&
-      isConnectionSuccess(selectedProviderId.value)
-    )
-  }
+  const state = stateFor(selectedProviderId.value)
   return Boolean(
     selectedProvider.value &&
-    providerCredential(selectedProvider.value) &&
-    stateFor(selectedProviderId.value).status === 'success' &&
-    isConnectionSuccess(selectedProviderId.value)
+    canActivateTranslationProvider({
+      panel: selectedPanel.value,
+      chromeReady: chromeState.value.phase === CHROME_TRANSLATOR_PHASES.AVAILABLE,
+      permissionAllowed: permissionStates[selectedProviderId.value] === 'allowed',
+      connectionStatus: state.status,
+      connectionMatches: isConnectionSuccess(selectedProviderId.value),
+      hasCredential: Boolean(providerCredential(selectedProvider.value))
+    })
   )
 }
 
@@ -719,8 +745,9 @@ watch(selectedProviderId, (providerId, previousProviderId) => {
 
 watch(editorForm, () => {
   const next = JSON.stringify(editorForm)
-  editorDirty.value = next !== editorBaseline.value
-  if (editorDirty.value) {
+  const nextDirty = next !== editorBaseline.value
+  setEditorDirty(nextDirty)
+  if (nextDirty) {
     invalidateConnectionState(selectedProviderId.value)
   }
 }, {deep: true})
@@ -911,19 +938,19 @@ onBeforeUnmount(() => {
                   :type="showApiKey ? 'text' : 'password'"
                   :value="providerCredential(selectedProvider)"
                   autocomplete="new-password"
-                  :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'"
+                  :disabled="connectionControlsDisabled(selectedProviderId)"
                   :placeholder="providerCredential(selectedProvider) ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')"
                   data-testid="settings-translation-preset-api-key"
                   @input="updatePresetCredential"
                 >
-                <button type="button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button>
+                <button type="button" :disabled="connectionControlsDisabled(selectedProviderId)" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button>
               </div>
               <small>{{ text('SETTINGS_TRANSLATION_API_KEY_HINT') }}</small>
-              <button v-if="providerCredential(selectedProvider)" type="button" class="translation-text-button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" @click="deletePresetCredential">{{ text('SETTINGS_TRANSLATION_DELETE_KEY') }}</button>
+              <button v-if="providerCredential(selectedProvider)" type="button" class="translation-text-button" :disabled="connectionControlsDisabled(selectedProviderId)" @click="deletePresetCredential">{{ text('SETTINGS_TRANSLATION_DELETE_KEY') }}</button>
             </label>
             <p v-if="stateFor(selectedProviderId).messageKey" class="translation-detail-result" :class="`translation-detail-result--${stateFor(selectedProviderId).status}`" role="status">{{ text(stateFor(selectedProviderId).messageKey) }}</p>
             <div class="translation-detail-actions">
-              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || stateFor(selectedProviderId).status === 'testing'" data-testid="settings-translation-test" @click="testPresetConnection">{{ text(stateFor(selectedProviderId).status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
+              <button type="button" class="translation-secondary-button" :disabled="connectionControlsDisabled(selectedProviderId)" data-testid="settings-translation-test" @click="testPresetConnection">{{ text(stateFor(selectedProviderId).status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
               <button v-if="activeProviderId !== selectedProviderId" type="button" class="translation-primary-button" :disabled="controlsDisabled || !canActivateSelected()" data-testid="settings-translation-activate" @click="activateSelectedProvider">{{ text('SETTINGS_TRANSLATION_ACTIVATE') }}</button>
               <span v-else class="translation-active-label">{{ text('SETTINGS_TRANSLATION_ACTIVE') }}</span>
             </div>
@@ -938,31 +965,31 @@ onBeforeUnmount(() => {
               <span class="translation-detail-badge" :class="permissionStates[selectedProviderId] === 'allowed' ? 'translation-detail-badge--connected' : 'translation-detail-badge--required'">{{ text(permissionStates[selectedProviderId] === 'allowed' ? 'SETTINGS_TRANSLATION_PERMISSION_ALLOWED_BADGE' : 'SETTINGS_TRANSLATION_PERMISSION_BADGE') }}</span>
             </div>
             <div class="translation-custom-grid">
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_NAME') }}</span><input v-model="editorForm.name" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-name"></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_URL') }}</span><input v-model="editorForm.url" type="url" autocomplete="off" placeholder="https://api.example.com/translate" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-url"></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_METHOD') }}</span><select v-model="editorForm.method" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-method"><option value="POST">POST</option><option value="PUT">PUT</option><option value="PATCH">PATCH</option></select></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_MODE') }}</span><select v-model="editorForm.authMode" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-mode" @change="syncAuthDefaults"><option value="none">{{ text('SETTINGS_TRANSLATION_AUTH_NONE') }}</option><option value="api-key">{{ text('SETTINGS_TRANSLATION_AUTH_API_KEY') }}</option><option value="bearer">{{ text('SETTINGS_TRANSLATION_AUTH_BEARER') }}</option><option value="custom">{{ text('SETTINGS_TRANSLATION_AUTH_CUSTOM') }}</option></select></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_NAME') }}</span><input v-model="editorForm.name" type="text" autocomplete="off" :disabled="connectionControlsDisabled()" data-testid="settings-custom-name"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_URL') }}</span><input v-model="editorForm.url" type="url" autocomplete="off" placeholder="https://api.example.com/translate" :disabled="connectionControlsDisabled()" data-testid="settings-custom-url"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_METHOD') }}</span><select v-model="editorForm.method" :disabled="connectionControlsDisabled()" data-testid="settings-custom-method"><option value="POST">POST</option><option value="PUT">PUT</option><option value="PATCH">PATCH</option></select></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_MODE') }}</span><select v-model="editorForm.authMode" :disabled="connectionControlsDisabled()" data-testid="settings-custom-auth-mode" @change="syncAuthDefaults"><option value="none">{{ text('SETTINGS_TRANSLATION_AUTH_NONE') }}</option><option value="api-key">{{ text('SETTINGS_TRANSLATION_AUTH_API_KEY') }}</option><option value="bearer">{{ text('SETTINGS_TRANSLATION_AUTH_BEARER') }}</option><option value="custom">{{ text('SETTINGS_TRANSLATION_AUTH_CUSTOM') }}</option></select></label>
             </div>
             <div v-if="editorForm.authMode !== 'none'" class="translation-custom-grid">
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_LOCATION') }}</span><select v-model="editorForm.authLocation" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-location"><option value="header">{{ text('SETTINGS_TRANSLATION_AUTH_HEADER') }}</option><option value="query">{{ text('SETTINGS_TRANSLATION_AUTH_QUERY') }}</option></select></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_HEADER') }}</span><input v-model="editorForm.authHeaderName" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-header"></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_PREFIX') }}</span><input v-model="editorForm.authPrefix" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-auth-prefix"></label>
-              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_API_KEY') }}</span><div class="translation-secret-field"><input v-model="editorForm.apiKey" :type="showApiKey ? 'text' : 'password'" autocomplete="new-password" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" :placeholder="editorForm.hasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')" data-testid="settings-custom-api-key"><button type="button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button></div></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_LOCATION') }}</span><select v-model="editorForm.authLocation" :disabled="connectionControlsDisabled()" data-testid="settings-custom-auth-location"><option value="header">{{ text('SETTINGS_TRANSLATION_AUTH_HEADER') }}</option><option value="query">{{ text('SETTINGS_TRANSLATION_AUTH_QUERY') }}</option></select></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_HEADER') }}</span><input v-model="editorForm.authHeaderName" type="text" autocomplete="off" :disabled="connectionControlsDisabled()" data-testid="settings-custom-auth-header"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_AUTH_PREFIX') }}</span><input v-model="editorForm.authPrefix" type="text" autocomplete="off" :disabled="connectionControlsDisabled()" data-testid="settings-custom-auth-prefix"></label>
+              <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_API_KEY') }}</span><div class="translation-secret-field"><input v-model="editorForm.apiKey" :type="showApiKey ? 'text' : 'password'" autocomplete="new-password" :disabled="connectionControlsDisabled()" :placeholder="editorForm.hasCredential ? '••••••••••••••••' : text('SETTINGS_TRANSLATION_API_KEY_PLACEHOLDER')" data-testid="settings-custom-api-key"><button type="button" :disabled="connectionControlsDisabled()" @click="showApiKey = !showApiKey">{{ text(showApiKey ? 'SETTINGS_TRANSLATION_HIDE_KEY' : 'SETTINGS_TRANSLATION_SHOW_KEY') }}</button></div></label>
             </div>
-            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_HEADERS') }}</span><textarea v-model="editorForm.headersText" rows="3" spellcheck="false" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-headers" /></label>
-            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_BODY') }}</span><textarea v-model="editorForm.bodyTemplateText" rows="5" spellcheck="false" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-body" /></label>
-            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_RESPONSE_PATH') }}</span><input v-model="editorForm.responsePath" type="text" autocomplete="off" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-response-path"></label>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_HEADERS') }}</span><textarea v-model="editorForm.headersText" rows="3" spellcheck="false" :disabled="connectionControlsDisabled()" data-testid="settings-custom-headers" /></label>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_BODY') }}</span><textarea v-model="editorForm.bodyTemplateText" rows="5" spellcheck="false" :disabled="connectionControlsDisabled()" data-testid="settings-custom-body" /></label>
+            <label class="translation-detail-field"><span>{{ text('SETTINGS_TRANSLATION_CUSTOM_RESPONSE_PATH') }}</span><input v-model="editorForm.responsePath" type="text" autocomplete="off" :disabled="connectionControlsDisabled()" data-testid="settings-custom-response-path"></label>
             <div class="translation-permission-box" :class="{'translation-permission-box--allowed': permissionStates[selectedProviderId] === 'allowed'}">
               <strong>{{ text('SETTINGS_TRANSLATION_CUSTOM_PERMISSION_TITLE') }}</strong>
               <code v-if="customPermissionPattern">{{ customPermissionPattern }}</code>
               <p>{{ text(permissionStates[selectedProviderId] === 'allowed' ? 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_GRANTED' : 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_HINT') }}</p>
-              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || permissionRequestState === 'requesting' || selectedConnectionState().status === 'testing'" data-testid="settings-custom-request-permission" @click="requestCustomPermissionFromForm">{{ text(permissionRequestState === 'requesting' ? 'SETTINGS_TRANSLATION_PERMISSION_REQUESTING' : 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_REQUEST') }}</button>
+              <button type="button" class="translation-secondary-button" :disabled="permissionRequestState === 'requesting' || connectionControlsDisabled()" data-testid="settings-custom-request-permission" @click="requestCustomPermissionFromForm">{{ text(permissionRequestState === 'requesting' ? 'SETTINGS_TRANSLATION_PERMISSION_REQUESTING' : 'SETTINGS_TRANSLATION_CUSTOM_PERMISSION_REQUEST') }}</button>
             </div>
             <ul v-if="formErrors.length" class="translation-form-errors" role="alert" data-testid="settings-custom-errors"><li v-for="(error, index) in formErrors" :key="`${error.code}-${index}`">{{ text(errorTextKey(error)) }}</li></ul>
             <p v-if="selectedConnectionState().messageKey" class="translation-detail-result" :class="`translation-detail-result--${selectedConnectionState().status}`" role="status" data-testid="settings-translation-test-result">{{ text(selectedConnectionState().messageKey) }}</p>
             <div class="translation-detail-actions">
-              <button type="button" class="translation-secondary-button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-test" @click="testCustomConnection">{{ text(selectedConnectionState().status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
-              <button type="submit" class="translation-primary-button" :disabled="controlsDisabled || selectedConnectionState().status === 'testing'" data-testid="settings-custom-save">{{ text('SETTINGS_TRANSLATION_CUSTOM_SAVE') }}</button>
+              <button type="button" class="translation-secondary-button" :disabled="connectionControlsDisabled()" data-testid="settings-custom-test" @click="testCustomConnection">{{ text(selectedConnectionState().status === 'testing' ? 'SETTINGS_TRANSLATION_TESTING' : 'SETTINGS_TRANSLATION_TEST') }}</button>
+              <button type="submit" class="translation-primary-button" :disabled="connectionControlsDisabled()" data-testid="settings-custom-save">{{ text('SETTINGS_TRANSLATION_CUSTOM_SAVE') }}</button>
               <button v-if="editorProviderId" type="button" class="translation-danger-button" :disabled="controlsDisabled" @click="deleteCustomProvider(editorProviderId)">{{ text('SETTINGS_TRANSLATION_CUSTOM_DELETE') }}</button>
               <button v-else type="button" class="translation-text-button" :disabled="controlsDisabled" @click="cancelCustomDraft">{{ text('SETTINGS_TRANSLATION_CUSTOM_CANCEL') }}</button>
               <button v-if="activeProviderId !== selectedProviderId" type="button" class="translation-secondary-button" :disabled="controlsDisabled || !canActivateSelected()" data-testid="settings-translation-activate" @click="activateSelectedProvider">{{ text('SETTINGS_TRANSLATION_ACTIVATE') }}</button>

--- a/src/components/TranslationSettings.vue
+++ b/src/components/TranslationSettings.vue
@@ -34,6 +34,7 @@ const props = defineProps({
   draft: {type: Object, required: true},
   draftSecrets: {type: Object, required: true},
   draftRevision: {type: Number, default: 0},
+  draftResetRevision: {type: Number, default: 0},
   isLoading: {type: Boolean, default: false},
   isSaving: {type: Boolean, default: false},
   onPendingChange: {type: Function, default: null},
@@ -130,13 +131,18 @@ function text(key, placeholders = undefined) {
   return getText(key, placeholders)
 }
 
+function hasCachedCustomEdits() {
+  return Object.values(customDraftDirty).some(Boolean)
+}
+
+function notifyPendingChange() {
+  props.onPendingChange?.(editorDirty.value || hasCachedCustomEdits())
+}
+
 function setEditorDirty(value) {
   const next = Boolean(value)
-  if (editorDirty.value === next) {
-    return
-  }
   editorDirty.value = next
-  props.onPendingChange?.(next)
+  notifyPendingChange()
 }
 
 function providerForId(providerId) {
@@ -345,13 +351,14 @@ function cacheEditorDraft(providerId = selectedProviderId.value) {
   }
   customDrafts[providerId] = cloneProvider(editorForm)
   customDraftDirty[providerId] = true
+  notifyPendingChange()
 }
 
 function loadEditorDraft(providerId) {
   const provider = providerId === CUSTOM_NEW_ID ? null : customProviders.value[providerId]
   const persistedForm = createCustomProviderForm(provider, props.draftSecrets)
   const hasCachedEdits = Boolean(customDrafts[providerId] && customDraftDirty[providerId])
-  const form = customDrafts[providerId] || persistedForm
+  const form = hasCachedEdits ? customDrafts[providerId] : persistedForm
   Object.assign(editorForm, form)
   editorProviderId.value = providerId === CUSTOM_NEW_ID ? '' : providerId
   editorBaseline.value = JSON.stringify(hasCachedEdits ? persistedForm : form)
@@ -372,7 +379,32 @@ function cancelCustomDraft() {
     loadEditorDraft(editorProviderId.value)
     return
   }
+  setEditorDirty(false)
   selectService(activeProviderId.value)
+}
+
+function clearCustomEditorState() {
+  Object.keys(customDrafts).forEach(providerId => {
+    delete customDrafts[providerId]
+  })
+  Object.keys(customDraftDirty).forEach(providerId => {
+    delete customDraftDirty[providerId]
+  })
+  Object.assign(editorForm, createCustomProviderForm())
+  editorProviderId.value = ''
+  editorBaseline.value = JSON.stringify(editorForm)
+  formErrors.value = []
+  showApiKey.value = false
+  permissionRequestState.value = 'idle'
+  setEditorDirty(false)
+}
+
+function resetCustomEditorFromDraft() {
+  clearCustomEditorState()
+  selectedProviderId.value = activeProviderId.value
+  if (selectedIsCustom.value) {
+    loadEditorDraft(selectedProviderId.value)
+  }
 }
 
 function syncAuthDefaults() {
@@ -638,6 +670,10 @@ function deleteCustomProvider(providerId) {
   delete customDraftDirty[providerId]
   delete connectionStates[providerId]
   delete permissionStates[providerId]
+  notifyPendingChange()
+  if (editorProviderId.value === providerId || selectedProviderId.value === providerId) {
+    setEditorDirty(false)
+  }
   if (activeProviderId.value === providerId) {
     props.draft.translation.providerId = 'deepl-free'
   }
@@ -740,7 +776,10 @@ watch(selectedProviderId, (providerId, previousProviderId) => {
     loadEditorDraft(providerId)
     refreshCustomPermission(providerId === CUSTOM_NEW_ID ? null : customProviders.value[providerId], providerId)
   } else if (providerId === CHROME_ID) {
+    setEditorDirty(false)
     refreshChromeAvailability()
+  } else {
+    setEditorDirty(false)
   }
 }, {immediate: true})
 
@@ -753,7 +792,19 @@ watch(editorForm, () => {
   }
 }, {deep: true})
 
+const lastResetRevision = ref(props.draftResetRevision)
+
+watch(() => props.draftResetRevision, revision => {
+  lastResetRevision.value = revision
+  resetCustomEditorFromDraft()
+})
+
 watch(() => props.draftRevision, () => {
+  if (props.draftResetRevision !== lastResetRevision.value) {
+    lastResetRevision.value = props.draftResetRevision
+    resetCustomEditorFromDraft()
+    return
+  }
   if (!selectedIsCustom.value || editorDirty.value) {
     return
   }

--- a/src/content-interaction.mjs
+++ b/src/content-interaction.mjs
@@ -262,7 +262,11 @@ export function createInteractionController(options, dependencies = {}) {
         openPopup(event)
       } else if (config.translate && triggerMatches(event, config.translate_trigger_key)) {
         removePopup()
-        openPopup(event, config.deepl_auth_key, 'translate')
+        openPopup(
+          event,
+          config.translationRequest || config.deepl_auth_key,
+          'translate'
+        )
       } else {
         removePopup()
       }

--- a/src/content-settings.mjs
+++ b/src/content-settings.mjs
@@ -1,0 +1,132 @@
+import {
+  SETTINGS_STORAGE,
+  normalizeSecretsV2,
+  normalizeSettingsV2
+} from './settings-v2.mjs'
+import {loadSettingsV2} from './settings-v2-storage.mjs'
+import {
+  LEGACY_SECRET_KEYS,
+  LEGACY_SETTING_KEYS
+} from './settings-migration-v2.mjs'
+import {getProviderPreset} from './translation-provider.mjs'
+import {getProviderCredential} from './translation-settings.mjs'
+
+const RELEVANT_KEYS = new Set([
+  SETTINGS_STORAGE.settings.key,
+  SETTINGS_STORAGE.secrets.key,
+  ...LEGACY_SETTING_KEYS,
+  ...LEGACY_SECRET_KEYS
+])
+
+function providerForSettings(settings) {
+  const providerId = settings.translation.providerId
+  return getProviderPreset(providerId) || settings.customProviders[providerId] || null
+}
+
+/**
+ * Adapt the v7 envelopes to the legacy interaction shape and attach the
+ * selected provider. The content script only receives the selected provider
+ * credential; other local secrets never cross the content/background boundary.
+ */
+export function normalizeContentRuntimeSettings(values = {}) {
+  const settings = normalizeSettingsV2(values.settings)
+  const secrets = normalizeSecretsV2(values.secrets)
+  const provider = providerForSettings(settings)
+  const credential = getProviderCredential(provider, secrets)
+
+  return {
+    dclick: settings.dictionary.doubleClick.enabled,
+    dclick_trigger_key: settings.dictionary.doubleClick.triggerKey,
+    dclick_speed: settings.dictionary.doubleClick.speedMs,
+    drag: settings.dictionary.drag.enabled,
+    drag_trigger_key: settings.dictionary.drag.triggerKey,
+    translate: settings.translation.enabled,
+    translate_trigger_key: settings.translation.triggerKey,
+    popup_bgcolor: settings.popup.backgroundColor,
+    popup_fontcolor: settings.popup.fontColor,
+    popup_fontsize: settings.popup.fontSizePt,
+    use_deny_list: settings.sites.denyListEnabled,
+    safe_urls: settings.sites.denyList,
+    translationProviderId: settings.translation.providerId,
+    translationProvider: provider,
+    translationTargetLanguage: settings.translation.targetLanguage,
+    translationCredential: credential,
+    // Preserve the v6.6 field for third-party callers that still read it. It
+    // is populated only for DeepL and is never used by the Chrome provider.
+    deepl_auth_key: /^deepl-/.test(settings.translation.providerId)
+      ? credential
+      : ''
+  }
+}
+
+/**
+ * Keep the content page synchronized with v7 sync/local envelopes while
+ * retaining the single-registration and stale-read guarantees of the v6.6
+ * lifecycle. A storage change causes a complete read so sync and local
+ * values cannot be combined from different revisions.
+ */
+export function createContentSettingsLifecycle({
+  storage,
+  onApply,
+  onError
+} = {}) {
+  let listener = null
+  let started = false
+  let revision = 0
+
+  function readLatest() {
+    const revisionAtRequest = ++revision
+    return loadSettingsV2(storage)
+      .then(values => {
+        if (!started || revisionAtRequest !== revision) {
+          return null
+        }
+
+        const runtimeSettings = normalizeContentRuntimeSettings(values)
+        onApply?.(runtimeSettings)
+        return runtimeSettings
+      })
+      .catch(error => {
+        if (started && revisionAtRequest === revision) {
+          onError?.(error)
+        }
+        return null
+      })
+  }
+
+  function handleStorageChange(changes, areaName) {
+    if (!started || (areaName && areaName !== 'sync' && areaName !== 'local')) {
+      return
+    }
+
+    if (!Object.keys(changes || {}).some(key => RELEVANT_KEYS.has(key))) {
+      return
+    }
+
+    readLatest()
+  }
+
+  function start() {
+    if (started) {
+      return
+    }
+
+    started = true
+    if (storage?.onChanged?.addListener) {
+      listener = handleStorageChange
+      storage.onChanged.addListener(listener)
+    }
+    readLatest()
+  }
+
+  function stop() {
+    started = false
+    revision += 1
+    if (listener && storage?.onChanged?.removeListener) {
+      storage.onChanged.removeListener(listener)
+    }
+    listener = null
+  }
+
+  return {start, stop, readLatest}
+}

--- a/src/content.js
+++ b/src/content.js
@@ -46,6 +46,7 @@ let activeInteractionController = null
 let storageLifecycle = null
 let chromeTranslatorRuntime = null
 let activeTranslationProviderId = ''
+let interactionConfigurationRevision = 0
 void createStorageLifecycle
 
 
@@ -188,6 +189,10 @@ function getChromeTranslatorRuntime() {
   return chromeTranslatorRuntime
 }
 
+function prepareChromeTranslatorRuntime() {
+  return getChromeTranslatorRuntime()
+}
+
 function translationErrorResponse(error) {
   return {
     ok: false,
@@ -304,6 +309,7 @@ function removePopup() {
 }
 
 function applyOptions(items) {
+  const configurationRevision = ++interactionConfigurationRevision
   const nextItems = items || {}
   const nextProviderId = nextItems.translationProviderId || 'deepl-free'
   const nextNeedsChromeRuntime = nextProviderId === CHROME_TRANSLATOR_PROVIDER_ID &&
@@ -339,21 +345,42 @@ function applyOptions(items) {
     targetLanguage: nextItems.translationTargetLanguage || 'ko'
   }
 
-  // This content script is injected into every frame (manifest all_frames).
-  // Binding to this frame's document keeps selection and events local to the
-  // browsing context; events do not bubble across iframe boundaries.
-  activeInteractionController = createInteractionController({
-    ...nextItems,
-    translationRequest
-  }, {
-    target: document,
-    openPopup,
-    removePopup,
-    checkTrigger
-  })
+  const bindInteractionController = () => {
+    if (configurationRevision !== interactionConfigurationRevision) {
+      return
+    }
+
+    // This content script is injected into every frame (manifest all_frames).
+    // Binding to this frame's document keeps selection and events local to the
+    // browsing context; events do not bubble across iframe boundaries.
+    activeInteractionController = createInteractionController({
+      ...nextItems,
+      translationRequest
+    }, {
+      target: document,
+      openPopup,
+      removePopup,
+      checkTrigger
+    })
+  }
+
+  if (nextNeedsChromeRuntime) {
+    // Finish the availability check before installing the mouseup handler.
+    // Once the handler runs, a ready model lets runtime.translate() reach
+    // Translator.create() before its first await, preserving the page's
+    // transient user activation. Model downloads still only start from the
+    // explicit settings click path.
+    prepareChromeTranslatorRuntime().refreshAvailability?.()
+      .catch(() => {})
+      .finally(bindInteractionController)
+    return
+  }
+
+  bindInteractionController()
 }
 
 export function unregisterEventListener() {
+  interactionConfigurationRevision += 1
   storageLifecycle?.stop()
   storageLifecycle = null
   activeInteractionController?.destroy()

--- a/src/content.js
+++ b/src/content.js
@@ -6,7 +6,11 @@ import {
   getSelectionText,
   isDeniedSite
 } from './content-interaction.mjs'
-import { createStorageLifecycle } from './content-storage.mjs'
+import {createContentSettingsLifecycle} from './content-settings.mjs'
+// Keep the v6.6 lifecycle module in the content dependency graph for unpacked
+// compatibility; v7 reads the split settings envelopes above.
+import {createStorageLifecycle} from './content-storage.mjs'
+import {createChromeTranslatorRuntime} from './chrome-translator.mjs'
 import {
   MESSAGE_ERROR_CODES,
   createDictionaryRequest,
@@ -16,10 +20,17 @@ import {
 } from './messaging.mjs'
 import {
   DEFAULT_OPTIONS,
-  normalizeSettings,
   STORAGE_DEFAULTS
 } from './settings.mjs'
-import {getProviderPreset} from './translation-provider.mjs'
+import {
+  executeProviderTranslation,
+  getPathValue
+} from './translation-engine.mjs'
+import {
+  CHROME_TRANSLATOR_PROVIDER_ID,
+  getProviderPreset,
+  PROVIDER_KINDS
+} from './translation-provider.mjs'
 
 export { DEFAULT_OPTIONS, STORAGE_DEFAULTS }
 
@@ -33,7 +44,9 @@ let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE
 
 let activeInteractionController = null
 let storageLifecycle = null
-const DEFAULT_TRANSLATION_PROVIDER = getProviderPreset('deepl-free')
+let chromeTranslatorRuntime = null
+let activeTranslationProviderId = ''
+void createStorageLifecycle
 
 
 function appendTextWithLineBreaks(element, value) {
@@ -168,25 +181,83 @@ async function consultDic(e, word, top, left) {
   showFrame(e, parseNaverDictionaryResponse(response.data), top, left)
 }
 
-async function translate(e, text, top, left, key) {
-  const response = await sendRuntimeMessage(
-    chrome.runtime,
-    createTranslationRequest({
-      provider: DEFAULT_TRANSLATION_PROVIDER,
-      key,
-      data: {
+function getChromeTranslatorRuntime() {
+  if (!chromeTranslatorRuntime) {
+    chromeTranslatorRuntime = createChromeTranslatorRuntime()
+  }
+  return chromeTranslatorRuntime
+}
+
+function translationErrorResponse(error) {
+  return {
+    ok: false,
+    error: {
+      code: error?.code || MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+      message: error?.message || 'The translation request failed.'
+    }
+  }
+}
+
+function translationConfigFromValue(value) {
+  if (value && typeof value === 'object' && value.provider) {
+    return {
+      provider: value.provider,
+      credential: typeof value.credential === 'string' ? value.credential : '',
+      targetLanguage: typeof value.targetLanguage === 'string'
+        ? value.targetLanguage
+        : 'ko'
+    }
+  }
+
+  return {
+    provider: getProviderPreset('deepl-free'),
+    credential: typeof value === 'string' ? value : '',
+    targetLanguage: 'ko'
+  }
+}
+
+async function translate(e, text, top, left, value) {
+  const config = translationConfigFromValue(value)
+  const provider = config.provider || getProviderPreset('deepl-free')
+  let response
+
+  if (provider.kind === PROVIDER_KINDS.BUILT_IN &&
+      provider.id === CHROME_TRANSLATOR_PROVIDER_ID) {
+    try {
+      const result = await executeProviderTranslation(provider, {
         text: [text],
-        target_lang: 'ko'
-      }
-    })
-  )
+        targetLanguage: 'ko',
+        translatorRuntime: getChromeTranslatorRuntime()
+      })
+      response = {ok: true, data: result}
+    } catch (error) {
+      response = translationErrorResponse(error)
+    }
+  } else {
+    response = await sendRuntimeMessage(
+      chrome.runtime,
+      createTranslationRequest({
+        provider,
+        key: config.credential,
+        data: {
+          text: [text],
+          targetLanguage: config.targetLanguage
+        }
+      })
+    )
+  }
 
   if (!response.ok) {
     reportMessageFailure('translation', response)
     return
   }
 
-  const translatedText = response.data?.translations?.[0]?.text
+  let translatedText
+  if (provider.kind === PROVIDER_KINDS.BUILT_IN) {
+    translatedText = response.data?.text
+  } else {
+    translatedText = getPathValue(response.data, provider.response?.textPath)
+  }
   if (typeof translatedText !== 'string') {
     reportMessageFailure('translation', {
       ok: false,
@@ -233,7 +304,17 @@ function removePopup() {
 }
 
 function applyOptions(items) {
-  const nextItems = normalizeSettings(items)
+  const nextItems = items || {}
+  const nextProviderId = nextItems.translationProviderId || 'deepl-free'
+  const nextNeedsChromeRuntime = nextProviderId === CHROME_TRANSLATOR_PROVIDER_ID &&
+    Boolean(nextItems.translate)
+
+  if (activeTranslationProviderId === CHROME_TRANSLATOR_PROVIDER_ID &&
+      !nextNeedsChromeRuntime) {
+    chromeTranslatorRuntime?.destroy()
+    chromeTranslatorRuntime = null
+  }
+  activeTranslationProviderId = nextProviderId
 
   activeInteractionController?.destroy()
   activeInteractionController = null
@@ -252,10 +333,19 @@ function applyOptions(items) {
     return
   }
 
+  const translationRequest = {
+    provider: nextItems.translationProvider || getProviderPreset('deepl-free'),
+    credential: nextItems.translationCredential || '',
+    targetLanguage: nextItems.translationTargetLanguage || 'ko'
+  }
+
   // This content script is injected into every frame (manifest all_frames).
   // Binding to this frame's document keeps selection and events local to the
   // browsing context; events do not bubble across iframe boundaries.
-  activeInteractionController = createInteractionController(nextItems, {
+  activeInteractionController = createInteractionController({
+    ...nextItems,
+    translationRequest
+  }, {
     target: document,
     openPopup,
     removePopup,
@@ -268,6 +358,9 @@ export function unregisterEventListener() {
   storageLifecycle = null
   activeInteractionController?.destroy()
   activeInteractionController = null
+  chromeTranslatorRuntime?.destroy()
+  chromeTranslatorRuntime = null
+  activeTranslationProviderId = ''
   removePopup()
 }
 
@@ -277,7 +370,7 @@ export function registerEventListener() {
   }
 
   const storage = typeof chrome === 'undefined' ? null : chrome.storage
-  storageLifecycle = createStorageLifecycle({
+  storageLifecycle = createContentSettingsLifecycle({
     storage,
     onApply: applyOptions
   })

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -5,12 +5,13 @@ import SettingsPage from '/src/components/SettingsPage.vue'
 
 <template>
   <SettingsShell>
-    <template #page="{ activePage, draft, draftSecrets, draftRevision, isLoading, isSaving, resetDraft, translationPendingChange }">
+    <template #page="{ activePage, draft, draftSecrets, draftRevision, draftResetRevision, isLoading, isSaving, resetDraft, translationPendingChange }">
       <SettingsPage
         :active-page="activePage"
         :draft="draft"
         :draft-secrets="draftSecrets"
         :draft-revision="draftRevision"
+        :draft-reset-revision="draftResetRevision"
         :is-loading="isLoading"
         :is-saving="isSaving"
         :reset-draft="resetDraft"

--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -5,7 +5,7 @@ import SettingsPage from '/src/components/SettingsPage.vue'
 
 <template>
   <SettingsShell>
-    <template #page="{ activePage, draft, draftSecrets, draftRevision, isLoading, isSaving, resetDraft }">
+    <template #page="{ activePage, draft, draftSecrets, draftRevision, isLoading, isSaving, resetDraft, translationPendingChange }">
       <SettingsPage
         :active-page="activePage"
         :draft="draft"
@@ -14,6 +14,7 @@ import SettingsPage from '/src/components/SettingsPage.vue'
         :is-loading="isLoading"
         :is-saving="isSaving"
         :reset-draft="resetDraft"
+        :translation-pending-change="translationPendingChange"
       />
     </template>
   </SettingsShell>

--- a/src/translation-engine.mjs
+++ b/src/translation-engine.mjs
@@ -26,6 +26,8 @@ export const PROVIDER_ERROR_CODES = Object.freeze({
   TIMEOUT: 'TIMEOUT'
 })
 
+const TRANSLATOR_ERROR_CODE_PATTERN = /^TRANSLATOR_[A-Z0-9_]+$/
+
 const TEMPLATE_PATTERN = /\{\{([a-zA-Z][a-zA-Z0-9_.-]*)\}\}/g
 const PATH_PATTERN = /(?:^|\.)([^.[\]]+)|\[(\d+)\]/g
 const DEFAULT_TIMEOUT_MS = 10000
@@ -479,6 +481,18 @@ export function normalizeProviderError(error, {secrets = {}, extraSecrets = []} 
     return error
   }
 
+  if (TRANSLATOR_ERROR_CODE_PATTERN.test(String(error?.code || ''))) {
+    return providerError(
+      error.code,
+      redactSecrets(
+        error?.message || 'The Chrome Translator request could not be completed.',
+        secrets,
+        extraSecrets
+      ),
+      {errorName: error?.errorName || error?.name}
+    )
+  }
+
   const code = error?.name === 'AbortError'
     ? PROVIDER_ERROR_CODES.TIMEOUT
     : PROVIDER_ERROR_CODES.NETWORK_ERROR
@@ -489,6 +503,79 @@ export function normalizeProviderError(error, {secrets = {}, extraSecrets = []} 
   return providerError(code, message || fallback)
 }
 
+/**
+ * Run a built-in provider in the document/content-page that owns the
+ * Translator API. This path intentionally has no permission or fetch step;
+ * background callers must continue to receive UNSUPPORTED_CONTEXT.
+ */
+export async function executeContentProviderTranslation(providerInput, {
+  text,
+  targetLanguage = 'ko',
+  sourceLanguage = '',
+  translatorRuntime
+} = {}) {
+  const provider = providerDefinition(providerInput)
+  if (!provider) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The translation provider configuration is invalid.'
+    )
+  }
+
+  if (provider.kind !== PROVIDER_KINDS.BUILT_IN ||
+      provider.id !== CHROME_TRANSLATOR_PROVIDER_ID ||
+      provider.execution.context !== PROVIDER_EXECUTION_CONTEXTS.CONTENT_PAGE) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT,
+      'This translation provider is not a content-page provider.',
+      {context: PROVIDER_EXECUTION_CONTEXTS.CONTENT_PAGE}
+    )
+  }
+
+  if (!translatorRuntime || typeof translatorRuntime.translate !== 'function') {
+    throw providerError(
+      PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT,
+      'The Chrome Translator provider must run in the content page.',
+      {context: PROVIDER_EXECUTION_CONTEXTS.CONTENT_PAGE}
+    )
+  }
+
+  const textValues = normalizeTextInput(text)
+  const normalizedSourceLanguage = String(sourceLanguage || '').trim().toLowerCase()
+  if (!textValues.length ||
+      (normalizedSourceLanguage && normalizedSourceLanguage !== 'en') ||
+      String(targetLanguage || '').trim().toLowerCase() !== 'ko') {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_PROVIDER,
+      'The Chrome Translator provider only supports English to Korean.'
+    )
+  }
+
+  // Keep the fixed source/target pair explicit at this execution boundary.
+  // `sourceLanguage` is accepted for the shared engine signature but cannot
+  // override the Chrome provider contract.
+  void sourceLanguage
+  const translated = []
+  for (const value of textValues) {
+    translated.push(await translatorRuntime.translate(value))
+  }
+
+  if (translated.some(value => typeof value !== 'string' || !value.trim())) {
+    throw providerError(
+      PROVIDER_ERROR_CODES.INVALID_RESPONSE,
+      'The Chrome Translator response did not include translated text.'
+    )
+  }
+
+  return {
+    providerId: provider.id,
+    text: translated.join('\n'),
+    raw: {
+      translations: translated.map(value => ({text: value}))
+    }
+  }
+}
+
 export async function executeProviderTranslation(providerInput, {
   text,
   targetLanguage,
@@ -497,7 +584,8 @@ export async function executeProviderTranslation(providerInput, {
   allowedOrigins = [],
   permissionChecker,
   fetchFn = globalThis.fetch,
-  timeoutMs = DEFAULT_TIMEOUT_MS
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  translatorRuntime
 } = {}) {
   const provider = providerDefinition(providerInput)
   if (!provider) {
@@ -516,6 +604,15 @@ export async function executeProviderTranslation(providerInput, {
   }
 
   try {
+    if (provider.kind === PROVIDER_KINDS.BUILT_IN) {
+      return await executeContentProviderTranslation(provider, {
+        text,
+        targetLanguage,
+        sourceLanguage,
+        translatorRuntime
+      })
+    }
+
     await hasPermission(provider, {allowedOrigins, permissionChecker})
     const request = adapter.buildRequest(provider, {
       text,

--- a/src/translation-provider.mjs
+++ b/src/translation-provider.mjs
@@ -405,7 +405,7 @@ const PRESET_DEFINITIONS = {
   [CHROME_TRANSLATOR_PROVIDER_ID]: {
     modelVersion: TRANSLATION_PROVIDER_MODEL_VERSION,
     id: CHROME_TRANSLATOR_PROVIDER_ID,
-    name: 'Chrome built-in Translator',
+    name: 'Chrome built-in translation (Translator API)',
     kind: PROVIDER_KINDS.BUILT_IN,
     source: PROVIDER_SOURCES.PRESET,
     presetId: CHROME_TRANSLATOR_PROVIDER_ID,

--- a/src/translation-settings-state.mjs
+++ b/src/translation-settings-state.mjs
@@ -1,0 +1,62 @@
+export const TRANSLATION_SETTINGS_PANELS = Object.freeze({
+  CHROME: 'chrome',
+  PRESET: 'preset',
+  CUSTOM: 'custom',
+  UNKNOWN: 'unknown'
+})
+
+const PRESET_IDS = new Set(['deepl-free', 'deepl-pro', 'gemini'])
+const NEW_CUSTOM_PROVIDER_ID = '__new-custom-api__'
+
+export function getTranslationSettingsPanel(providerId, customProviders = {}) {
+  if (providerId === 'chrome-translator') {
+    return TRANSLATION_SETTINGS_PANELS.CHROME
+  }
+  if (PRESET_IDS.has(providerId)) {
+    return TRANSLATION_SETTINGS_PANELS.PRESET
+  }
+  if (providerId === NEW_CUSTOM_PROVIDER_ID ||
+      customProviders?.[providerId]?.source === 'custom') {
+    return TRANSLATION_SETTINGS_PANELS.CUSTOM
+  }
+  return TRANSLATION_SETTINGS_PANELS.UNKNOWN
+}
+
+export function isTranslationConnectionLocked({
+  globallyDisabled = false,
+  connectionStatus = 'idle'
+} = {}) {
+  return Boolean(globallyDisabled || connectionStatus === 'testing')
+}
+
+export function canActivateTranslationProvider({
+  panel,
+  chromeReady = false,
+  permissionAllowed = false,
+  connectionStatus = 'idle',
+  connectionMatches = false,
+  hasCredential = false
+} = {}) {
+  if (panel === TRANSLATION_SETTINGS_PANELS.CHROME) {
+    return Boolean(chromeReady)
+  }
+  if (panel === TRANSLATION_SETTINGS_PANELS.CUSTOM) {
+    return Boolean(
+      permissionAllowed &&
+      connectionStatus === 'success' &&
+      connectionMatches
+    )
+  }
+  if (panel === TRANSLATION_SETTINGS_PANELS.PRESET) {
+    return Boolean(
+      hasCredential &&
+      connectionStatus === 'success' &&
+      connectionMatches
+    )
+  }
+  return false
+}
+
+export function hasPendingTranslationChanges(settingsPending, editorDirty) {
+  return Boolean(settingsPending || editorDirty)
+}

--- a/src/translation-testing.mjs
+++ b/src/translation-testing.mjs
@@ -8,8 +8,25 @@ import {
 } from './translation-provider.mjs'
 import {
   getProviderOriginPattern,
+  hasProviderOriginPermission,
   requestProviderOriginPermission
 } from './provider-permissions.mjs'
+
+export async function hasTranslationProviderPermission(
+  provider,
+  permissionApi = globalThis.chrome?.permissions
+) {
+  if (provider?.source !== PROVIDER_SOURCES.CUSTOM) {
+    return true
+  }
+
+  const pattern = getProviderOriginPattern(provider.endpoint?.url)
+  if (!pattern) {
+    return false
+  }
+
+  return hasProviderOriginPermission(permissionApi, provider.endpoint.url)
+}
 
 export async function requestTranslationProviderPermission(
   provider,
@@ -22,6 +39,11 @@ export async function requestTranslationProviderPermission(
   const pattern = getProviderOriginPattern(provider.endpoint?.url)
   if (!pattern) {
     return false
+  }
+
+  if (typeof permissionApi?.contains === 'function' &&
+      await hasProviderOriginPermission(permissionApi, provider.endpoint.url)) {
+    return true
   }
 
   return requestProviderOriginPermission(permissionApi, provider.endpoint?.url)

--- a/tests/chrome-translator.test.mjs
+++ b/tests/chrome-translator.test.mjs
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  CHROME_TRANSLATOR_ERROR_CODES,
+  CHROME_TRANSLATOR_PHASES,
+  createChromeTranslatorRuntime
+} from '../src/chrome-translator.mjs'
+
+class FakeMonitor {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(type, listener) {
+    if (!this.listeners.has(type)) {
+      this.listeners.set(type, new Set())
+    }
+    this.listeners.get(type).add(listener)
+  }
+
+  emit(type, event) {
+    this.listeners.get(type)?.forEach(listener => listener(event))
+  }
+}
+
+function fakeTranslator(overrides = {}) {
+  return {
+    translate: async value => `ko:${value}`,
+    destroy: async () => {},
+    ...overrides
+  }
+}
+
+function translatorApi({availability = 'available', create} = {}) {
+  const calls = []
+  const api = {
+    availability: async options => {
+      calls.push({type: 'availability', options})
+      return typeof availability === 'function' ? availability() : availability
+    },
+    create: options => {
+      calls.push({type: 'create', options})
+      return create ? create(options) : Promise.resolve(fakeTranslator())
+    }
+  }
+  return {api, calls}
+}
+
+test('uses Translator feature detection and the fixed en to ko availability contract', async () => {
+  const unsupported = createChromeTranslatorRuntime({scope: {}})
+  assert.equal(unsupported.getState().supported, false)
+  assert.equal(unsupported.getState().phase, CHROME_TRANSLATOR_PHASES.UNSUPPORTED)
+  await assert.rejects(
+    unsupported.refreshAvailability(),
+    error => error.code === CHROME_TRANSLATOR_ERROR_CODES.UNSUPPORTED
+  )
+
+  for (const availability of ['unavailable', 'downloadable', 'downloading', 'available']) {
+    const {api, calls} = translatorApi({availability})
+    const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+    const state = await runtime.refreshAvailability()
+    assert.equal(state.availability, availability)
+    assert.equal(state.status, availability)
+    assert.deepEqual(calls[0], {
+      type: 'availability',
+      options: {sourceLanguage: 'en', targetLanguage: 'ko'}
+    })
+  }
+})
+
+test('starts download from the click path, reports progress, and prevents duplicate create calls', async () => {
+  const monitor = new FakeMonitor()
+  let resolveCreate
+  const {api, calls} = translatorApi({
+    availability: 'downloadable',
+    create: options => {
+      options.monitor(monitor)
+      return new Promise(resolve => {
+        resolveCreate = resolve
+      })
+    }
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+  await runtime.refreshAvailability()
+
+  const downloadPromise = runtime.download()
+  assert.equal(calls.filter(call => call.type === 'create').length, 1)
+  assert.equal(runtime.getState().phase, CHROME_TRANSLATOR_PHASES.DOWNLOADING)
+  monitor.emit('downloadprogress', {loaded: 0.68})
+  assert.equal(runtime.getState().progress, 0.68)
+  assert.equal(runtime.getState().indeterminate, false)
+
+  const duplicatePromise = runtime.download()
+  assert.strictEqual(duplicatePromise, downloadPromise)
+  resolveCreate(fakeTranslator())
+  await downloadPromise
+  assert.equal(runtime.getState().phase, CHROME_TRANSLATOR_PHASES.AVAILABLE)
+  assert.equal(runtime.getState().availability, 'available')
+  assert.equal(runtime.getState().progress, 1)
+  assert.equal(calls.filter(call => call.type === 'create').length, 1)
+})
+
+test('keeps progress indeterminate when Chrome provides no download event', async () => {
+  let resolveCreate
+  const {api} = translatorApi({
+    availability: 'downloadable',
+    create: () => new Promise(resolve => { resolveCreate = resolve })
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+  await runtime.refreshAvailability()
+  const pending = runtime.download()
+  assert.equal(runtime.getState().indeterminate, true)
+  assert.equal(runtime.getState().progress, null)
+  resolveCreate(fakeTranslator())
+  await pending
+})
+
+test('publishes typed download errors and permits a user-initiated retry', async () => {
+  let createCount = 0
+  const {api} = translatorApi({
+    availability: 'downloadable',
+    create: () => {
+      createCount += 1
+      if (createCount === 1) {
+        return Promise.reject(Object.assign(new Error('offline'), {name: 'NetworkError'}))
+      }
+      return Promise.resolve(fakeTranslator())
+    }
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+  await runtime.refreshAvailability()
+  await assert.rejects(
+    runtime.download(),
+    error => error.code === CHROME_TRANSLATOR_ERROR_CODES.NETWORK
+  )
+  assert.equal(runtime.getState().phase, CHROME_TRANSLATOR_PHASES.FAILED)
+  assert.equal(runtime.getState().availability, 'downloadable')
+  await runtime.download()
+  assert.equal(createCount, 2)
+  assert.equal(runtime.getState().phase, CHROME_TRANSLATOR_PHASES.AVAILABLE)
+})
+
+test('maps the documented Translator error names to stable UI error codes', async () => {
+  for (const [name, code] of [
+    ['NetworkError', CHROME_TRANSLATOR_ERROR_CODES.NETWORK],
+    ['NotAllowedError', CHROME_TRANSLATOR_ERROR_CODES.NOT_ALLOWED],
+    ['NotSupportedError', CHROME_TRANSLATOR_ERROR_CODES.NOT_SUPPORTED],
+    ['OperationError', CHROME_TRANSLATOR_ERROR_CODES.OPERATION],
+    ['UnexpectedError', CHROME_TRANSLATOR_ERROR_CODES.DOWNLOAD_FAILED]
+  ]) {
+    const {api} = translatorApi({
+      availability: 'downloadable',
+      create: () => Promise.reject(Object.assign(new Error(name), {name}))
+    })
+    const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+    await runtime.refreshAvailability()
+    await assert.rejects(runtime.download(), error => error.code === code)
+  }
+})
+
+test('translates in the document runtime, reuses the created translator, and destroys it', async () => {
+  let createCount = 0
+  let translateCount = 0
+  let destroyCount = 0
+  const translator = fakeTranslator({
+    translate: async value => {
+      translateCount += 1
+      return `translated:${value}`
+    },
+    destroy: async () => { destroyCount += 1 }
+  })
+  const {api} = translatorApi({
+    availability: 'available',
+    create: () => {
+      createCount += 1
+      return Promise.resolve(translator)
+    }
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+
+  assert.equal(await runtime.translate('one'), 'translated:one')
+  assert.equal(await runtime.translate('two'), 'translated:two')
+  assert.equal(createCount, 1)
+  assert.equal(translateCount, 2)
+  await runtime.destroy()
+  assert.equal(destroyCount, 1)
+})
+
+test('does not create a model during translation when availability is downloadable', async () => {
+  let createCount = 0
+  const {api} = translatorApi({
+    availability: 'downloadable',
+    create: () => {
+      createCount += 1
+      return Promise.resolve(fakeTranslator())
+    }
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+  await assert.rejects(
+    runtime.translate('hello'),
+    error => error.code === CHROME_TRANSLATOR_ERROR_CODES.MODEL_NOT_READY
+  )
+  assert.equal(createCount, 0)
+})

--- a/tests/chrome-translator.test.mjs
+++ b/tests/chrome-translator.test.mjs
@@ -6,6 +6,7 @@ import {
   CHROME_TRANSLATOR_PHASES,
   createChromeTranslatorRuntime
 } from '../src/chrome-translator.mjs'
+import {createInteractionController} from '../src/content-interaction.mjs'
 
 class FakeMonitor {
   constructor() {
@@ -21,6 +22,26 @@ class FakeMonitor {
 
   emit(type, event) {
     this.listeners.get(type)?.forEach(listener => listener(event))
+  }
+}
+
+class FakeTarget {
+  constructor() {
+    this.listeners = new Map()
+  }
+
+  addEventListener(type, listener) {
+    this.listeners.set(type, listener)
+  }
+
+  removeEventListener(type, listener) {
+    if (this.listeners.get(type) === listener) {
+      this.listeners.delete(type)
+    }
+  }
+
+  dispatch(type, event = {}) {
+    this.listeners.get(type)?.(event)
   }
 }
 
@@ -202,4 +223,46 @@ test('does not create a model during translation when availability is downloadab
     error => error.code === CHROME_TRANSLATOR_ERROR_CODES.MODEL_NOT_READY
   )
   assert.equal(createCount, 0)
+})
+
+test('starts the first real translation create call inside the prepared mouseup path', async () => {
+  const order = []
+  const {api} = translatorApi({
+    availability: 'available',
+    create: () => {
+      order.push('create')
+      return Promise.resolve(fakeTranslator())
+    }
+  })
+  const runtime = createChromeTranslatorRuntime({scope: {Translator: api}})
+  await runtime.refreshAvailability()
+
+  const target = new FakeTarget()
+  let translationPromise
+  const controller = createInteractionController({
+    translate: true,
+    translate_trigger_key: 'none'
+  }, {
+    target,
+    checkTrigger: () => true,
+    removePopup: () => {},
+    openPopup: () => {
+      order.push('mouseup')
+      translationPromise = runtime.translate('hello')
+      order.push('after-create-request')
+    }
+  })
+
+  target.dispatch('mousedown', {button: 0, clientX: 0, clientY: 0})
+  target.dispatch('mousemove', {clientX: 12, clientY: 0})
+  target.dispatch('mouseup', {button: 0, clientX: 12, clientY: 0})
+
+  assert.deepEqual(order.slice(-3), [
+    'mouseup',
+    'create',
+    'after-create-request'
+  ])
+  await translationPromise
+  controller.destroy()
+  await runtime.destroy()
 })

--- a/tests/content-settings.test.mjs
+++ b/tests/content-settings.test.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  createContentSettingsLifecycle,
+  normalizeContentRuntimeSettings
+} from '../src/content-settings.mjs'
+import {
+  SETTINGS_STORAGE,
+  createDefaultSecretsV2,
+  createDefaultSettingsV2
+} from '../src/settings-v2.mjs'
+
+class FakeStorage {
+  constructor(syncValues = {}, localValues = {}) {
+    this.syncValues = syncValues
+    this.localValues = localValues
+    this.listeners = new Set()
+    this.onChanged = {
+      addListener: listener => this.listeners.add(listener),
+      removeListener: listener => this.listeners.delete(listener)
+    }
+    this.sync = {
+      get: (_keys, callback) => callback(this.syncValues)
+    }
+    this.local = {
+      get: (_keys, callback) => callback(this.localValues)
+    }
+  }
+
+  emit(changes, areaName = 'sync') {
+    this.listeners.forEach(listener => listener(changes, areaName))
+  }
+}
+
+test('maps v7 Chrome settings to content runtime without exposing unrelated local credentials', () => {
+  const settings = createDefaultSettingsV2()
+  settings.translation.providerId = 'chrome-translator'
+  settings.translation.enabled = true
+  const secrets = createDefaultSecretsV2()
+  secrets.providers['deepl-free'] = {apiKey: 'deep-secret'}
+
+  const runtime = normalizeContentRuntimeSettings({settings, secrets})
+  assert.equal(runtime.translationProvider.id, 'chrome-translator')
+  assert.equal(runtime.translationCredential, '')
+  assert.equal(runtime.translationTargetLanguage, 'ko')
+  assert.equal(runtime.deepl_auth_key, '')
+  assert.equal(JSON.stringify(runtime).includes('deep-secret'), false)
+})
+
+test('reads split sync/local envelopes and follows provider changes once per lifecycle', async () => {
+  const settings = createDefaultSettingsV2()
+  settings.translation.providerId = 'deepl-free'
+  const secrets = createDefaultSecretsV2()
+  secrets.providers['deepl-free'] = {apiKey: 'local-only-key'}
+  const storage = new FakeStorage({[SETTINGS_STORAGE.settings.key]: settings}, {
+    [SETTINGS_STORAGE.secrets.key]: secrets
+  })
+  const applied = []
+  const lifecycle = createContentSettingsLifecycle({
+    storage,
+    onApply: value => applied.push(value)
+  })
+
+  lifecycle.start()
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(applied.length, 1)
+  assert.equal(applied[0].translationProvider.id, 'deepl-free')
+  assert.equal(applied[0].translationCredential, 'local-only-key')
+  assert.equal(storage.listeners.size, 1)
+
+  const next = createDefaultSettingsV2()
+  next.translation.providerId = 'chrome-translator'
+  storage.syncValues[SETTINGS_STORAGE.settings.key] = next
+  storage.emit({[SETTINGS_STORAGE.settings.key]: {newValue: next}})
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(applied.at(-1).translationProvider.id, 'chrome-translator')
+  assert.equal(applied.at(-1).translationCredential, '')
+
+  lifecycle.stop()
+  assert.equal(storage.listeners.size, 0)
+})

--- a/tests/stage2-contracts.test.mjs
+++ b/tests/stage2-contracts.test.mjs
@@ -207,6 +207,17 @@ test('represents Chrome built-in Translator with a content-page execution bounda
   )
 })
 
+test('keeps the official Chrome Translator display name and translation panel boundary', () => {
+  const ko = JSON.parse(fs.readFileSync(path.join(projectRoot, 'src/_locales/ko/messages.json'), 'utf8'))
+  const en = JSON.parse(fs.readFileSync(path.join(projectRoot, 'src/_locales/en/messages.json'), 'utf8'))
+  assert.equal(ko.SETTINGS_TRANSLATION_CHROME_NAME.message, 'Chrome 내장 번역 (Translator API)')
+  assert.equal(en.SETTINGS_TRANSLATION_CHROME_NAME.message.includes('Translator API'), true)
+
+  const shell = fs.readFileSync(path.join(projectRoot, 'src/components/SettingsShell.vue'), 'utf8')
+  assert.match(shell, /settings-content--translation/)
+  assert.match(shell, /currentNavigation\.id !== 'translation-service'/)
+})
+
 test('normalizes a custom provider and drops credential-shaped input fields', () => {
   const provider = normalizeProviderDefinition({
     id: 'Custom API',

--- a/tests/translation-engine.test.mjs
+++ b/tests/translation-engine.test.mjs
@@ -268,3 +268,30 @@ test('keeps Chrome built-in Translator outside the background HTTP adapter', asy
     error => error.code === PROVIDER_ERROR_CODES.UNSUPPORTED_CONTEXT
   )
 })
+
+test('runs Chrome Translator directly in the content-page runtime without fetch or permission checks', async () => {
+  const calls = []
+  const result = await executeProviderTranslation(getProviderPreset('chrome-translator'), {
+    text: ['hello', 'world'],
+    targetLanguage: 'ko',
+    fetchFn: async () => {
+      throw new Error('background fetch must not run')
+    },
+    permissionChecker: async () => {
+      throw new Error('background permission check must not run')
+    },
+    translatorRuntime: {
+      translate: async value => {
+        calls.push(value)
+        return `ko:${value}`
+      }
+    }
+  })
+
+  assert.deepEqual(calls, ['hello', 'world'])
+  assert.equal(result.providerId, 'chrome-translator')
+  assert.equal(result.text, 'ko:hello\nko:world')
+  assert.deepEqual(result.raw, {
+    translations: [{text: 'ko:hello'}, {text: 'ko:world'}]
+  })
+})

--- a/tests/translation-settings-component.test.mjs
+++ b/tests/translation-settings-component.test.mjs
@@ -1,0 +1,98 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import {fileURLToPath} from 'node:url'
+
+import {
+  canActivateTranslationProvider,
+  getTranslationSettingsPanel,
+  hasPendingTranslationChanges,
+  isTranslationConnectionLocked,
+  TRANSLATION_SETTINGS_PANELS
+} from '../src/translation-settings-state.mjs'
+
+const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const translationSettings = fs.readFileSync(
+  path.join(projectRoot, 'src/components/TranslationSettings.vue'),
+  'utf8'
+)
+const settingsShell = fs.readFileSync(
+  path.join(projectRoot, 'src/components/SettingsShell.vue'),
+  'utf8'
+)
+const settingsPage = fs.readFileSync(
+  path.join(projectRoot, 'src/components/SettingsPage.vue'),
+  'utf8'
+)
+const optionsApp = fs.readFileSync(
+  path.join(projectRoot, 'src/options/App.vue'),
+  'utf8'
+)
+const contentScript = fs.readFileSync(
+  path.join(projectRoot, 'src/content.js'),
+  'utf8'
+)
+
+test('switching providers selects the matching detail panel', () => {
+  assert.equal(
+    getTranslationSettingsPanel('chrome-translator'),
+    TRANSLATION_SETTINGS_PANELS.CHROME
+  )
+  assert.equal(
+    getTranslationSettingsPanel('deepl-free'),
+    TRANSLATION_SETTINGS_PANELS.PRESET
+  )
+  assert.equal(
+    getTranslationSettingsPanel('my-api', {
+      'my-api': {source: 'custom'}
+    }),
+    TRANSLATION_SETTINGS_PANELS.CUSTOM
+  )
+  assert.match(translationSettings, /v-if="selectedIsChrome"/)
+  assert.match(translationSettings, /v-else-if="selectedPresetId"/)
+  assert.match(translationSettings, /<form v-else class="translation-custom-editor"/)
+})
+
+test('connection-test controls are locked while a request is in flight', () => {
+  assert.equal(isTranslationConnectionLocked({connectionStatus: 'testing'}), true)
+  assert.equal(isTranslationConnectionLocked({connectionStatus: 'success'}), false)
+  assert.equal(isTranslationConnectionLocked({globallyDisabled: true}), true)
+  assert.ok((translationSettings.match(/connectionControlsDisabled\(/g) || []).length >= 4)
+  assert.match(translationSettings, /data-testid="settings-custom-test"/)
+  assert.match(translationSettings, /data-testid="settings-translation-test"/)
+})
+
+test('Custom activation remains blocked when host permission is denied', () => {
+  const base = {
+    panel: TRANSLATION_SETTINGS_PANELS.CUSTOM,
+    connectionStatus: 'success',
+    connectionMatches: true
+  }
+  assert.equal(canActivateTranslationProvider(base), false)
+  assert.equal(canActivateTranslationProvider({
+    ...base,
+    permissionAllowed: true
+  }), true)
+  assert.match(translationSettings, /permissionStates\[selectedProviderId\] === 'allowed'/)
+  assert.match(translationSettings, /canActivateSelected\(\)/)
+})
+
+test('Custom editor dirty state reaches the global save and unload boundary', () => {
+  assert.equal(hasPendingTranslationChanges(false, false), false)
+  assert.equal(hasPendingTranslationChanges(false, true), true)
+  assert.equal(hasPendingTranslationChanges(true, false), true)
+  assert.match(translationSettings, /onPendingChange/)
+  assert.match(translationSettings, /props\.onPendingChange\?\.\(next\)/)
+  assert.match(settingsShell, /translationEditorDirty/)
+  assert.match(settingsShell, /hasPendingTranslationChanges\(/)
+  assert.match(settingsShell, /shouldWarnBeforeUnload\(hasPendingChanges\.value\)/)
+  assert.match(settingsPage, /on-pending-change="translationPendingChange"/)
+  assert.match(optionsApp, /translation-pending-change="translationPendingChange"/)
+})
+
+test('content translation waits for availability before installing the mouseup path', () => {
+  assert.match(contentScript, /prepareChromeTranslatorRuntime\(\)\.refreshAvailability/)
+  assert.match(contentScript, /finally\(bindInteractionController\)/)
+  assert.match(contentScript, /Translator\.create\(\) before its first await/)
+})

--- a/tests/translation-settings-component.test.mjs
+++ b/tests/translation-settings-component.test.mjs
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict'
-import fs from 'node:fs'
+import {mkdtemp, readFile, rm, writeFile} from 'node:fs/promises'
 import path from 'node:path'
-import test from 'node:test'
-import {fileURLToPath} from 'node:url'
+import {fileURLToPath, pathToFileURL} from 'node:url'
+import {after, before, test} from 'node:test'
+import {JSDOM} from 'jsdom'
+import {compileScript, parse} from '@vue/compiler-sfc'
 
 import {
   canActivateTranslationProvider,
@@ -11,30 +13,344 @@ import {
   isTranslationConnectionLocked,
   TRANSLATION_SETTINGS_PANELS
 } from '../src/translation-settings-state.mjs'
+import {
+  createDefaultSecretsV2,
+  createDefaultSettingsV2
+} from '../src/settings-v2.mjs'
+import {normalizeProviderDefinition} from '../src/translation-provider.mjs'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
-const translationSettings = fs.readFileSync(
-  path.join(projectRoot, 'src/components/TranslationSettings.vue'),
-  'utf8'
-)
-const settingsShell = fs.readFileSync(
-  path.join(projectRoot, 'src/components/SettingsShell.vue'),
-  'utf8'
-)
-const settingsPage = fs.readFileSync(
-  path.join(projectRoot, 'src/components/SettingsPage.vue'),
-  'utf8'
-)
-const optionsApp = fs.readFileSync(
-  path.join(projectRoot, 'src/options/App.vue'),
-  'utf8'
-)
-const contentScript = fs.readFileSync(
-  path.join(projectRoot, 'src/content.js'),
-  'utf8'
-)
+let tempRoot
+let compiledModuleId = 0
+let dom
+let mount
+let flushPromises
+let TranslationSettings
+let SettingsPage
 
-test('switching providers selects the matching detail panel', () => {
+async function createTextModule() {
+  const modulePath = path.join(tempRoot, 'text.mjs')
+  const enPath = JSON.stringify(path.join(projectRoot, 'src/_locales/en/messages.json'))
+  const koPath = JSON.stringify(path.join(projectRoot, 'src/_locales/ko/messages.json'))
+  await writeFile(modulePath, `
+import {readFileSync} from 'node:fs'
+const en = JSON.parse(readFileSync(${enPath}, 'utf8'))
+const ko = JSON.parse(readFileSync(${koPath}, 'utf8'))
+
+export function getText(textId, placeholder = null) {
+  const locale = globalThis.navigator?.language?.toLowerCase().startsWith('ko') ? ko : en
+  const entry = locale[textId]
+  if (!entry?.message) return ''
+  let message = entry.message
+  Object.entries(entry.placeholders || {}).forEach(([name, definition]) => {
+    const match = /^\\$(\\d+)\\$?$/.exec(definition.content || '')
+    const index = match ? Number(match[1]) - 1 : -1
+    const value = Array.isArray(placeholder) ? placeholder[index] : placeholder?.[name]
+    message = message.replaceAll(\`$\${name}$\`, String(value ?? ''))
+  })
+  return message
+}
+`, 'utf8')
+  return pathToFileURL(modulePath).href
+}
+
+function exposeDomGlobal(name, value) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value
+  })
+}
+
+function installDom() {
+  dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    url: 'https://naverdic.test/'
+  })
+
+  const windowGlobals = [
+    'window',
+    'document',
+    'navigator',
+    'Node',
+    'Element',
+    'HTMLElement',
+    'SVGElement',
+    'Event',
+    'MouseEvent',
+    'CustomEvent',
+    'Text',
+    'Comment',
+    'Document',
+    'DocumentFragment',
+    'HTMLInputElement',
+    'HTMLButtonElement',
+    'HTMLSelectElement',
+    'HTMLTextAreaElement',
+    'MutationObserver'
+  ]
+  windowGlobals.forEach(name => exposeDomGlobal(name, dom.window[name]))
+  dom.window.scrollTo = () => {}
+  dom.window.requestAnimationFrame = callback => setTimeout(callback, 0)
+  exposeDomGlobal('requestAnimationFrame', dom.window.requestAnimationFrame)
+  exposeDomGlobal('cancelAnimationFrame', clearTimeout)
+  exposeDomGlobal('getComputedStyle', dom.window.getComputedStyle.bind(dom.window))
+}
+
+function installChromePermissions({contains = true, request = false} = {}) {
+  globalThis.chrome = {
+    i18n: {
+      getMessage() {
+        return ''
+      }
+    },
+    permissions: {
+      contains(_details, callback) {
+        callback?.(contains)
+        return Promise.resolve(contains)
+      },
+      request(_details, callback) {
+        callback?.(request)
+        return Promise.resolve(request)
+      }
+    }
+  }
+}
+
+function rewriteImports(content, replacements = {}) {
+  for (const [specifier, replacement] of Object.entries(replacements)) {
+    content = content
+      .replaceAll(`from '${specifier}'`, `from '${replacement}'`)
+      .replaceAll(`from \"${specifier}\"`, `from \"${replacement}\"`)
+  }
+
+  const sourceUrl = `${pathToFileURL(path.join(projectRoot, 'src')).href}/`
+  return content
+    .replaceAll("from '/src/", `from '${sourceUrl}`)
+    .replaceAll('from \"/src/', `from \"${sourceUrl}`)
+}
+
+async function compileVueModule(relativePath, replacements = {}) {
+  const filename = path.join(projectRoot, relativePath)
+  const source = await readFile(filename, 'utf8')
+  const {descriptor, errors} = parse(source, {filename})
+  assert.equal(errors.length, 0, `failed to parse ${relativePath}`)
+  const compiled = compileScript(descriptor, {
+    id: `test-${compiledModuleId}`,
+    inlineTemplate: true
+  })
+  const content = rewriteImports(compiled.content, replacements)
+  const modulePath = path.join(
+    tempRoot,
+    `${compiledModuleId++}-${path.basename(relativePath, '.vue')}.mjs`
+  )
+  await writeFile(modulePath, content, 'utf8')
+  const imported = await import(`${pathToFileURL(modulePath).href}?test=${compiledModuleId}`)
+  return {component: imported.default, modulePath}
+}
+
+function createChromeRuntime(state = {}) {
+  const currentState = {
+    supported: true,
+    availability: 'available',
+    phase: 'available',
+    progress: null,
+    indeterminate: false,
+    errorCode: null,
+    errorName: '',
+    errorMessage: '',
+    ...state
+  }
+  return {
+    getState: () => currentState,
+    subscribe(listener) {
+      listener(currentState)
+      return () => {}
+    },
+    refreshAvailability: async () => currentState,
+    download: async () => currentState,
+    destroy: async () => {}
+  }
+}
+
+function createCustomProvider() {
+  return normalizeProviderDefinition({
+    id: 'custom-api',
+    name: 'Custom API',
+    kind: 'http',
+    source: 'custom',
+    endpoint: {
+      url: 'https://api.example.test/translate',
+      method: 'POST'
+    },
+    auth: {mode: 'none'},
+    request: {
+      headers: [{name: 'Content-Type', valueTemplate: 'application/json'}],
+      bodyTemplate: {text: '{{text}}'},
+      textPath: 'text',
+      targetLanguagePath: 'target_lang'
+    },
+    response: {textPath: 'text'}
+  })
+}
+
+function createDraft(providerId, customProvider = null) {
+  const draft = createDefaultSettingsV2()
+  draft.translation.enabled = true
+  draft.translation.providerId = providerId
+  if (customProvider) {
+    draft.customProviders = {[customProvider.id]: customProvider}
+  }
+  return draft
+}
+
+before(async () => {
+  installDom()
+  installChromePermissions({contains: true})
+  // Keep generated modules below the workspace so Node can resolve the
+  // repository's Vue package from their location without a custom loader.
+  tempRoot = await mkdtemp(path.join(projectRoot, '.tmp-naverdic-vue-tests-'))
+  const textModuleUrl = await createTextModule()
+  const translationModule = await compileVueModule('src/components/TranslationSettings.vue', {
+    '/src/text.js': textModuleUrl
+  })
+  TranslationSettings = translationModule.component
+  const settingsPageModule = await compileVueModule(
+    'src/components/SettingsPage.vue',
+    {
+      '/src/components/TranslationSettings.vue': pathToFileURL(translationModule.modulePath).href,
+      '/src/text.js': textModuleUrl
+    }
+  )
+  SettingsPage = settingsPageModule.component
+  const testUtils = await import('@vue/test-utils')
+  mount = testUtils.mount
+  flushPromises = testUtils.flushPromises
+})
+
+after(async () => {
+  await rm(tempRoot, {recursive: true, force: true})
+  dom?.window.close()
+})
+
+test('provider panels expose the correct controls when mounted', async () => {
+  const chromeWrapper = mount(TranslationSettings, {
+    props: {
+      draft: createDraft('chrome-translator'),
+      draftSecrets: createDefaultSecretsV2(),
+      translatorRuntime: createChromeRuntime()
+    }
+  })
+  await flushPromises()
+  assert.ok(chromeWrapper.find('[data-testid="settings-translation-form"]').exists())
+  assert.match(chromeWrapper.text(), /en → ko/)
+  assert.equal(chromeWrapper.find('[data-testid="settings-translation-preset-api-key"]').exists(), false)
+  assert.equal(chromeWrapper.find('[data-testid="settings-translation-test"]').exists(), false)
+  chromeWrapper.unmount()
+
+  const deepLSecrets = createDefaultSecretsV2()
+  deepLSecrets.providers['deepl-free'] = {apiKey: 'test-key'}
+  const deepLWrapper = mount(TranslationSettings, {
+    props: {
+      draft: createDraft('deepl-free'),
+      draftSecrets: deepLSecrets
+    }
+  })
+  await flushPromises()
+  assert.ok(deepLWrapper.find('[data-testid="settings-translation-preset-api-key"]').exists())
+  assert.ok(deepLWrapper.find('[data-testid="settings-translation-test"]').exists())
+  deepLWrapper.unmount()
+
+  const customProvider = createCustomProvider()
+  const customWrapper = mount(TranslationSettings, {
+    props: {
+      draft: createDraft(customProvider.id, customProvider),
+      draftSecrets: createDefaultSecretsV2()
+    }
+  })
+  await flushPromises()
+  assert.ok(customWrapper.find('[data-testid="settings-translation-custom-editor"]').exists())
+  assert.ok(customWrapper.find('[data-testid="settings-custom-name"]').exists())
+  assert.ok(customWrapper.find('[data-testid="settings-custom-test"]').exists())
+  customWrapper.unmount()
+})
+
+test('connection controls lock during a mounted request and denied Custom access cannot activate', async () => {
+  const previousFetch = globalThis.fetch
+  let resolveFetch
+  globalThis.fetch = () => new Promise(resolve => {
+    resolveFetch = resolve
+  })
+
+  const secrets = createDefaultSecretsV2()
+  secrets.providers['deepl-free'] = {apiKey: 'test-key'}
+  const deepLWrapper = mount(TranslationSettings, {
+    props: {
+      draft: createDraft('deepl-free'),
+      draftSecrets: secrets
+    }
+  })
+  await deepLWrapper.get('[data-testid="settings-translation-test"]').trigger('click')
+  await flushPromises()
+  assert.equal(deepLWrapper.get('[data-testid="settings-translation-preset-api-key"]').attributes('disabled'), '')
+  assert.equal(deepLWrapper.get('[data-testid="settings-translation-test"]').attributes('disabled'), '')
+  resolveFetch({
+    ok: true,
+    json: async () => ({translations: [{text: 'ok'}]})
+  })
+  await flushPromises()
+  deepLWrapper.unmount()
+  globalThis.fetch = previousFetch
+
+  installChromePermissions({contains: false, request: false})
+  const customProvider = createCustomProvider()
+  const customDraft = createDraft('deepl-free', customProvider)
+  const deniedWrapper = mount(TranslationSettings, {
+    props: {
+      draft: customDraft,
+      draftSecrets: createDefaultSecretsV2()
+    }
+  })
+  await deniedWrapper.get('[data-provider-id="custom-api"]').trigger('click')
+  await flushPromises()
+  await deniedWrapper.get('[data-testid="settings-custom-test"]').trigger('click')
+  await flushPromises()
+  const activateButton = deniedWrapper.get('[data-testid="settings-translation-activate"]')
+  assert.equal(activateButton.attributes('disabled'), '')
+  deniedWrapper.unmount()
+  installChromePermissions({contains: true})
+})
+
+test('Custom edits survive the SettingsPage menu round-trip and keep the dirty callback active', async () => {
+  const customProvider = createCustomProvider()
+  const draft = createDraft(customProvider.id, customProvider)
+  const pendingValues = []
+  const wrapper = mount(SettingsPage, {
+    props: {
+      activePage: {id: 'translation-service'},
+      draft,
+      draftSecrets: createDefaultSecretsV2(),
+      translationPendingChange: value => pendingValues.push(value)
+    }
+  })
+  await flushPromises()
+
+  const nameInput = wrapper.get('[data-testid="settings-custom-name"]')
+  await nameInput.setValue('Edited Custom API')
+  await flushPromises()
+  assert.equal(pendingValues.at(-1), true)
+
+  await wrapper.setProps({activePage: {id: 'appearance'}})
+  await flushPromises()
+  assert.equal(wrapper.find('[data-testid="settings-custom-name"]').exists(), false)
+
+  await wrapper.setProps({activePage: {id: 'translation-service'}})
+  await flushPromises()
+  assert.equal(wrapper.get('[data-testid="settings-custom-name"]').element.value, 'Edited Custom API')
+  assert.equal(pendingValues.at(-1), true)
+  wrapper.unmount()
+})
+
+test('translation settings state helpers keep provider activation and global dirty rules explicit', () => {
   assert.equal(
     getTranslationSettingsPanel('chrome-translator'),
     TRANSLATION_SETTINGS_PANELS.CHROME
@@ -44,55 +360,21 @@ test('switching providers selects the matching detail panel', () => {
     TRANSLATION_SETTINGS_PANELS.PRESET
   )
   assert.equal(
-    getTranslationSettingsPanel('my-api', {
-      'my-api': {source: 'custom'}
-    }),
+    getTranslationSettingsPanel('my-api', {'my-api': {source: 'custom'}}),
     TRANSLATION_SETTINGS_PANELS.CUSTOM
   )
-  assert.match(translationSettings, /v-if="selectedIsChrome"/)
-  assert.match(translationSettings, /v-else-if="selectedPresetId"/)
-  assert.match(translationSettings, /<form v-else class="translation-custom-editor"/)
-})
-
-test('connection-test controls are locked while a request is in flight', () => {
   assert.equal(isTranslationConnectionLocked({connectionStatus: 'testing'}), true)
   assert.equal(isTranslationConnectionLocked({connectionStatus: 'success'}), false)
   assert.equal(isTranslationConnectionLocked({globallyDisabled: true}), true)
-  assert.ok((translationSettings.match(/connectionControlsDisabled\(/g) || []).length >= 4)
-  assert.match(translationSettings, /data-testid="settings-custom-test"/)
-  assert.match(translationSettings, /data-testid="settings-translation-test"/)
-})
 
-test('Custom activation remains blocked when host permission is denied', () => {
   const base = {
     panel: TRANSLATION_SETTINGS_PANELS.CUSTOM,
     connectionStatus: 'success',
     connectionMatches: true
   }
   assert.equal(canActivateTranslationProvider(base), false)
-  assert.equal(canActivateTranslationProvider({
-    ...base,
-    permissionAllowed: true
-  }), true)
-  assert.match(translationSettings, /permissionStates\[selectedProviderId\] === 'allowed'/)
-  assert.match(translationSettings, /canActivateSelected\(\)/)
-})
-
-test('Custom editor dirty state reaches the global save and unload boundary', () => {
+  assert.equal(canActivateTranslationProvider({...base, permissionAllowed: true}), true)
   assert.equal(hasPendingTranslationChanges(false, false), false)
   assert.equal(hasPendingTranslationChanges(false, true), true)
   assert.equal(hasPendingTranslationChanges(true, false), true)
-  assert.match(translationSettings, /onPendingChange/)
-  assert.match(translationSettings, /props\.onPendingChange\?\.\(next\)/)
-  assert.match(settingsShell, /translationEditorDirty/)
-  assert.match(settingsShell, /hasPendingTranslationChanges\(/)
-  assert.match(settingsShell, /shouldWarnBeforeUnload\(hasPendingChanges\.value\)/)
-  assert.match(settingsPage, /on-pending-change="translationPendingChange"/)
-  assert.match(optionsApp, /translation-pending-change="translationPendingChange"/)
-})
-
-test('content translation waits for availability before installing the mouseup path', () => {
-  assert.match(contentScript, /prepareChromeTranslatorRuntime\(\)\.refreshAvailability/)
-  assert.match(contentScript, /finally\(bindInteractionController\)/)
-  assert.match(contentScript, /Translator\.create\(\) before its first await/)
 })

--- a/tests/translation-settings-component.test.mjs
+++ b/tests/translation-settings-component.test.mjs
@@ -172,14 +172,14 @@ function createChromeRuntime(state = {}) {
   }
 }
 
-function createCustomProvider() {
+function createCustomProvider(id = 'custom-api') {
   return normalizeProviderDefinition({
-    id: 'custom-api',
-    name: 'Custom API',
+    id,
+    name: `Custom API ${id}`,
     kind: 'http',
     source: 'custom',
     endpoint: {
-      url: 'https://api.example.test/translate',
+      url: `https://api.example.test/${id}`,
       method: 'POST'
     },
     auth: {mode: 'none'},
@@ -347,6 +347,70 @@ test('Custom edits survive the SettingsPage menu round-trip and keep the dirty c
   await flushPromises()
   assert.equal(wrapper.get('[data-testid="settings-custom-name"]').element.value, 'Edited Custom API')
   assert.equal(pendingValues.at(-1), true)
+  wrapper.unmount()
+})
+
+test('pending state remains true when a dirty Custom provider is cached while switching to another provider', async () => {
+  const customA = createCustomProvider('custom-a')
+  const customB = createCustomProvider('custom-b')
+  const draft = createDraft(customA.id, customA)
+  draft.customProviders[customB.id] = customB
+  const pendingValues = []
+  const wrapper = mount(TranslationSettings, {
+    props: {
+      draft,
+      draftSecrets: createDefaultSecretsV2(),
+      onPendingChange: value => pendingValues.push(value)
+    }
+  })
+  await flushPromises()
+
+  await wrapper.get('[data-testid="settings-custom-name"]').setValue('Edited Custom A')
+  await flushPromises()
+  await wrapper.get('[data-provider-id="custom-b"]').trigger('click')
+  await flushPromises()
+  assert.equal(pendingValues.at(-1), true)
+
+  await wrapper.get('[data-provider-id="custom-a"]').trigger('click')
+  await flushPromises()
+  assert.equal(wrapper.get('[data-testid="settings-custom-name"]').element.value, 'Edited Custom A')
+  assert.equal(pendingValues.at(-1), true)
+  wrapper.unmount()
+})
+
+test('reset revision clears cached Custom edits and the global dirty callback', async () => {
+  const customProvider = createCustomProvider('custom-reset')
+  const pendingValues = []
+  const wrapper = mount(SettingsPage, {
+    props: {
+      activePage: {id: 'translation-service'},
+      draft: createDraft(customProvider.id, customProvider),
+      draftSecrets: createDefaultSecretsV2(),
+      draftRevision: 0,
+      draftResetRevision: 0,
+      translationPendingChange: value => pendingValues.push(value)
+    }
+  })
+  await flushPromises()
+
+  await wrapper.get('[data-testid="settings-custom-name"]').setValue('Discard me')
+  await flushPromises()
+  await wrapper.setProps({activePage: {id: 'appearance'}})
+  await flushPromises()
+
+  await wrapper.setProps({
+    draft: createDefaultSettingsV2(),
+    draftSecrets: createDefaultSecretsV2(),
+    draftRevision: 1,
+    draftResetRevision: 1
+  })
+  await flushPromises()
+  await wrapper.setProps({activePage: {id: 'translation-service'}})
+  await flushPromises()
+
+  assert.equal(wrapper.find('[data-testid="settings-custom-name"]').exists(), false)
+  assert.ok(wrapper.find('[data-testid="settings-translation-preset-api-key"]').exists())
+  assert.equal(pendingValues.at(-1), false)
   wrapper.unmount()
 })
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,10 @@
 import vue from '@vitejs/plugin-vue'
-import { resolve } from 'path'
+import { dirname, resolve } from 'path'
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
+import { fileURLToPath } from 'url'
+
+const projectRoot = dirname(fileURLToPath(import.meta.url))
 
 export default defineConfig({
   server: {
@@ -10,9 +13,9 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
-        index: resolve(__dirname, 'index.html'),
-        popup: resolve(__dirname, 'popup.html'),
-        options: resolve(__dirname, 'options.html'),
+        index: resolve(projectRoot, 'index.html'),
+        popup: resolve(projectRoot, 'popup.html'),
+        options: resolve(projectRoot, 'options.html'),
       }
     }
   },
@@ -56,7 +59,35 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/content-settings.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/chrome-translator.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/settings.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/settings-v2.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/settings-v2-storage.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/settings-migration-v2.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/translation-settings.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/translation-testing.mjs',
           dest: '.'
         },
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,49 @@
 # yarn lockfile v1
 
 
+"@asamuzakjp/css-color@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
+  integrity sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==
+  dependencies:
+    "@csstools/css-calc" "^2.1.3"
+    "@csstools/css-color-parser" "^3.0.9"
+    "@csstools/css-parser-algorithms" "^3.0.4"
+    "@csstools/css-tokenizer" "^3.0.3"
+    lru-cache "^10.4.3"
+
 "@babel/parser@^7.16.4":
   version "7.21.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.2.tgz#dacafadfc6d7654c3051a66d6fe55b6cb2f2a0b3"
   integrity sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==
+
+"@csstools/color-helpers@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.1.0.tgz#106c54c808cabfd1ab4c602d8505ee584c2996ef"
+  integrity sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==
+
+"@csstools/css-calc@^2.1.3", "@csstools/css-calc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-calc/-/css-calc-2.1.4.tgz#8473f63e2fcd6e459838dd412401d5948f224c65"
+  integrity sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==
+
+"@csstools/css-color-parser@^3.0.9":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz#4e386af3a99dd36c46fef013cfe4c1c341eed6f0"
+  integrity sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==
+  dependencies:
+    "@csstools/color-helpers" "^5.1.0"
+    "@csstools/css-calc" "^2.1.4"
+
+"@csstools/css-parser-algorithms@^3.0.4":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz#5755370a9a29abaec5515b43c8b3f2cf9c2e3076"
+  integrity sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==
+
+"@csstools/css-tokenizer@^3.0.3":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz#333fedabc3fd1a8e5d0100013731cf19e6a8c5d3"
+  integrity sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==
 
 "@esbuild/aix-ppc64@0.25.12":
   version "0.25.12"
@@ -137,6 +176,18 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz#9bdad8176be7811ad148d1f8772359041f46c6c5"
   integrity sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -157,6 +208,16 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
+
+"@one-ini/wasm@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@one-ini/wasm/-/wasm-0.1.1.tgz#6013659736c9dbfccc96e8a9c2b3de317df39323"
+  integrity sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@rollup/rollup-android-arm-eabi@4.60.1":
   version "4.60.1"
@@ -383,6 +444,46 @@
   resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.2.47.tgz#e597ef75086c6e896ff5478a6bfc0a7aa4bbd14c"
   integrity sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==
 
+"@vue/test-utils@2.4.6":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.4.6.tgz#7d534e70c4319d2a587d6a3b45a39e9695ade03c"
+  integrity sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==
+  dependencies:
+    js-beautify "^1.14.9"
+    vue-component-type-helpers "^2.0.0"
+
+abbrev@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz#cf59829b8b4f03f89dda2771cb7f3653828c89bf"
+  integrity sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==
+
+agent-base@^7.1.0, agent-base@^7.1.2:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
+  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-regex@^6.2.2:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.3.0.tgz#247c8e7b70a1a43b10ce14c0226fcbf58e8815d5"
+  integrity sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==
+
+ansi-styles@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
+  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -391,10 +492,27 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+balanced-match@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+brace-expansion@^2.0.2:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.4.tgz#589dab11c0018d0366be64cd8bf12c8dbecc8326"
+  integrity sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -402,6 +520,14 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
 
 chokidar@^3.5.3:
   version "3.5.3"
@@ -418,10 +544,150 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+commander@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
+  integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
+
+config-chain@^1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/config-chain/-/config-chain-1.1.13.tgz#fad0795aa6a6cdaff9ed1b68e9dff94372c232f4"
+  integrity sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==
+  dependencies:
+    ini "^1.3.4"
+    proto-list "~1.2.1"
+
+cross-spawn@^7.0.6:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+cssstyle@^4.0.1:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-4.6.0.tgz#ea18007024e3167f4f105315f3ec2d982bf48ed9"
+  integrity sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==
+  dependencies:
+    "@asamuzakjp/css-color" "^3.2.0"
+    rrweb-cssom "^0.8.0"
+
 csstype@^2.6.8:
   version "2.6.21"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.21.tgz#2efb85b7cc55c80017c66a5ad7cbd931fda3a90e"
   integrity sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==
+
+data-urls@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-5.0.0.tgz#2f76906bce1824429ffecb6920f45a0b30f00dde"
+  integrity sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==
+  dependencies:
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+
+debug@4, debug@^4.3.4:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+decimal.js@^10.4.3:
+  version "10.6.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
+  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
+
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+editorconfig@^1.0.4:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/editorconfig/-/editorconfig-1.0.7.tgz#8d6e178aeb507c206d65e1804c1d7510d110d434"
+  integrity sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==
+  dependencies:
+    "@one-ini/wasm" "0.1.1"
+    commander "^10.0.0"
+    minimatch "^9.0.1"
+    semver "^7.5.3"
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+entities@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-6.0.1.tgz#c28c34a43379ca7f61d074130b2f5f7020a30694"
+  integrity sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==
+
+es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
+  integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
 
 esbuild@^0.25.0:
   version "0.25.12"
@@ -490,6 +756,25 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+foreground-child@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.3.1.tgz#32e8e9ed1b68a3497befb9ac2b6adf92a638576f"
+  integrity sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==
+  dependencies:
+    cross-spawn "^7.0.6"
+    signal-exit "^4.0.1"
+
+form-data@^4.0.0:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    hasown "^2.0.4"
+    mime-types "^2.1.35"
+
 fs-extra@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.1.0.tgz#5784b102104433bb0e090f48bfc4a30742c357ed"
@@ -509,6 +794,35 @@ fsevents@~2.3.3:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-intrinsic@^1.2.6:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -516,10 +830,81 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
+glob@^10.4.2:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
+  integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
+
+gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
+hasown@^2.0.2, hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
+html-encoding-sniffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz#696df529a7cfd82446369dc5193e590a3735b448"
+  integrity sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==
+  dependencies:
+    whatwg-encoding "^3.1.1"
+
+http-proxy-agent@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
+  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
+  dependencies:
+    agent-base "^7.1.0"
+    debug "^4.3.4"
+
+https-proxy-agent@^7.0.5:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
+  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
+  dependencies:
+    agent-base "^7.1.2"
+    debug "4"
+
+iconv-lite@0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
+  integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
+
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -533,6 +918,11 @@ is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+
 is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
@@ -545,6 +935,68 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
+
+js-beautify@^1.14.9:
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/js-beautify/-/js-beautify-1.15.4.tgz#f579f977ed4c930cef73af8f98f3f0a608acd51e"
+  integrity sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==
+  dependencies:
+    config-chain "^1.1.13"
+    editorconfig "^1.0.4"
+    glob "^10.4.2"
+    js-cookie "^3.0.5"
+    nopt "^7.2.1"
+
+js-cookie@^3.0.5:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.8.tgz#444e6f4b27a5d844594fef61c9d6bca5f0787688"
+  integrity sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==
+
+jsdom@24.1.3:
+  version "24.1.3"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-24.1.3.tgz#88e4a07cb9dd21067514a619e9f17b090a394a9f"
+  integrity sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==
+  dependencies:
+    cssstyle "^4.0.1"
+    data-urls "^5.0.0"
+    decimal.js "^10.4.3"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^4.0.0"
+    http-proxy-agent "^7.0.2"
+    https-proxy-agent "^7.0.5"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.12"
+    parse5 "^7.1.2"
+    rrweb-cssom "^0.7.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.4"
+    w3c-xmlserializer "^5.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^3.1.1"
+    whatwg-mimetype "^4.0.0"
+    whatwg-url "^14.0.0"
+    ws "^8.18.0"
+    xml-name-validator "^5.0.0"
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
@@ -554,12 +1006,22 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+lru-cache@^10.2.0, lru-cache@^10.4.3:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 magic-string@^0.25.7:
   version "0.25.9"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.9.tgz#de7f9faf91ef8a1c91d02c2e5314c8277dbcdd1c"
   integrity sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==
   dependencies:
     sourcemap-codec "^1.4.8"
+
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 merge2@^1.3.0:
   version "1.4.1"
@@ -574,20 +1036,86 @@ micromatch@^4.0.4:
     braces "^3.0.3"
     picomatch "^2.3.1"
 
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.35:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+minimatch@^9.0.1, minimatch@^9.0.4:
+  version "9.0.9"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
+  integrity sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==
+  dependencies:
+    brace-expansion "^2.0.2"
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
 nanoid@^3.3.16:
   version "3.3.18"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
+nopt@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-7.2.1.tgz#1cac0eab9b8e97c9093338446eddd40b2c8ca1e7"
+  integrity sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==
+  dependencies:
+    abbrev "^2.0.0"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+nwsapi@^2.2.12:
+  version "2.2.24"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.24.tgz#f8927043d4c9b516abdebe804a32c8d1f9484d1f"
+  integrity sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==
+
 p-map@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-7.0.3.tgz#7ac210a2d36f81ec28b736134810f7ba4418cdb6"
   integrity sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
+  integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
+
+parse5@^7.1.2:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.3.0.tgz#d7e224fa72399c7a175099f45fc2ad024b05ec05"
+  integrity sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==
+  dependencies:
+    entities "^6.0.0"
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 picocolors@^1.0.0:
   version "1.0.0"
@@ -618,6 +1146,28 @@ postcss@^8.1.10, postcss@^8.5.3:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+proto-list@~1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
+  integrity sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==
+
+psl@^1.1.33:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.15.0.tgz#bdace31896f1d97cec6a79e8224898ce93d974c6"
+  integrity sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==
+  dependencies:
+    punycode "^2.3.1"
+
+punycode@^2.1.1, punycode@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
@@ -629,6 +1179,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -669,12 +1224,56 @@ rollup@^4.34.9:
     "@rollup/rollup-win32-x64-msvc" "4.60.1"
     fsevents "~2.3.2"
 
+rrweb-cssom@^0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz#c73451a484b86dd7cfb1e0b2898df4b703183e4b"
+  integrity sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==
+
+rrweb-cssom@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz#3021d1b4352fbf3b614aaeed0bc0d5739abe0bc2"
+  integrity sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+"safer-buffer@>= 2.1.2 < 3.0.0":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
+
+semver@^7.5.3:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-2.0.0.tgz#ccd0af4f8835fbdc265b82461aaf0c36663f34ea"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -691,6 +1290,59 @@ sourcemap-codec@^1.4.8:
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
   integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
+
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
+  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
+  dependencies:
+    ansi-regex "^6.2.2"
+
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tinyglobby@^0.2.13:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -706,10 +1358,40 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+tough-cookie@^4.1.4:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.4.tgz#945f1461b45b5a8c76821c33ea49c3ac192c1b36"
+  integrity sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
+tr46@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-5.1.1.tgz#96ae867cddb8fdb64a49cc3059a8d428bcf238ca"
+  integrity sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==
+  dependencies:
+    punycode "^2.3.1"
+
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 vite-plugin-static-copy@^2.3.2:
   version "2.3.2"
@@ -736,6 +1418,11 @@ vite@^6.4.3:
   optionalDependencies:
     fsevents "~2.3.3"
 
+vue-component-type-helpers@^2.0.0:
+  version "2.2.12"
+  resolved "https://registry.yarnpkg.com/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz#5014787aad185a22f460ad469cc51f14524308bc"
+  integrity sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==
+
 vue@^3.2.45:
   version "3.2.47"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.47.tgz#3eb736cbc606fc87038dbba6a154707c8a34cff0"
@@ -746,3 +1433,75 @@ vue@^3.2.45:
     "@vue/runtime-dom" "3.2.47"
     "@vue/server-renderer" "3.2.47"
     "@vue/shared" "3.2.47"
+
+w3c-xmlserializer@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz#f925ba26855158594d907313cedd1476c5967f6c"
+  integrity sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==
+  dependencies:
+    xml-name-validator "^5.0.0"
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-encoding@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz#d0f4ef769905d426e1688f3e34381a99b60b76e5"
+  integrity sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==
+  dependencies:
+    iconv-lite "0.6.3"
+
+whatwg-mimetype@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz#bc1bf94a985dc50388d54a9258ac405c3ca2fc0a"
+  integrity sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==
+
+whatwg-url@^14.0.0:
+  version "14.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-14.2.0.tgz#4ee02d5d725155dae004f6ae95c73e7ef5d95663"
+  integrity sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==
+  dependencies:
+    tr46 "^5.1.0"
+    webidl-conversions "^7.0.0"
+
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
+ws@^8.18.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
+
+xml-name-validator@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-5.0.0.tgz#82be9b957f7afdacf961e5980f1bf227c0bf7673"
+  integrity sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==


### PR DESCRIPTION
## Summary
- 최신 Figma 번역 서비스 화면을 300px 서비스 선택 열 + 556px 세부 설정 열로 반영
- Chrome 내장 번역 (Translator API)의 고정 en → ko availability/download/progress/error 상태와 content-page 직접 번역 경로 구현
- DeepL/Gemini API 키·연결 테스트, Custom API 편집·host permission·활성화 조건과 local-only secrets 회귀 보존
- v6.6 storage migration, content runtime, manifest/build/package 의존성 회귀 보강

## Review follow-up
- 최신 `firstlight`(PR #35 merge) 기준으로 rebase했습니다.
- Chrome provider 적용 시 availability 확인이 끝난 뒤 mouseup 핸들러를 설치해, 첫 실제 번역의 `Translator.create()`가 사용자 활성화 안에서 시작되도록 보강했습니다.
- Custom API 미저장 편집 상태를 SettingsShell의 전체 dirty 상태·상단 저장 상태·beforeunload 경고에 연결했습니다.
- `isTranslationConnectionLocked` import 누락을 보완해 실제 TranslationSettings 렌더링 오류를 제거했습니다.
- `KeepAlive`를 항상 유지하고 TranslationSettings 자식만 전환하도록 바꿔, Custom 편집값과 dirty 콜백이 메뉴 왕복 후에도 유지되도록 했습니다.
- Custom A를 수정한 뒤 Custom B로 전환해도 캐시 전체를 기준으로 전역 pending을 유지하도록 했습니다.
- reset 전용 revision을 SettingsShell → SettingsPage → TranslationSettings로 전달해 기본값 복원 시 모든 Custom 편집 캐시·editor·dirty 상태를 폐기하도록 했습니다.
- jsdom + Vue Test Utils 실제 mount 테스트로 Chrome/DeepL/Custom 패널 렌더링, 연결 테스트 중 잠금, Custom 권한 거부 활성화 차단, 메뉴 왕복, 복수 Custom 캐시 pending, reset 후 초기화를 검증했습니다.

## Verification
- `yarn test` — 103 passed
- `yarn build` — passed
- `NAVERDIC_ZIP_DIR=/tmp yarn package` — package validation passed (39 unpacked files + ZIP)

## Review points
- Chrome model download calls `Translator.create({sourceLanguage:'en', targetLanguage:'ko', monitor})` synchronously from the button handler and reuses the document translator instance.
- Chrome is never sent through the background HTTP adapter; background requests without a content runtime remain rejected.
- Chrome detail/preview contains no API key, external endpoint, or connection-test controls.
