### PR TITLE
fix(settings): rename reset preview title

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -503,7 +503,7 @@
     "message": "Add only the domains you need; the popup will continue to work on other sites."
   },
   "SETTINGS_PREVIEW_ADVANCED_TITLE": {
-    "message": "Complete reset"
+    "message": "Reset settings"
   },
   "SETTINGS_PREVIEW_ADVANCED_DESCRIPTION": {
     "message": "Review the contents before deleting."

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -503,7 +503,7 @@
     "message": "필요한 도메인만 추가하면 다른 사이트에는 계속 적용됩니다."
   },
   "SETTINGS_PREVIEW_ADVANCED_TITLE": {
-    "message": "완전 초기화"
+    "message": "설정 초기화"
   },
   "SETTINGS_PREVIEW_ADVANCED_DESCRIPTION": {
     "message": "삭제 전 내용을 꼭 확인하세요."


### PR DESCRIPTION
## 변경 내용

- 고급 설정 우측 미리보기 제목을 `설정 초기화` / `Reset settings`로 변경했습니다.
- 초기화 동작과 다른 문구는 변경하지 않았습니다.

## 검증 결과

- `yarn lint` 통과
- `yarn test` 통과 — 126 tests
- `yarn build` 통과 — Vite 50 modules transformed