### PR TITLE
[NaverDic][Stage 2] TASK 7 inline popup rebuild

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -25,12 +25,11 @@
     "matches": [ "<all_urls>" ],
     "run_at": "document_idle",
     "all_frames": true,
-    "css": ["content.css"],
     "js": ["contentWrapper.js"]
   }],
   "web_accessible_resources": [
     {
-      "resources": ["content.js", "content-interaction.mjs", "content-storage.mjs", "content-settings.mjs", "chrome-translator.mjs", "messaging.mjs", "settings.mjs", "settings-v2.mjs", "settings-v2-storage.mjs", "settings-migration-v2.mjs", "translation-provider.mjs", "translation-engine.mjs", "translation-settings.mjs", "translation-testing.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
+      "resources": ["content.js", "content-data.mjs", "content-position.mjs", "content-popup.mjs", "content-request.mjs", "content-interaction.mjs", "content-storage.mjs", "content-settings.mjs", "chrome-translator.mjs", "messaging.mjs", "settings.mjs", "settings-v2.mjs", "settings-v2-storage.mjs", "settings-migration-v2.mjs", "translation-provider.mjs", "translation-engine.mjs", "translation-settings.mjs", "translation-testing.mjs", "content.css", "dictionary/parser.mjs", "dictionary/normalizer.mjs"],
       "matches": [ "<all_urls>" ]
     }
   ],

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -143,6 +143,24 @@
   "RESET_STATUS": {
     "message": "Options reset."
   },
+  "INLINE_POPUP_DICTIONARY_TITLE": {
+    "message": "Dictionary"
+  },
+  "INLINE_POPUP_TRANSLATION_TITLE": {
+    "message": "Translation"
+  },
+  "INLINE_POPUP_LOADING": {
+    "message": "Loading…"
+  },
+  "INLINE_POPUP_NO_RESULT": {
+    "message": "No result found."
+  },
+  "INLINE_POPUP_NETWORK_ERROR": {
+    "message": "The result could not be loaded. Please try again."
+  },
+  "INLINE_POPUP_AUDIO_UNAVAILABLE": {
+    "message": "Audio is unavailable."
+  },
   "SAVE": {
     "message": "Save"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -158,9 +158,6 @@
   "INLINE_POPUP_NETWORK_ERROR": {
     "message": "The result could not be loaded. Please try again."
   },
-  "INLINE_POPUP_AUDIO_UNAVAILABLE": {
-    "message": "Audio is unavailable."
-  },
   "SAVE": {
     "message": "Save"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -143,6 +143,24 @@
   "RESET_STATUS": {
     "message": "초기화 되었습니다."
   },
+  "INLINE_POPUP_DICTIONARY_TITLE": {
+    "message": "사전"
+  },
+  "INLINE_POPUP_TRANSLATION_TITLE": {
+    "message": "번역"
+  },
+  "INLINE_POPUP_LOADING": {
+    "message": "불러오는 중…"
+  },
+  "INLINE_POPUP_NO_RESULT": {
+    "message": "결과가 없습니다."
+  },
+  "INLINE_POPUP_NETWORK_ERROR": {
+    "message": "결과를 불러오지 못했습니다. 다시 시도해 주세요."
+  },
+  "INLINE_POPUP_AUDIO_UNAVAILABLE": {
+    "message": "발음을 재생할 수 없습니다."
+  },
   "SAVE": {
     "message": "저장"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -158,9 +158,6 @@
   "INLINE_POPUP_NETWORK_ERROR": {
     "message": "결과를 불러오지 못했습니다. 다시 시도해 주세요."
   },
-  "INLINE_POPUP_AUDIO_UNAVAILABLE": {
-    "message": "발음을 재생할 수 없습니다."
-  },
   "SAVE": {
     "message": "저장"
   },

--- a/src/content-data.mjs
+++ b/src/content-data.mjs
@@ -1,0 +1,216 @@
+import {buildNaverApiUrl, parseNaverDictionaryResponse} from './dictionary/parser.mjs'
+import {
+  MESSAGE_ERROR_CODES,
+  createDictionaryRequest as createDictionaryMessage,
+  createErrorResponse,
+  createTranslationRequest as createTranslationMessage,
+  sendRuntimeMessage
+} from './messaging.mjs'
+import {executeProviderTranslation, getPathValue} from './translation-engine.mjs'
+import {
+  CHROME_TRANSLATOR_PROVIDER_ID,
+  getProviderPreset,
+  PROVIDER_KINDS
+} from './translation-provider.mjs'
+import {createAbortError} from './content-request.mjs'
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) {
+    throw createAbortError()
+  }
+}
+
+/**
+ * Chrome's runtime messaging API cannot cancel an already-dispatched message.
+ * Race it against the request signal so a closed/replaced popup stops waiting
+ * immediately while the coordinator's revision guard ignores the late result.
+ */
+export function awaitWithAbort(value, signal) {
+  throwIfAborted(signal)
+
+  if (!signal || typeof signal.addEventListener !== 'function') {
+    return Promise.resolve(value)
+  }
+
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let abortListener = null
+
+    const cleanup = () => {
+      if (abortListener) {
+        signal.removeEventListener?.('abort', abortListener)
+      }
+    }
+
+    const complete = callback => result => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      cleanup()
+      callback(result)
+    }
+
+    const onAbort = complete(reject)
+    abortListener = () => onAbort(createAbortError())
+    signal.addEventListener('abort', abortListener, {once: true})
+
+    Promise.resolve(value).then(
+      complete(resolve),
+      complete(reject)
+    )
+  })
+}
+
+function createInlineRequestError(scope, {
+  code = MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+  message = 'The popup request failed.',
+  response,
+  cause
+} = {}) {
+  const error = new Error(message)
+  error.name = 'InlinePopupRequestError'
+  error.code = code
+  error.scope = scope
+  error.response = response || createErrorResponse(code, message)
+  if (cause) {
+    error.cause = cause
+  }
+  return error
+}
+
+function responseError(scope, response) {
+  return createInlineRequestError(scope, {
+    code: response?.error?.code || MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+    message: response?.error?.message || 'The popup request failed.',
+    response
+  })
+}
+
+function normalizeTranslationConfig(value) {
+  if (value && typeof value === 'object' && value.provider) {
+    return {
+      provider: value.provider,
+      credential: typeof value.credential === 'string' ? value.credential : '',
+      targetLanguage: typeof value.targetLanguage === 'string'
+        ? value.targetLanguage
+        : 'ko'
+    }
+  }
+
+  return {
+    provider: getProviderPreset('deepl-free'),
+    credential: typeof value === 'string' ? value : '',
+    targetLanguage: 'ko'
+  }
+}
+
+function providerError(scope, error) {
+  if (error?.name === 'InlinePopupRequestError') {
+    return error
+  }
+
+  return createInlineRequestError(scope, {
+    code: error?.code || MESSAGE_ERROR_CODES.RUNTIME_ERROR,
+    message: error?.message || 'The popup request failed.',
+    cause: error
+  })
+}
+
+/**
+ * Keep dictionary/translation transport and response normalization out of the
+ * content interaction and popup rendering code.
+ */
+export function createInlinePopupDataClient({
+  runtime,
+  getChromeTranslatorRuntime,
+  sendMessage = sendRuntimeMessage
+} = {}) {
+  async function lookupDictionary(query, {signal} = {}) {
+    throwIfAborted(signal)
+
+    const response = await awaitWithAbort(
+      sendMessage(
+        runtime,
+        createDictionaryMessage({
+          method: 'GET',
+          url: buildNaverApiUrl(query)
+        })
+      ),
+      signal
+    )
+
+    if (!response?.ok) {
+      throw responseError('dictionary lookup', response)
+    }
+
+    return parseNaverDictionaryResponse(response.data)
+  }
+
+  async function translate(text, value, {signal} = {}) {
+    throwIfAborted(signal)
+
+    const config = normalizeTranslationConfig(value)
+    const provider = config.provider || getProviderPreset('deepl-free')
+
+    if (
+      provider.kind === PROVIDER_KINDS.BUILT_IN &&
+      provider.id === CHROME_TRANSLATOR_PROVIDER_ID
+    ) {
+      try {
+        const result = await awaitWithAbort(
+          executeProviderTranslation(provider, {
+            text: [text],
+            targetLanguage: 'ko',
+            translatorRuntime: getChromeTranslatorRuntime?.()
+          }),
+          signal
+        )
+        return typeof result?.text === 'string' ? result.text : ''
+      } catch (error) {
+        throw providerError('translation', error)
+      }
+    }
+
+    const response = await awaitWithAbort(
+      sendMessage(
+        runtime,
+        createTranslationMessage({
+          provider,
+          key: config.credential,
+          data: {
+            text: [text],
+            targetLanguage: config.targetLanguage
+          }
+        })
+      ),
+      signal
+    )
+
+    if (!response?.ok) {
+      throw responseError('translation', response)
+    }
+
+    const translatedText = getPathValue(response.data, provider.response?.textPath)
+    if (typeof translatedText !== 'string') {
+      throw createInlineRequestError('translation', {
+        code: MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+        message: 'The translation response did not include translated text.',
+        response: createErrorResponse(
+          MESSAGE_ERROR_CODES.INVALID_RESPONSE,
+          'The translation response did not include translated text.'
+        )
+      })
+    }
+
+    return translatedText
+  }
+
+  return {
+    lookupDictionary,
+    translate
+  }
+}
+
+export {normalizeTranslationConfig}

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -12,7 +12,7 @@ export const POPUP_STATES = Object.freeze({
 })
 
 const DEFAULT_POPUP_OPTIONS = Object.freeze({
-  width: 360,
+  width: 440,
   backgroundColor: '#FFF59D',
   fontColor: '#000000',
   fontSizePt: 11,
@@ -57,6 +57,9 @@ const FALLBACK_CSS = `
   max-height: calc(var(--naverdic-popup-max-height, 480px) - 42px);
   overflow: auto;
   overscroll-behavior: contain;
+}
+.naverdic-popup[data-type="translation"] .naverdic-popup__body {
+  line-height: 1.45;
 }
 `
 

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -574,9 +574,9 @@ export function createPopupController({
     popupView.mount()
     popupView.update({type, state: POPUP_STATES.LOADING})
     popupView.setVisibility('hidden')
+    visibilityRevision += 1
     bindListeners()
     reposition()
-    revealWhenReady()
   }
 
   function update(state, data) {
@@ -586,8 +586,11 @@ export function createPopupController({
 
     popupView.update({type, state, data})
     popupView.setVisibility('hidden')
+    visibilityRevision += 1
     reposition()
-    revealWhenReady()
+    if (state !== POPUP_STATES.LOADING) {
+      revealWhenReady()
+    }
   }
 
   function close(reason = 'programmatic', {notify = true} = {}) {

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -226,7 +226,7 @@ function createPopupView({
     host.dataset.naverdicPopup = 'true'
     host.style.cssText = [
       'all: initial',
-      'position: absolute',
+      'position: fixed',
       'top: 0',
       'left: 0',
       'width: 0',
@@ -265,7 +265,7 @@ function createPopupView({
     popup.style.color = popupOptions.fontColor
     popup.style.fontSize = `${popupOptions.fontSizePt}pt`
 
-    const mountTarget = documentLike.body || documentLike.documentElement
+    const mountTarget = documentLike.documentElement || documentLike.body
     mountTarget?.appendChild(host)
 
     stylesPromise = Promise.resolve()
@@ -474,7 +474,15 @@ export function createPopupController({
       margin: popupOptions.margin,
       gap: popupOptions.gap
     })
-    popupView.setPosition(position)
+    const viewport = position.viewport
+    popupView.setPosition({
+      ...position,
+      // The calculator works in document coordinates. The fixed host is
+      // anchored to the current visual viewport, so convert only the final
+      // coordinates before applying them to the shadow popup.
+      left: position.left - viewport.left,
+      top: position.top - viewport.top
+    })
   }
 
   function revealWhenReady() {

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -114,7 +114,7 @@ function createTextElement(documentLike, tagName, className, value) {
   return element
 }
 
-function renderDictionary(documentLike, container, entries) {
+function renderDictionary(documentLike, container, entries, onAudioFailure) {
   let audioShown = false
 
   entries.forEach(entry => {
@@ -158,6 +158,7 @@ function renderDictionary(documentLike, container, entries) {
 
         audio.dataset.failed = 'true'
         audioWrapper.remove?.()
+        onAudioFailure?.()
       })
       audioWrapper.appendChild(audio)
       title.appendChild(audioWrapper)
@@ -329,7 +330,12 @@ function createPopupView({
         'alert'
       )
     } else if (type === 'dictionary') {
-      renderDictionary(documentLike, body, Array.isArray(data) ? data : [])
+      renderDictionary(
+        documentLike,
+        body,
+        Array.isArray(data) ? data : [],
+        () => layoutChangeHandler?.()
+      )
     } else {
       renderTranslation(documentLike, body, data)
     }

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -31,8 +31,33 @@ const DEFAULT_TEXT = Object.freeze({
 
 const FALLBACK_CSS = `
 :host { all: initial; }
-.naverdic-popup { box-sizing: border-box; }
-.naverdic-popup__body { box-sizing: border-box; overflow: auto; }
+.naverdic-popup {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  height: auto;
+  line-height: normal;
+  padding: 9px;
+  border: 1px solid #999;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  pointer-events: auto;
+}
+.naverdic-popup__header {
+  flex: 0 0 auto;
+  margin: 0 0 8px;
+  padding: 0 1px;
+  font-weight: bold;
+}
+.naverdic-popup__body {
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  max-height: calc(var(--naverdic-popup-max-height, 480px) - 42px);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
 `
 
 function defaultText(messageId) {
@@ -183,6 +208,7 @@ function createPopupView({
   let host = null
   let shadowRoot = null
   let popup = null
+  let header = null
   let title = null
   let body = null
   let style = null
@@ -222,7 +248,7 @@ function createPopupView({
     popup.setAttribute('aria-live', 'polite')
     popup.setAttribute('aria-label', getText('INLINE_POPUP_DICTIONARY_TITLE'))
 
-    const header = documentLike.createElement('div')
+    header = documentLike.createElement('div')
     header.className = 'naverdic-popup__header'
     title = documentLike.createElement('div')
     title.className = 'naverdic-popup__title'
@@ -233,6 +259,11 @@ function createPopupView({
     body.className = 'naverdic-popup__body'
     popup.appendChild(body)
     shadowRoot.appendChild(popup)
+
+    popup.style.width = `${Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width}px`
+    popup.style.backgroundColor = popupOptions.backgroundColor
+    popup.style.color = popupOptions.fontColor
+    popup.style.fontSize = `${popupOptions.fontSizePt}pt`
 
     const mountTarget = documentLike.body || documentLike.documentElement
     mountTarget?.appendChild(host)
@@ -260,7 +291,10 @@ function createPopupView({
     const titleText = type === 'translation'
       ? getText('INLINE_POPUP_TRANSLATION_TITLE')
       : getText('INLINE_POPUP_DICTIONARY_TITLE')
-    title.textContent = titleText
+    const showHeader = type === 'translation'
+    header.hidden = !showHeader
+    header.style.display = showHeader ? '' : 'none'
+    title.textContent = showHeader ? titleText : ''
     popup.dataset.type = type
     popup.dataset.state = state
     popup.setAttribute('aria-label', titleText)
@@ -300,6 +334,7 @@ function createPopupView({
 
   function measure() {
     ensureMounted()
+    popup.style.width = `${Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width}px`
     popup.style.maxHeight = 'none'
     popup.style.setProperty('--naverdic-popup-max-height', '100000px')
     const rect = popup.getBoundingClientRect?.() || {}
@@ -352,6 +387,7 @@ function createPopupView({
     host = null
     shadowRoot = null
     popup = null
+    header = null
     title = null
     body = null
     style = null
@@ -361,6 +397,7 @@ function createPopupView({
     mount: ensureMounted,
     update,
     measure,
+    whenReady: () => stylesPromise || Promise.resolve(),
     setPosition,
     setVisibility,
     setOptions,
@@ -395,6 +432,7 @@ export function createPopupController({
   let frameId = null
   let listenersBound = false
   let onClose = null
+  let visibilityRevision = 0
 
   function scheduleReposition() {
     if (!open || destroyed) {
@@ -435,6 +473,20 @@ export function createPopupController({
       gap: popupOptions.gap
     })
     popupView.setPosition(position)
+  }
+
+  function revealWhenReady() {
+    const revision = ++visibilityRevision
+    Promise.resolve(popupView.whenReady?.())
+      .catch(() => {})
+      .then(() => {
+        if (!open || destroyed || revision !== visibilityRevision) {
+          return
+        }
+
+        popupView.setVisibility('visible')
+        scheduleReposition()
+      })
   }
 
   function eventIsInside(event) {
@@ -524,7 +576,7 @@ export function createPopupController({
     popupView.setVisibility('hidden')
     bindListeners()
     reposition()
-    popupView.setVisibility('visible')
+    revealWhenReady()
   }
 
   function update(state, data) {
@@ -535,7 +587,7 @@ export function createPopupController({
     popupView.update({type, state, data})
     popupView.setVisibility('hidden')
     reposition()
-    popupView.setVisibility('visible')
+    revealWhenReady()
   }
 
   function close(reason = 'programmatic', {notify = true} = {}) {
@@ -544,6 +596,7 @@ export function createPopupController({
     }
 
     open = false
+    visibilityRevision += 1
     if (frameId !== null) {
       const cancelFrame = windowLike?.cancelAnimationFrame
       if (typeof cancelFrame === 'function') {

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -291,7 +291,9 @@ function createPopupView({
     const titleText = type === 'translation'
       ? getText('INLINE_POPUP_TRANSLATION_TITLE')
       : getText('INLINE_POPUP_DICTIONARY_TITLE')
-    const showHeader = type === 'translation'
+    // The inline shell is content-first for both dictionary and translation.
+    // Keep the type in aria-label, but do not spend popup space on a title row.
+    const showHeader = false
     header.hidden = !showHeader
     header.style.display = showHeader ? '' : 'none'
     title.textContent = showHeader ? titleText : ''

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -1,0 +1,596 @@
+import {
+  calculatePopupPosition,
+  createPopupAnchor,
+  getDocumentViewport
+} from './content-position.mjs'
+
+export const POPUP_STATES = Object.freeze({
+  LOADING: 'loading',
+  RESULT: 'result',
+  EMPTY: 'empty',
+  ERROR: 'error'
+})
+
+const DEFAULT_POPUP_OPTIONS = Object.freeze({
+  width: 360,
+  backgroundColor: '#FFF59D',
+  fontColor: '#000000',
+  fontSizePt: 11,
+  margin: 10,
+  gap: 12
+})
+
+const DEFAULT_TEXT = Object.freeze({
+  INLINE_POPUP_DICTIONARY_TITLE: 'Dictionary',
+  INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
+  INLINE_POPUP_LOADING: 'Loading…',
+  INLINE_POPUP_NO_RESULT: 'No result found.',
+  INLINE_POPUP_NETWORK_ERROR: 'The result could not be loaded. Please try again.',
+  INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio is unavailable.'
+})
+
+const FALLBACK_CSS = `
+:host { all: initial; }
+.naverdic-popup { box-sizing: border-box; }
+.naverdic-popup__body { box-sizing: border-box; overflow: auto; }
+`
+
+function defaultText(messageId) {
+  const getMessage = globalThis.chrome?.i18n?.getMessage
+  if (typeof getMessage === 'function') {
+    const localized = getMessage.call(globalThis.chrome.i18n, messageId)
+    if (localized) {
+      return localized
+    }
+  }
+
+  return DEFAULT_TEXT[messageId] || messageId
+}
+
+async function loadDefaultStylesheet() {
+  const getURL = globalThis.chrome?.runtime?.getURL
+  if (typeof getURL !== 'function' || typeof fetch !== 'function') {
+    return FALLBACK_CSS
+  }
+
+  try {
+    const response = await fetch(getURL('content.css'), {method: 'GET'})
+    if (!response.ok) {
+      return FALLBACK_CSS
+    }
+    return response.text()
+  } catch (_error) {
+    return FALLBACK_CSS
+  }
+}
+
+function appendTextWithLineBreaks(documentLike, element, value) {
+  const lines = String(value ?? '').split(/(?:\r\n|\r|\n)/g)
+  lines.forEach((line, index) => {
+    if (index > 0) {
+      element.appendChild(documentLike.createElement('br'))
+    }
+    element.appendChild(documentLike.createTextNode(line))
+  })
+}
+
+function createTextElement(documentLike, tagName, className, value) {
+  const element = documentLike.createElement(tagName)
+  if (className) {
+    element.className = className
+  }
+  if (value !== undefined) {
+    appendTextWithLineBreaks(documentLike, element, value)
+  }
+  return element
+}
+
+function renderAudioUnavailable(documentLike, wrapper, getText) {
+  const unavailable = createTextElement(
+    documentLike,
+    'span',
+    'naverdic-audio-unavailable',
+    getText('INLINE_POPUP_AUDIO_UNAVAILABLE')
+  )
+  unavailable.setAttribute('role', 'status')
+  wrapper.appendChild(unavailable)
+}
+
+function renderDictionary(documentLike, container, entries, getText) {
+  let audioShown = false
+
+  entries.forEach(entry => {
+    const title = createTextElement(documentLike, 'div', 'naverdic-wordTitle')
+    const wordLink = documentLike.createElement('a')
+    wordLink.href = entry.dictionaryUrl || '#'
+    wordLink.target = '_blank'
+    wordLink.rel = 'noopener noreferrer'
+    appendTextWithLineBreaks(documentLike, wordLink, entry.word)
+    title.appendChild(wordLink)
+
+    if (entry.partOfSpeech) {
+      appendTextWithLineBreaks(documentLike, title, ` [${entry.partOfSpeech}]`)
+    }
+
+    if (!audioShown && entry.audioUrl) {
+      audioShown = true
+
+      if (entry.phoneticSymbol) {
+        appendTextWithLineBreaks(
+          documentLike,
+          title,
+          ` [${entry.phoneticSymbol}]`
+        )
+      }
+
+      const audioWrapper = documentLike.createElement('span')
+      audioWrapper.className = 'naverdic-audio-wrapper'
+      const audio = documentLike.createElement('audio')
+      audio.className = 'naverdic-audio'
+      audio.controls = true
+      audio.preload = 'none'
+      audio.playsInline = true
+      audio.src = entry.audioUrl
+      audio.setAttribute('controlslist', 'nodownload')
+      audio.setAttribute('aria-label', `${entry.word} audio`)
+      audio.addEventListener('error', () => {
+        if (audio.dataset.failed === 'true') {
+          return
+        }
+
+        audio.dataset.failed = 'true'
+        audio.hidden = true
+        renderAudioUnavailable(documentLike, audioWrapper, getText)
+      })
+      audioWrapper.appendChild(audio)
+      title.appendChild(audioWrapper)
+    }
+
+    container.appendChild(title)
+
+    const meanings = Array.isArray(entry.meanings) ? entry.meanings : []
+    meanings.forEach((meaning, meaningIndex) => {
+      const className = meaningIndex === meanings.length - 1
+        ? 'naverdic-wordMeans-last'
+        : 'naverdic-wordMeans'
+      container.appendChild(createTextElement(
+        documentLike,
+        'div',
+        className,
+        `${meaning.order}. ${meaning.value}`
+      ))
+    })
+  })
+}
+
+function renderTranslation(documentLike, container, text) {
+  appendTextWithLineBreaks(documentLike, container, text)
+}
+
+function renderStatus(documentLike, container, className, text, role = 'status') {
+  const status = createTextElement(documentLike, 'p', className, text)
+  status.setAttribute('role', role)
+  container.appendChild(status)
+}
+
+function createPopupView({
+  document: documentLike = globalThis.document,
+  loadStylesheet = loadDefaultStylesheet,
+  getText = defaultText,
+  options = {}
+} = {}) {
+  const popupOptions = {...DEFAULT_POPUP_OPTIONS, ...options}
+  let host = null
+  let shadowRoot = null
+  let popup = null
+  let title = null
+  let body = null
+  let style = null
+  let stylesPromise = null
+  let layoutChangeHandler = null
+
+  function ensureMounted() {
+    if (host) {
+      return host
+    }
+
+    documentLike.getElementById?.('popupFrame')?.remove?.()
+    host = documentLike.createElement('div')
+    host.id = 'popupFrame'
+    host.dataset.naverdicPopup = 'true'
+    host.style.cssText = [
+      'all: initial',
+      'position: absolute',
+      'top: 0',
+      'left: 0',
+      'width: 0',
+      'height: 0',
+      'overflow: visible',
+      'z-index: 2147483647',
+      'pointer-events: none'
+    ].join(';')
+
+    shadowRoot = host.attachShadow({mode: 'open'})
+    style = documentLike.createElement('style')
+    style.textContent = FALLBACK_CSS
+    shadowRoot.appendChild(style)
+
+    popup = documentLike.createElement('div')
+    popup.id = 'popupShadow'
+    popup.className = 'popupFrame naverdic-popup'
+    popup.setAttribute('role', 'dialog')
+    popup.setAttribute('aria-live', 'polite')
+    popup.setAttribute('aria-label', getText('INLINE_POPUP_DICTIONARY_TITLE'))
+
+    const header = documentLike.createElement('div')
+    header.className = 'naverdic-popup__header'
+    title = documentLike.createElement('div')
+    title.className = 'naverdic-popup__title'
+    header.appendChild(title)
+    popup.appendChild(header)
+
+    body = documentLike.createElement('div')
+    body.className = 'naverdic-popup__body'
+    popup.appendChild(body)
+    shadowRoot.appendChild(popup)
+
+    const mountTarget = documentLike.body || documentLike.documentElement
+    mountTarget?.appendChild(host)
+
+    stylesPromise = Promise.resolve()
+      .then(() => loadStylesheet())
+      .then(css => {
+        if (style && host) {
+          style.textContent = css || FALLBACK_CSS
+          layoutChangeHandler?.()
+        }
+      })
+      .catch(() => {
+        if (style && host) {
+          style.textContent = FALLBACK_CSS
+          layoutChangeHandler?.()
+        }
+      })
+
+    return host
+  }
+
+  function update({type = 'dictionary', state = POPUP_STATES.LOADING, data} = {}) {
+    ensureMounted()
+    const titleText = type === 'translation'
+      ? getText('INLINE_POPUP_TRANSLATION_TITLE')
+      : getText('INLINE_POPUP_DICTIONARY_TITLE')
+    title.textContent = titleText
+    popup.dataset.type = type
+    popup.dataset.state = state
+    popup.setAttribute('aria-label', titleText)
+    popup.setAttribute('aria-busy', state === POPUP_STATES.LOADING ? 'true' : 'false')
+    body.replaceChildren()
+
+    if (state === POPUP_STATES.LOADING) {
+      renderStatus(
+        documentLike,
+        body,
+        'naverdic-popup__status naverdic-popup__status--loading',
+        getText('INLINE_POPUP_LOADING')
+      )
+    } else if (state === POPUP_STATES.EMPTY) {
+      renderStatus(
+        documentLike,
+        body,
+        'naverdic-popup__status naverdic-popup__status--empty',
+        getText('INLINE_POPUP_NO_RESULT')
+      )
+    } else if (state === POPUP_STATES.ERROR) {
+      renderStatus(
+        documentLike,
+        body,
+        'naverdic-popup__status naverdic-popup__status--error',
+        getText('INLINE_POPUP_NETWORK_ERROR'),
+        'alert'
+      )
+    } else if (type === 'dictionary') {
+      renderDictionary(documentLike, body, Array.isArray(data) ? data : [], getText)
+    } else {
+      renderTranslation(documentLike, body, data)
+    }
+
+    return popup
+  }
+
+  function measure() {
+    ensureMounted()
+    popup.style.maxHeight = 'none'
+    popup.style.setProperty('--naverdic-popup-max-height', '100000px')
+    const rect = popup.getBoundingClientRect?.() || {}
+    const width = Number(rect.width) > 0
+      ? Number(rect.width)
+      : Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width
+    const height = Number(rect.height) > 0
+      ? Number(rect.height)
+      : Number(popup.scrollHeight || body.scrollHeight || 0)
+
+    return {
+      width,
+      height: height > 0 ? height : 80
+    }
+  }
+
+  function setPosition(position) {
+    if (!popup) {
+      return
+    }
+
+    popup.style.left = `${position.left}px`
+    popup.style.top = `${position.top}px`
+    popup.style.width = `${position.width}px`
+    popup.style.maxHeight = `${position.maxHeight}px`
+    popup.style.setProperty('--naverdic-popup-max-height', `${position.maxHeight}px`)
+    popup.style.backgroundColor = popupOptions.backgroundColor
+    popup.style.color = popupOptions.fontColor
+    popup.style.fontSize = `${popupOptions.fontSizePt}pt`
+  }
+
+  function setVisibility(value) {
+    if (popup) {
+      popup.style.visibility = value
+    }
+  }
+
+  function setOptions(nextOptions = {}) {
+    Object.assign(popupOptions, nextOptions)
+    if (popup) {
+      popup.style.backgroundColor = popupOptions.backgroundColor
+      popup.style.color = popupOptions.fontColor
+      popup.style.fontSize = `${popupOptions.fontSizePt}pt`
+    }
+  }
+
+  function destroy() {
+    stylesPromise = null
+    host?.remove?.()
+    host = null
+    shadowRoot = null
+    popup = null
+    title = null
+    body = null
+    style = null
+  }
+
+  return {
+    mount: ensureMounted,
+    update,
+    measure,
+    setPosition,
+    setVisibility,
+    setOptions,
+    destroy,
+    getHost: () => host,
+    getPopup: () => popup,
+    setLayoutChangeHandler: handler => {
+      layoutChangeHandler = handler
+    }
+  }
+}
+
+export function createPopupController({
+  document: documentLike = globalThis.document,
+  window: windowLike = documentLike?.defaultView || globalThis.window,
+  getText = defaultText,
+  loadStylesheet,
+  options = {},
+  view
+} = {}) {
+  const popupView = view || createPopupView({
+    document: documentLike,
+    getText,
+    loadStylesheet,
+    options
+  })
+  const popupOptions = {...DEFAULT_POPUP_OPTIONS, ...options}
+  let open = false
+  let destroyed = false
+  let anchor = null
+  let type = 'dictionary'
+  let frameId = null
+  let listenersBound = false
+  let onClose = null
+
+  function scheduleReposition() {
+    if (!open || destroyed) {
+      return
+    }
+
+    if (frameId !== null) {
+      return
+    }
+
+    const requestFrame = windowLike?.requestAnimationFrame
+    if (typeof requestFrame === 'function') {
+      frameId = requestFrame(() => {
+        frameId = null
+        reposition()
+      })
+      return
+    }
+
+    reposition()
+  }
+
+  function reposition() {
+    if (!open || destroyed) {
+      return
+    }
+
+    const rect = anchor?.getRect?.() || anchor?.rect || anchor?.fallback
+    if (!rect) {
+      return
+    }
+
+    const position = calculatePopupPosition({
+      anchorRect: rect,
+      popupSize: popupView.measure(),
+      viewport: getDocumentViewport(windowLike),
+      margin: popupOptions.margin,
+      gap: popupOptions.gap
+    })
+    popupView.setPosition(position)
+  }
+
+  function eventIsInside(event) {
+    const host = popupView.getHost()
+    if (!host) {
+      return false
+    }
+
+    const path = event?.composedPath?.() || []
+    return path.includes(host) || host === event?.target || host.contains?.(event?.target)
+  }
+
+  function handleOutsidePointer(event) {
+    if (!eventIsInside(event)) {
+      close('outside')
+    }
+  }
+
+  function handleKeydown(event) {
+    if (event?.key === 'Escape' || event?.key === 'Esc') {
+      event.preventDefault?.()
+      close('escape')
+    }
+  }
+
+  function stopPopupEvent(event) {
+    event.stopPropagation()
+  }
+
+  function bindListeners() {
+    if (listenersBound) {
+      return
+    }
+
+    const host = popupView.getHost()
+    host?.addEventListener('pointerdown', stopPopupEvent)
+    host?.addEventListener('mousedown', stopPopupEvent)
+    host?.addEventListener('mousemove', stopPopupEvent)
+    host?.addEventListener('mouseup', stopPopupEvent)
+    host?.addEventListener('click', stopPopupEvent)
+    documentLike.addEventListener?.('pointerdown', handleOutsidePointer, true)
+    documentLike.addEventListener?.('keydown', handleKeydown, true)
+    documentLike.addEventListener?.('scroll', scheduleReposition, true)
+    windowLike?.addEventListener?.('resize', scheduleReposition)
+    windowLike?.addEventListener?.('scroll', scheduleReposition)
+    windowLike?.visualViewport?.addEventListener?.('resize', scheduleReposition)
+    windowLike?.visualViewport?.addEventListener?.('scroll', scheduleReposition)
+    listenersBound = true
+  }
+
+  function unbindListeners() {
+    if (!listenersBound) {
+      return
+    }
+
+    const host = popupView.getHost()
+    host?.removeEventListener('pointerdown', stopPopupEvent)
+    host?.removeEventListener('mousedown', stopPopupEvent)
+    host?.removeEventListener('mousemove', stopPopupEvent)
+    host?.removeEventListener('mouseup', stopPopupEvent)
+    host?.removeEventListener('click', stopPopupEvent)
+    documentLike.removeEventListener?.('pointerdown', handleOutsidePointer, true)
+    documentLike.removeEventListener?.('keydown', handleKeydown, true)
+    documentLike.removeEventListener?.('scroll', scheduleReposition, true)
+    windowLike?.removeEventListener?.('resize', scheduleReposition)
+    windowLike?.removeEventListener?.('scroll', scheduleReposition)
+    windowLike?.visualViewport?.removeEventListener?.('resize', scheduleReposition)
+    windowLike?.visualViewport?.removeEventListener?.('scroll', scheduleReposition)
+    listenersBound = false
+  }
+
+  function openPopup({
+    popupType = 'dictionary',
+    popupAnchor,
+    onPopupClose
+  } = {}) {
+    if (destroyed) {
+      return
+    }
+
+    type = popupType
+    anchor = popupAnchor
+    onClose = onPopupClose || null
+    open = true
+    popupView.mount()
+    popupView.update({type, state: POPUP_STATES.LOADING})
+    popupView.setVisibility('hidden')
+    bindListeners()
+    reposition()
+    popupView.setVisibility('visible')
+  }
+
+  function update(state, data) {
+    if (!open || destroyed) {
+      return
+    }
+
+    popupView.update({type, state, data})
+    popupView.setVisibility('hidden')
+    reposition()
+    popupView.setVisibility('visible')
+  }
+
+  function close(reason = 'programmatic', {notify = true} = {}) {
+    if (!open && !popupView.getHost()) {
+      return
+    }
+
+    open = false
+    if (frameId !== null) {
+      const cancelFrame = windowLike?.cancelAnimationFrame
+      if (typeof cancelFrame === 'function') {
+        cancelFrame(frameId)
+      }
+      frameId = null
+    }
+    unbindListeners()
+    popupView.destroy()
+    const closeHandler = onClose
+    onClose = null
+    if (notify) {
+      closeHandler?.(reason)
+    }
+  }
+
+  function setOptions(nextOptions = {}) {
+    Object.assign(popupOptions, nextOptions)
+    popupView.setOptions(nextOptions)
+    if (open) {
+      scheduleReposition()
+    }
+  }
+
+  function destroy() {
+    if (destroyed) {
+      return
+    }
+
+    destroyed = true
+    close('destroyed')
+  }
+
+  popupView.setLayoutChangeHandler(scheduleReposition)
+
+  return {
+    open: openPopup,
+    update,
+    close,
+    destroy,
+    setOptions,
+    isOpen: () => open,
+    getHost: popupView.getHost,
+    getPopup: popupView.getPopup,
+    getAnchor: () => anchor,
+    createAnchor: createPopupAnchor
+  }
+}
+
+export {createPopupView}

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -12,13 +12,15 @@ export const POPUP_STATES = Object.freeze({
 })
 
 const DEFAULT_POPUP_OPTIONS = Object.freeze({
-  width: 440,
+  width: 360,
   backgroundColor: '#FFF59D',
   fontColor: '#000000',
   fontSizePt: 11,
   margin: 10,
   gap: 12
 })
+
+const TRANSLATION_POPUP_WIDTH = 440
 
 const DEFAULT_TEXT = Object.freeze({
   INLINE_POPUP_DICTIONARY_TITLE: 'Dictionary',
@@ -208,6 +210,7 @@ function createPopupView({
   options = {}
 } = {}) {
   const popupOptions = {...DEFAULT_POPUP_OPTIONS, ...options}
+  let popupType = 'dictionary'
   let host = null
   let shadowRoot = null
   let popup = null
@@ -217,6 +220,14 @@ function createPopupView({
   let style = null
   let stylesPromise = null
   let layoutChangeHandler = null
+
+  function getPopupWidth(type = popupType) {
+    if (type === 'translation') {
+      return TRANSLATION_POPUP_WIDTH
+    }
+
+    return Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width
+  }
 
   function ensureMounted() {
     if (host) {
@@ -263,7 +274,7 @@ function createPopupView({
     popup.appendChild(body)
     shadowRoot.appendChild(popup)
 
-    popup.style.width = `${Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width}px`
+    popup.style.width = `${getPopupWidth()}px`
     popup.style.backgroundColor = popupOptions.backgroundColor
     popup.style.color = popupOptions.fontColor
     popup.style.fontSize = `${popupOptions.fontSizePt}pt`
@@ -290,7 +301,9 @@ function createPopupView({
   }
 
   function update({type = 'dictionary', state = POPUP_STATES.LOADING, data} = {}) {
+    popupType = type
     ensureMounted()
+    popup.style.width = `${getPopupWidth()}px`
     const titleText = type === 'translation'
       ? getText('INLINE_POPUP_TRANSLATION_TITLE')
       : getText('INLINE_POPUP_DICTIONARY_TITLE')
@@ -339,13 +352,14 @@ function createPopupView({
 
   function measure() {
     ensureMounted()
-    popup.style.width = `${Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width}px`
+    const popupWidth = getPopupWidth()
+    popup.style.width = `${popupWidth}px`
     popup.style.maxHeight = 'none'
     popup.style.setProperty('--naverdic-popup-max-height', '100000px')
     const rect = popup.getBoundingClientRect?.() || {}
     const width = Number(rect.width) > 0
       ? Number(rect.width)
-      : Number(popupOptions.width) || DEFAULT_POPUP_OPTIONS.width
+      : popupWidth
     const height = Number(rect.height) > 0
       ? Number(rect.height)
       : Number(popup.scrollHeight || body.scrollHeight || 0)
@@ -380,6 +394,7 @@ function createPopupView({
   function setOptions(nextOptions = {}) {
     Object.assign(popupOptions, nextOptions)
     if (popup) {
+      popup.style.width = `${getPopupWidth()}px`
       popup.style.backgroundColor = popupOptions.backgroundColor
       popup.style.color = popupOptions.fontColor
       popup.style.fontSize = `${popupOptions.fontSizePt}pt`
@@ -396,6 +411,7 @@ function createPopupView({
     title = null
     body = null
     style = null
+    popupType = 'dictionary'
   }
 
   return {

--- a/src/content-popup.mjs
+++ b/src/content-popup.mjs
@@ -27,8 +27,7 @@ const DEFAULT_TEXT = Object.freeze({
   INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
   INLINE_POPUP_LOADING: 'Loading…',
   INLINE_POPUP_NO_RESULT: 'No result found.',
-  INLINE_POPUP_NETWORK_ERROR: 'The result could not be loaded. Please try again.',
-  INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio is unavailable.'
+  INLINE_POPUP_NETWORK_ERROR: 'The result could not be loaded. Please try again.'
 })
 
 const FALLBACK_CSS = `
@@ -115,18 +114,7 @@ function createTextElement(documentLike, tagName, className, value) {
   return element
 }
 
-function renderAudioUnavailable(documentLike, wrapper, getText) {
-  const unavailable = createTextElement(
-    documentLike,
-    'span',
-    'naverdic-audio-unavailable',
-    getText('INLINE_POPUP_AUDIO_UNAVAILABLE')
-  )
-  unavailable.setAttribute('role', 'status')
-  wrapper.appendChild(unavailable)
-}
-
-function renderDictionary(documentLike, container, entries, getText) {
+function renderDictionary(documentLike, container, entries) {
   let audioShown = false
 
   entries.forEach(entry => {
@@ -169,8 +157,7 @@ function renderDictionary(documentLike, container, entries, getText) {
         }
 
         audio.dataset.failed = 'true'
-        audio.hidden = true
-        renderAudioUnavailable(documentLike, audioWrapper, getText)
+        audioWrapper.remove?.()
       })
       audioWrapper.appendChild(audio)
       title.appendChild(audioWrapper)
@@ -342,7 +329,7 @@ function createPopupView({
         'alert'
       )
     } else if (type === 'dictionary') {
-      renderDictionary(documentLike, body, Array.isArray(data) ? data : [], getText)
+      renderDictionary(documentLike, body, Array.isArray(data) ? data : [])
     } else {
       renderTranslation(documentLike, body, data)
     }

--- a/src/content-position.mjs
+++ b/src/content-position.mjs
@@ -1,0 +1,290 @@
+const DEFAULT_POPUP_MARGIN = 10
+const DEFAULT_POPUP_GAP = 12
+const DEFAULT_POPUP_WIDTH = 360
+
+function finiteNumber(value, fallback = 0) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback
+}
+
+function positiveNumber(value, fallback = 0) {
+  const normalized = finiteNumber(value, fallback)
+  return normalized > 0 ? normalized : fallback
+}
+
+function clamp(value, minimum, maximum) {
+  if (maximum < minimum) {
+    return minimum
+  }
+
+  return Math.min(Math.max(value, minimum), maximum)
+}
+
+export function normalizeRect(value = {}) {
+  const left = finiteNumber(value.left)
+  const top = finiteNumber(value.top)
+  const width = Math.max(0, finiteNumber(value.width, finiteNumber(value.right) - left))
+  const height = Math.max(0, finiteNumber(value.height, finiteNumber(value.bottom) - top))
+  const right = finiteNumber(value.right, left + width)
+  const bottom = finiteNumber(value.bottom, top + height)
+
+  return {
+    left,
+    top,
+    right: Math.max(left, right),
+    bottom: Math.max(top, bottom),
+    width: Math.max(0, right - left),
+    height: Math.max(0, bottom - top)
+  }
+}
+
+/**
+ * Convert the layout/visual viewport into document coordinates. Content
+ * scripts run independently in every frame, so the supplied window is always
+ * the frame whose selection owns the popup.
+ */
+export function getDocumentViewport(windowLike = globalThis.window) {
+  const visualViewport = windowLike?.visualViewport
+  const scrollX = finiteNumber(windowLike?.scrollX, finiteNumber(windowLike?.pageXOffset))
+  const scrollY = finiteNumber(windowLike?.scrollY, finiteNumber(windowLike?.pageYOffset))
+  const visualLeft = finiteNumber(visualViewport?.offsetLeft)
+  const visualTop = finiteNumber(visualViewport?.offsetTop)
+  const width = positiveNumber(
+    visualViewport?.width,
+    positiveNumber(windowLike?.innerWidth)
+  )
+  const height = positiveNumber(
+    visualViewport?.height,
+    positiveNumber(windowLike?.innerHeight)
+  )
+  const left = scrollX + visualLeft
+  const top = scrollY + visualTop
+
+  return {
+    left,
+    top,
+    right: left + width,
+    bottom: top + height,
+    width,
+    height,
+    scrollX,
+    scrollY,
+    visualLeft,
+    visualTop
+  }
+}
+
+export function getDocumentScrollOffset(windowLike = globalThis.window) {
+  return {
+    x: finiteNumber(windowLike?.scrollX, finiteNumber(windowLike?.pageXOffset)),
+    y: finiteNumber(windowLike?.scrollY, finiteNumber(windowLike?.pageYOffset))
+  }
+}
+
+function toDocumentRect(rect, windowLike) {
+  const normalized = normalizeRect(rect)
+  if (rect?.coordinateSpace === 'document') {
+    return normalized
+  }
+
+  const offset = getDocumentScrollOffset(windowLike)
+  return {
+    ...normalized,
+    left: normalized.left + offset.x,
+    right: normalized.right + offset.x,
+    top: normalized.top + offset.y,
+    bottom: normalized.bottom + offset.y
+  }
+}
+
+export function getSelectionRect(selection) {
+  if (!selection || !selection.rangeCount) {
+    return null
+  }
+
+  try {
+    const range = selection.getRangeAt(0)
+    const rect = range?.getBoundingClientRect?.()
+    if (!rect) {
+      return null
+    }
+
+    return normalizeRect(rect)
+  } catch (_error) {
+    return null
+  }
+}
+
+export function getEventRect(event = {}) {
+  const hasClientCoordinates = (
+    typeof event.clientX === 'number' && Number.isFinite(event.clientX) &&
+    typeof event.clientY === 'number' && Number.isFinite(event.clientY)
+  )
+  const x = finiteNumber(event.clientX, finiteNumber(event.pageX))
+  const y = finiteNumber(event.clientY, finiteNumber(event.pageY))
+
+  return {
+    left: x,
+    top: y,
+    right: x,
+    bottom: y,
+    width: 0,
+    height: 0,
+    coordinateSpace: hasClientCoordinates ? 'viewport' : 'document'
+  }
+}
+
+/**
+ * Keep a live range callback when possible. A Range's client rect changes as
+ * its frame scrolls or zooms; the event rect is retained as a safe fallback
+ * when the selection disappears before a reposition pass.
+ */
+export function createPopupAnchor({selection, event, window: windowLike} = {}) {
+  const fallback = toDocumentRect(getEventRect(event), windowLike)
+
+  return {
+    getRect() {
+      const selectionRect = getSelectionRect(selection)
+      return selectionRect
+        ? toDocumentRect(selectionRect, windowLike)
+        : fallback
+    },
+    fallback
+  }
+}
+
+function candidateOverflow(candidate, viewport, margin) {
+  return (
+    Math.max(0, viewport.left + margin - candidate.left) +
+    Math.max(0, candidate.left + candidate.width - (viewport.right - margin)) +
+    Math.max(0, viewport.top + margin - candidate.top) +
+    Math.max(0, candidate.top + candidate.height - (viewport.bottom - margin))
+  )
+}
+
+function compareCandidates(left, right) {
+  for (const index of [0, 1, 2, 3]) {
+    if (left.score[index] !== right.score[index]) {
+      return left.score[index] - right.score[index]
+    }
+  }
+
+  return 0
+}
+
+/**
+ * Place a popup around an anchor using all four quadrants. The returned
+ * coordinates are document coordinates suitable for an absolutely positioned
+ * element, while the viewport boundaries include scroll and visual viewport
+ * offsets. Long content is constrained to the available side of the anchor.
+ */
+export function calculatePopupPosition({
+  anchorRect,
+  popupSize = {},
+  viewport = getDocumentViewport(),
+  margin = DEFAULT_POPUP_MARGIN,
+  gap = DEFAULT_POPUP_GAP,
+  preferredVertical = 'below'
+} = {}) {
+  const anchor = normalizeRect(anchorRect)
+  const normalizedViewport = normalizeRect(viewport)
+  const viewportWidth = Math.max(1, normalizedViewport.right - normalizedViewport.left)
+  const viewportHeight = Math.max(1, normalizedViewport.bottom - normalizedViewport.top)
+  const normalizedMargin = Math.max(0, finiteNumber(margin, DEFAULT_POPUP_MARGIN))
+  const normalizedGap = Math.max(0, finiteNumber(gap, DEFAULT_POPUP_GAP))
+  const availableWidth = Math.max(1, viewportWidth - normalizedMargin * 2)
+  const width = Math.min(
+    positiveNumber(popupSize.width, DEFAULT_POPUP_WIDTH),
+    availableWidth
+  )
+  const height = Math.max(0, finiteNumber(popupSize.height))
+
+  const belowAvailable = Math.max(
+    0,
+    normalizedViewport.bottom - anchor.bottom - normalizedGap - normalizedMargin
+  )
+  const aboveAvailable = Math.max(
+    0,
+    anchor.top - normalizedViewport.top - normalizedGap - normalizedMargin
+  )
+
+  let verticalPreference
+  if (height > 0 && belowAvailable < height && aboveAvailable >= height) {
+    verticalPreference = 'above'
+  } else if (height > 0 && aboveAvailable < height && belowAvailable >= height) {
+    verticalPreference = 'below'
+  } else if (height > 0 && belowAvailable !== aboveAvailable) {
+    verticalPreference = belowAvailable > aboveAvailable ? 'below' : 'above'
+  } else {
+    verticalPreference = preferredVertical === 'above' ? 'above' : 'below'
+  }
+
+  const verticalOrder = verticalPreference === 'above'
+    ? ['above', 'below']
+    : ['below', 'above']
+  const horizontalOrder = ['right', 'left']
+  const candidates = []
+
+  verticalOrder.forEach((vertical, verticalIndex) => {
+    horizontalOrder.forEach((horizontal, horizontalIndex) => {
+      const top = vertical === 'below'
+        ? anchor.bottom + normalizedGap
+        : anchor.top - height - normalizedGap
+      const left = horizontal === 'right'
+        ? anchor.left
+        : anchor.right - width
+      const candidate = {
+        top,
+        left,
+        width,
+        height,
+        vertical,
+        horizontal
+      }
+      const overflow = candidateOverflow(candidate, normalizedViewport, normalizedMargin)
+      candidates.push({
+        candidate,
+        score: [overflow > 0 ? 1 : 0, overflow, verticalIndex, horizontalIndex]
+      })
+    })
+  })
+
+  candidates.sort(compareCandidates)
+  const selected = candidates[0]?.candidate || {
+    top: normalizedViewport.top + normalizedMargin,
+    left: normalizedViewport.left + normalizedMargin,
+    width,
+    height,
+    vertical: verticalPreference,
+    horizontal: 'right'
+  }
+
+  const minLeft = normalizedViewport.left + normalizedMargin
+  const maxLeft = normalizedViewport.right - normalizedMargin - width
+  const maxAvailableHeight = Math.max(1, viewportHeight - normalizedMargin * 2)
+  const verticalAvailable = selected.vertical === 'above'
+    ? aboveAvailable
+    : belowAvailable
+  const maxHeight = Math.min(
+    maxAvailableHeight,
+    Math.max(1, verticalAvailable || maxAvailableHeight)
+  )
+  const minTop = normalizedViewport.top + normalizedMargin
+  const maxTop = normalizedViewport.bottom - normalizedMargin - Math.min(height || maxHeight, maxAvailableHeight)
+
+  return {
+    left: clamp(selected.left, minLeft, maxLeft),
+    top: clamp(selected.top, minTop, Math.max(minTop, maxTop)),
+    width,
+    maxHeight,
+    vertical: selected.vertical,
+    horizontal: selected.horizontal,
+    direction: `${selected.vertical}-${selected.horizontal}`,
+    viewport: normalizedViewport
+  }
+}
+
+export const POPUP_POSITION_DEFAULTS = Object.freeze({
+  margin: DEFAULT_POPUP_MARGIN,
+  gap: DEFAULT_POPUP_GAP,
+  width: DEFAULT_POPUP_WIDTH
+})

--- a/src/content-position.mjs
+++ b/src/content-position.mjs
@@ -1,6 +1,6 @@
 const DEFAULT_POPUP_MARGIN = 10
 const DEFAULT_POPUP_GAP = 12
-const DEFAULT_POPUP_WIDTH = 360
+const DEFAULT_POPUP_WIDTH = 440
 
 function finiteNumber(value, fallback = 0) {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback

--- a/src/content-position.mjs
+++ b/src/content-position.mjs
@@ -1,6 +1,6 @@
 const DEFAULT_POPUP_MARGIN = 10
 const DEFAULT_POPUP_GAP = 12
-const DEFAULT_POPUP_WIDTH = 440
+const DEFAULT_POPUP_WIDTH = 360
 
 function finiteNumber(value, fallback = 0) {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback

--- a/src/content-position.mjs
+++ b/src/content-position.mjs
@@ -264,9 +264,13 @@ export function calculatePopupPosition({
   const verticalAvailable = selected.vertical === 'above'
     ? aboveAvailable
     : belowAvailable
+  const largestSideAvailable = Math.max(belowAvailable, aboveAvailable)
+  const needsScrollableViewport = height > largestSideAvailable
   const maxHeight = Math.min(
     maxAvailableHeight,
-    Math.max(1, verticalAvailable || maxAvailableHeight)
+    needsScrollableViewport
+      ? maxAvailableHeight
+      : Math.max(1, verticalAvailable || maxAvailableHeight)
   )
   const minTop = normalizedViewport.top + normalizedMargin
   const maxTop = normalizedViewport.bottom - normalizedMargin - Math.min(height || maxHeight, maxAvailableHeight)

--- a/src/content-request.mjs
+++ b/src/content-request.mjs
@@ -1,0 +1,105 @@
+export const POPUP_REQUEST_STATUSES = Object.freeze({
+  SUCCESS: 'success',
+  EMPTY: 'empty',
+  ERROR: 'error',
+  STALE: 'stale',
+  CANCELLED: 'cancelled'
+})
+
+export function createAbortError(reason = 'The popup request was cancelled.') {
+  const error = new Error(reason)
+  error.name = 'AbortError'
+  error.code = 'ABORTED'
+  return error
+}
+
+export function isAbortError(error) {
+  return error?.name === 'AbortError' || error?.code === 'ABORTED'
+}
+
+function isEmpty(value) {
+  if (Array.isArray(value)) {
+    return value.length === 0
+  }
+
+  return typeof value !== 'string' || value.trim() === ''
+}
+
+/**
+ * Run one popup request at a time. Abort is used where the underlying API
+ * supports it; the request id remains the final guard for Chrome runtime and
+ * Translator promises that cannot be cancelled after dispatch.
+ */
+export function createPopupRequestCoordinator() {
+  let revision = 0
+  let activeController = null
+
+  function isCurrent(requestId) {
+    return requestId === revision
+  }
+
+  function cancel(reason = 'The popup request was cancelled.') {
+    revision += 1
+    activeController?.abort(reason)
+    activeController = null
+  }
+
+  async function run(task) {
+    const requestId = revision + 1
+    revision = requestId
+    activeController?.abort('A newer popup request superseded this request.')
+
+    const controller = typeof AbortController === 'function'
+      ? new AbortController()
+      : {signal: {aborted: false}, abort() { this.signal.aborted = true }}
+    activeController = controller
+
+    try {
+      const value = await task({
+        signal: controller.signal,
+        requestId
+      })
+
+      if (!isCurrent(requestId) || controller.signal.aborted) {
+        return {status: POPUP_REQUEST_STATUSES.STALE, requestId}
+      }
+
+      return {
+        status: isEmpty(value)
+          ? POPUP_REQUEST_STATUSES.EMPTY
+          : POPUP_REQUEST_STATUSES.SUCCESS,
+        data: value,
+        requestId
+      }
+    } catch (error) {
+      if (!isCurrent(requestId) || controller.signal.aborted || isAbortError(error)) {
+        return {
+          status: isCurrent(requestId)
+            ? POPUP_REQUEST_STATUSES.CANCELLED
+            : POPUP_REQUEST_STATUSES.STALE,
+          error,
+          requestId
+        }
+      }
+
+      return {
+        status: POPUP_REQUEST_STATUSES.ERROR,
+        error,
+        requestId
+      }
+    } finally {
+      if (isCurrent(requestId)) {
+        activeController = null
+      }
+    }
+  }
+
+  return {
+    run,
+    cancel,
+    isCurrent,
+    get revision() {
+      return revision
+    }
+  }
+}

--- a/src/content.css
+++ b/src/content.css
@@ -48,10 +48,6 @@
   text-align: center;
 }
 
-.naverdic-popup__status--error {
-  color: #8b1e1e;
-}
-
 .naverdic-wordTitle {
   margin-bottom: 5px;
   padding-left: 1px;

--- a/src/content.css
+++ b/src/content.css
@@ -42,6 +42,10 @@
   scrollbar-width: thin;
 }
 
+.naverdic-popup[data-type="translation"] .naverdic-popup__body {
+  line-height: 1.45;
+}
+
 .naverdic-popup__status {
   margin: 0;
   padding: 14px 4px;

--- a/src/content.css
+++ b/src/content.css
@@ -1,33 +1,12 @@
-audio.naverdic-audio {
-  width: 100px;
-  height: 20px;
-  margin-left: 5px;
-  opacity: 0.8;
+:host {
+  all: initial;
 }
 
-audio.naverdic-audio::-webkit-media-controls-timeline-container {
-  display: none !important;
-}
-
-audio.naverdic-audio::-webkit-media-controls-current-time-display {
-  display: none !important;
-}
-
-audio.naverdic-audio::-webkit-media-controls-time-remaining-display {
-  display: none !important;
-}
-
-audio.naverdic-audio::-webkit-media-controls-timeline {
-  display: none !important;
-}
-
-audio.naverdic-audio::-webkit-media-controls-volume-control-container {
-  display: none !important;
-}
-
-div.popupFrame {
+.naverdic-popup {
   position: absolute;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
   height: auto;
   line-height: normal;
   padding: 9px;
@@ -36,25 +15,87 @@ div.popupFrame {
   box-shadow: 0 0 20px 3px rgba(0, 0, 0, 0.5);
   z-index: 99997;
   font-family: Arial, Helvetica, sans-serif;
+  overflow: hidden;
+  pointer-events: auto;
+  overflow-wrap: anywhere;
 }
 
-div.naverdic-wordTitle {
+.naverdic-popup__header {
+  flex: 0 0 auto;
+  margin: 0 0 8px;
+  padding: 0 1px;
+  font-weight: bold;
+}
+
+.naverdic-popup__title {
+  font-size: 0.9em;
+  opacity: 0.72;
+}
+
+.naverdic-popup__body {
+  box-sizing: border-box;
+  min-width: 0;
+  min-height: 0;
+  max-height: calc(var(--naverdic-popup-max-height, 480px) - 42px);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+}
+
+.naverdic-popup__status {
+  margin: 0;
+  padding: 14px 4px;
+  text-align: center;
+}
+
+.naverdic-popup__status--error {
+  color: #8b1e1e;
+}
+
+.naverdic-wordTitle {
   margin-bottom: 5px;
   padding-left: 1px;
 }
 
-div.naverdic-wordTitle a {
+.naverdic-wordTitle a {
   text-decoration: none;
-  color: black;
+  color: inherit;
   font-weight: bold;
 }
 
-div.naverdic-wordMeans {
+.naverdic-wordMeans {
   margin-bottom: 2px;
 }
 
-div.naverdic-wordMeans-last {
+.naverdic-wordMeans-last {
   margin-bottom: 5px;
+}
+
+.naverdic-audio-wrapper {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+}
+
+audio.naverdic-audio {
+  width: 100px;
+  height: 20px;
+  margin-left: 5px;
+  opacity: 0.8;
+}
+
+audio.naverdic-audio::-webkit-media-controls-timeline-container,
+audio.naverdic-audio::-webkit-media-controls-current-time-display,
+audio.naverdic-audio::-webkit-media-controls-time-remaining-display,
+audio.naverdic-audio::-webkit-media-controls-timeline,
+audio.naverdic-audio::-webkit-media-controls-volume-control-container {
+  display: none !important;
+}
+
+.naverdic-audio-unavailable {
+  margin-left: 5px;
+  font-size: 0.85em;
+  opacity: 0.72;
 }
 
 dd.naverdic-means {

--- a/src/content.css
+++ b/src/content.css
@@ -92,12 +92,6 @@ audio.naverdic-audio::-webkit-media-controls-volume-control-container {
   display: none !important;
 }
 
-.naverdic-audio-unavailable {
-  margin-left: 5px;
-  font-size: 0.85em;
-  opacity: 0.72;
-}
-
 dd.naverdic-means {
   margin-inline-start: 8px;
 }

--- a/src/content.js
+++ b/src/content.js
@@ -1,4 +1,3 @@
-import { buildNaverApiUrl, parseNaverDictionaryResponse } from './dictionary/parser.mjs'
 import {
   checkTrigger,
   createInteractionController,
@@ -10,33 +9,30 @@ import {createContentSettingsLifecycle} from './content-settings.mjs'
 // Keep the v6.6 lifecycle module in the content dependency graph for unpacked
 // compatibility; v7 reads the split settings envelopes above.
 import {createStorageLifecycle} from './content-storage.mjs'
+import {createInlinePopupDataClient} from './content-data.mjs'
+import {createPopupAnchor} from './content-position.mjs'
+import {createPopupController, POPUP_STATES} from './content-popup.mjs'
+import {
+  createPopupRequestCoordinator,
+  POPUP_REQUEST_STATUSES,
+  isAbortError
+} from './content-request.mjs'
 import {createChromeTranslatorRuntime} from './chrome-translator.mjs'
 import {
   MESSAGE_ERROR_CODES,
-  createDictionaryRequest,
-  createTranslationRequest,
-  reportMessageFailure,
-  sendRuntimeMessage
+  reportMessageFailure
 } from './messaging.mjs'
 import {
   DEFAULT_OPTIONS,
   STORAGE_DEFAULTS
 } from './settings.mjs'
 import {
-  executeProviderTranslation,
-  getPathValue
-} from './translation-engine.mjs'
-import {
   CHROME_TRANSLATOR_PROVIDER_ID,
-  getProviderPreset,
-  PROVIDER_KINDS
+  getProviderPreset
 } from './translation-provider.mjs'
 
-export { DEFAULT_OPTIONS, STORAGE_DEFAULTS }
+export {DEFAULT_OPTIONS, STORAGE_DEFAULTS}
 
-const marginLeft = 10
-const marginRight = 30
-const marginY = 20
 const popupWidth = 360
 let popupColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
 let popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
@@ -47,139 +43,45 @@ let storageLifecycle = null
 let chromeTranslatorRuntime = null
 let activeTranslationProviderId = ''
 let interactionConfigurationRevision = 0
+let popupController = null
+let popupRequestCoordinator = null
+let popupDataClient = null
 void createStorageLifecycle
 
-
-function appendTextWithLineBreaks(element, value) {
-  const lines = String(value).split(/(?:\r\n|\r|\n)/g)
-  lines.forEach((line, index) => {
-    if (index > 0) {
-      element.appendChild(document.createElement('br'))
-    }
-    element.appendChild(document.createTextNode(line))
-  })
-}
-
-function renderDictionary(container, entries) {
-  let audioShown = false
-
-  entries.forEach(entry => {
-    const title = document.createElement('div')
-    title.className = 'naverdic-wordTitle'
-
-    const wordLink = document.createElement('a')
-    wordLink.href = entry.dictionaryUrl
-    wordLink.target = '_blank'
-    wordLink.rel = 'noopener noreferrer'
-    appendTextWithLineBreaks(wordLink, entry.word)
-    title.appendChild(wordLink)
-
-    if (entry.partOfSpeech) {
-      appendTextWithLineBreaks(title, ` [${entry.partOfSpeech}]`)
-    }
-
-    if (!audioShown && entry.audioUrl) {
-      audioShown = true
-
-      if (entry.phoneticSymbol) {
-        const phonetic = document.createElement('span')
-        appendTextWithLineBreaks(phonetic, ` [${entry.phoneticSymbol}]`)
-        title.appendChild(phonetic)
+function getPopupController() {
+  if (!popupController) {
+    popupController = createPopupController({
+      document,
+      window,
+      options: {
+        width: popupWidth,
+        backgroundColor: popupColor,
+        fontColor: popupFontColor,
+        fontSizePt: popupFontsize
       }
-
-      const audioWrapper = document.createElement('span')
-      const audio = document.createElement('audio')
-      audio.className = 'naverdic-audio'
-      audio.controls = true
-      audio.src = entry.audioUrl
-      audio.id = 'proaudio1'
-      audio.setAttribute('controlslist', 'nodownload nooption')
-      audioWrapper.appendChild(audio)
-      title.appendChild(audioWrapper)
-    }
-
-    container.appendChild(title)
-
-    entry.meanings.forEach((meaning, meaningIndex) => {
-      const meaningElement = document.createElement('div')
-      meaningElement.className = meaningIndex === entry.meanings.length - 1
-        ? 'naverdic-wordMeans-last'
-        : 'naverdic-wordMeans'
-      appendTextWithLineBreaks(meaningElement, `${meaning.order}. ${meaning.value}`)
-      container.appendChild(meaningElement)
     })
-  })
+  }
+
+  return popupController
 }
 
-function renderTranslation(container, text) {
-  appendTextWithLineBreaks(container, text)
+function getPopupRequestCoordinator() {
+  if (!popupRequestCoordinator) {
+    popupRequestCoordinator = createPopupRequestCoordinator()
+  }
+
+  return popupRequestCoordinator
 }
 
-function showFrame(e, datain, top, left, type = 'dictionary') {
-  if (!datain || (Array.isArray(datain) && datain.length === 0)) {
-    return
+function getPopupDataClient() {
+  if (!popupDataClient) {
+    popupDataClient = createInlinePopupDataClient({
+      runtime: chrome.runtime,
+      getChromeTranslatorRuntime
+    })
   }
 
-  let shadowRoot = document.createElement('div')
-  shadowRoot.setAttribute('id', 'popupFrame')
-
-  let shadow = shadowRoot.attachShadow({mode: 'open'});
-  fetch(chrome.runtime.getURL("content.css"), {
-    method: 'GET'
-  })
-  .then(resp => resp.text())
-  .then(css => {
-    const style = document.createElement('style')
-    style.textContent = css
-    shadow.appendChild(style)
-  })
-
-  let div = document.createElement('div')
-  div.setAttribute('id', 'popupShadow')
-  div.className = 'popupFrame'
-  div.style.cssText = "top:" + top + "px;left:" + left + "px;width:" + popupWidth +"px;background-color:" + popupColor + ";font-size: " + popupFontsize + "pt;color:" + popupFontColor + ";"
-
-  if (type === 'dictionary') {
-    renderDictionary(div, datain)
-  } else {
-    renderTranslation(div, datain)
-  }
-
-  shadow.appendChild(div)
-  document.body.appendChild(shadowRoot)
-
-  const height = div.clientHeight
-  if ((e.clientY > height) && (e.clientY + height > window.innerHeight)) {
-    const newtop = top - height - 2.5 * marginY
-    shadow.getElementById('popupShadow').style.top = newtop + "px"
-  }
-
-  document.getElementById('popupFrame').onmousedown = function(e) {
-    e.stopPropagation()
-  }
-  document.getElementById('popupFrame').onmousemove = function(e) {
-    e.stopPropagation()
-  }
-  document.getElementById('popupFrame').onmouseup = function(e) {
-    e.stopPropagation()
-  }
-}
-
-
-async function consultDic(e, word, top, left) {
-  const url = buildNaverApiUrl(word)
-
-  const response = await sendRuntimeMessage(
-    chrome.runtime,
-    createDictionaryRequest({method: 'GET', url})
-  )
-
-  if (!response.ok) {
-    reportMessageFailure('dictionary lookup', response)
-    return
-  }
-
-  showFrame(e, parseNaverDictionaryResponse(response.data), top, left)
+  return popupDataClient
 }
 
 function getChromeTranslatorRuntime() {
@@ -193,119 +95,88 @@ function prepareChromeTranslatorRuntime() {
   return getChromeTranslatorRuntime()
 }
 
-function translationErrorResponse(error) {
-  return {
+function reportPopupError(scope, error) {
+  if (isAbortError(error)) {
+    return
+  }
+
+  if (error?.response) {
+    reportMessageFailure(scope, error.response)
+    return
+  }
+
+  reportMessageFailure(scope, {
     ok: false,
     error: {
       code: error?.code || MESSAGE_ERROR_CODES.RUNTIME_ERROR,
-      message: error?.message || 'The translation request failed.'
+      message: error?.message || 'The popup request failed.'
     }
-  }
+  })
 }
 
-function translationConfigFromValue(value) {
-  if (value && typeof value === 'object' && value.provider) {
-    return {
-      provider: value.provider,
-      credential: typeof value.credential === 'string' ? value.credential : '',
-      targetLanguage: typeof value.targetLanguage === 'string'
-        ? value.targetLanguage
-        : 'ko'
-    }
-  }
-
-  return {
-    provider: getProviderPreset('deepl-free'),
-    credential: typeof value === 'string' ? value : '',
-    targetLanguage: 'ko'
-  }
+function getPopupAnchor(event) {
+  return createPopupAnchor({
+    selection: window.getSelection?.(),
+    event,
+    window
+  })
 }
 
-async function translate(e, text, top, left, value) {
-  const config = translationConfigFromValue(value)
-  const provider = config.provider || getProviderPreset('deepl-free')
-  let response
-
-  if (provider.kind === PROVIDER_KINDS.BUILT_IN &&
-      provider.id === CHROME_TRANSLATOR_PROVIDER_ID) {
-    try {
-      const result = await executeProviderTranslation(provider, {
-        text: [text],
-        targetLanguage: 'ko',
-        translatorRuntime: getChromeTranslatorRuntime()
-      })
-      response = {ok: true, data: result}
-    } catch (error) {
-      response = translationErrorResponse(error)
-    }
-  } else {
-    response = await sendRuntimeMessage(
-      chrome.runtime,
-      createTranslationRequest({
-        provider,
-        key: config.credential,
-        data: {
-          text: [text],
-          targetLanguage: config.targetLanguage
-        }
-      })
-    )
-  }
-
-  if (!response.ok) {
-    reportMessageFailure('translation', response)
+function renderRequestResult(type, result) {
+  if (!popupController?.isOpen?.()) {
     return
   }
 
-  let translatedText
-  if (provider.kind === PROVIDER_KINDS.BUILT_IN) {
-    translatedText = response.data?.text
-  } else {
-    translatedText = getPathValue(response.data, provider.response?.textPath)
-  }
-  if (typeof translatedText !== 'string') {
-    reportMessageFailure('translation', {
-      ok: false,
-      error: {
-        code: MESSAGE_ERROR_CODES.INVALID_RESPONSE,
-        message: 'The translation response did not include translated text.'
-      }
-    })
+  if (result.status === POPUP_REQUEST_STATUSES.SUCCESS) {
+    popupController.update(POPUP_STATES.RESULT, result.data)
     return
   }
 
-  showFrame(e, translatedText, top, left, 'translation')
+  if (result.status === POPUP_REQUEST_STATUSES.EMPTY) {
+    popupController.update(POPUP_STATES.EMPTY)
+    return
+  }
+
+  if (result.status === POPUP_REQUEST_STATUSES.ERROR) {
+    reportPopupError(type === 'translation' ? 'translation' : 'dictionary lookup', result.error)
+    popupController.update(POPUP_STATES.ERROR)
+  }
 }
 
-function openPopup(e, key=null, type='search') {
-  let top = e.clientY + window.scrollY + marginY
-  let left = e.clientX - 120 + window.scrollX
-
-  if (e.clientX - 120 < marginLeft) {
-    left = marginLeft + window.scrollX
-  }
-  else if (left + popupWidth + marginRight >= window.innerWidth) {
-    left = window.innerWidth - popupWidth - marginLeft - marginRight
-  }
-
-  const text = getSelectionText(window.getSelection())
+function openPopup(event, key = null, type = 'search') {
+  const text = getSelectionText(window.getSelection?.())
   if (!text) {
     return
   }
 
-  if (type === 'translate') {
-    translate(e, text, top, left, key)
+  const isTranslation = type === 'translate'
+  const popupType = isTranslation ? 'translation' : 'dictionary'
+  const query = isTranslation ? text : getDictionaryQuery(text)
+  if (!query) {
+    return
   }
-  else {
-    const word = getDictionaryQuery(text)
-    if (word) {
-      consultDic(e, word, top, left)
-    }
-  }
+
+  const controller = getPopupController()
+  const coordinator = getPopupRequestCoordinator()
+  const dataClient = getPopupDataClient()
+  controller.open({
+    popupType,
+    popupAnchor: getPopupAnchor(event),
+    onPopupClose: reason => coordinator.cancel(`Popup closed: ${reason}`)
+  })
+
+  const request = isTranslation
+    ? ({signal}) => dataClient.translate(query, key, {signal})
+    : ({signal}) => dataClient.lookupDictionary(query, {signal})
+
+  coordinator.run(request).then(result => {
+    renderRequestResult(popupType, result)
+  })
 }
 
 function removePopup() {
-  document.getElementById('popupFrame')?.remove()
+  popupRequestCoordinator?.cancel('Popup removed')
+  popupController?.close('programmatic', {notify: false})
 }
 
 function applyOptions(items) {
@@ -326,9 +197,14 @@ function applyOptions(items) {
   activeInteractionController = null
   removePopup()
 
-  popupColor = nextItems.popup_bgcolor
-  popupFontColor = nextItems.popup_fontcolor
-  popupFontsize = nextItems.popup_fontsize
+  popupColor = nextItems.popup_bgcolor || DEFAULT_OPTIONS.POPUP_BG_COLOR
+  popupFontColor = nextItems.popup_fontcolor || DEFAULT_OPTIONS.POPUP_FONT_COLOR
+  popupFontsize = nextItems.popup_fontsize || DEFAULT_OPTIONS.POPUP_FONT_SIZE
+  popupController?.setOptions({
+    backgroundColor: popupColor,
+    fontColor: popupFontColor,
+    fontSizePt: popupFontsize
+  })
 
   if (!nextItems.dclick && !nextItems.drag && !nextItems.translate) {
     return
@@ -385,10 +261,11 @@ export function unregisterEventListener() {
   storageLifecycle = null
   activeInteractionController?.destroy()
   activeInteractionController = null
+  popupRequestCoordinator?.cancel('Content script unregistered')
+  popupController?.close('unregister', {notify: false})
   chromeTranslatorRuntime?.destroy()
   chromeTranslatorRuntime = null
   activeTranslationProviderId = ''
-  removePopup()
 }
 
 export function registerEventListener() {

--- a/src/content.js
+++ b/src/content.js
@@ -33,7 +33,7 @@ import {
 
 export {DEFAULT_OPTIONS, STORAGE_DEFAULTS}
 
-const popupWidth = 440
+const popupWidth = 360
 let popupColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
 let popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
 let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE

--- a/src/content.js
+++ b/src/content.js
@@ -241,15 +241,16 @@ function applyOptions(items) {
   }
 
   if (nextNeedsChromeRuntime) {
-    // Finish the availability check before installing the mouseup handler.
-    // Once the handler runs, a ready model lets runtime.translate() reach
-    // Translator.create() before its first await, preserving the page's
-    // transient user activation. Model downloads still only start from the
-    // explicit settings click path.
-    prepareChromeTranslatorRuntime().refreshAvailability?.()
-      .catch(() => {})
-      .finally(bindInteractionController)
-    return
+    // Warm the availability state without gating dictionary interaction on it.
+    // Translator availability can wait on browser/network state; delaying the
+    // document handlers would make double-click dictionary lookup appear dead.
+    // Model downloads still only start from the explicit settings click path.
+    try {
+      const availability = prepareChromeTranslatorRuntime().refreshAvailability?.()
+      availability?.catch?.(() => {})
+    } catch (_error) {
+      // An unavailable Translator API must not disable dictionary lookup.
+    }
   }
 
   bindInteractionController()

--- a/src/content.js
+++ b/src/content.js
@@ -33,7 +33,7 @@ import {
 
 export {DEFAULT_OPTIONS, STORAGE_DEFAULTS}
 
-const popupWidth = 360
+const popupWidth = 440
 let popupColor = DEFAULT_OPTIONS.POPUP_BG_COLOR
 let popupFontColor = DEFAULT_OPTIONS.POPUP_FONT_COLOR
 let popupFontsize = DEFAULT_OPTIONS.POPUP_FONT_SIZE

--- a/src/dictionary/normalizer.mjs
+++ b/src/dictionary/normalizer.mjs
@@ -9,12 +9,27 @@ function isRecord(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value)
 }
 
+const INLINE_HTML_BREAK_PATTERN = /<br\s*\/?>/gi
+const INLINE_HTML_TAG_PATTERN = /<\/?[a-z][^>]*>/gi
+
 export function normalizeString(value) {
   if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
     return ''
   }
 
   return String(value).trim()
+}
+
+/**
+ * Naver's meaning strings may contain presentational tags such as
+ * `<span class="related_word">`. Popup rendering intentionally uses text
+ * nodes, so normalize those tags out while preserving their readable text.
+ */
+export function stripInlineMarkup(value) {
+  return normalizeString(value)
+    .replace(INLINE_HTML_BREAK_PATTERN, '\n')
+    .replace(INLINE_HTML_TAG_PATTERN, '')
+    .trim()
 }
 
 export function normalizeStringList(value) {
@@ -52,7 +67,7 @@ export function normalizeMeaning(value) {
 
   return {
     order: normalizeString(value.order),
-    value: normalizeString(value.value)
+    value: stripInlineMarkup(value.value)
   }
 }
 

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -246,6 +246,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
     .querySelector('#popupShadow')
   assert.equal(translationPopup.querySelector('.naverdic-popup__header').hidden, true)
   assert.equal(translationPopup.querySelector('.naverdic-popup__title').textContent, '')
+  assert.equal(translationPopup.style.width, '440px')
   assert.equal(translationPopup.querySelector('.naverdic-popup__body').textContent, longTranslation)
   assert.match(
     document.getElementById('popupFrame').shadowRoot.querySelector('style').textContent,
@@ -305,8 +306,7 @@ test('mounts outside positioned or transformed body coordinate systems', async (
   ].join(';')
   const controller = createPopupController({
     document,
-    window,
-    loadStylesheet: () => Promise.resolve('.naverdic-popup { display: block; }')
+    window
   })
 
   controller.open({
@@ -320,6 +320,7 @@ test('mounts outside positioned or transformed body coordinate systems', async (
   const popup = host.shadowRoot.querySelector('#popupShadow')
   assert.equal(host.parentElement, document.documentElement)
   assert.equal(host.style.position, 'fixed')
+  assert.match(host.shadowRoot.querySelector('style').textContent, /line-height: 1\.45/)
   assert.equal(popup.style.left, '100px')
   assert.equal(popup.style.top, '132px')
 

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -201,8 +201,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
       INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
       INLINE_POPUP_LOADING: 'Loading',
       INLINE_POPUP_NO_RESULT: 'No result',
-      INLINE_POPUP_NETWORK_ERROR: 'Network error',
-      INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio unavailable'
+      INLINE_POPUP_NETWORK_ERROR: 'Network error'
     }[id] || id)
   })
 
@@ -232,6 +231,12 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   assert.equal(host.shadowRoot.querySelector('#popupShadow').style.width, '360px')
   assert.equal(host.shadowRoot.querySelector('audio').getAttribute('controlslist'), 'nodownload')
   assert.equal(host.shadowRoot.querySelector('audio').id, '')
+
+  const audio = host.shadowRoot.querySelector('audio')
+  audio.dispatchEvent(new window.Event('error'))
+  assert.equal(host.shadowRoot.querySelector('audio'), null)
+  assert.equal(host.shadowRoot.querySelector('.naverdic-audio-wrapper'), null)
+  assert.equal(host.shadowRoot.querySelector('.naverdic-audio-unavailable'), null)
 
   document.body.dispatchEvent(new window.Event('pointerdown', {bubbles: true}))
   assert.equal(controller.isOpen(), false)
@@ -274,8 +279,7 @@ test('keeps the loading shell hidden and reveals only the settled result', async
       INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
       INLINE_POPUP_LOADING: 'Loading',
       INLINE_POPUP_NO_RESULT: 'No result',
-      INLINE_POPUP_NETWORK_ERROR: 'Network error',
-      INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio unavailable'
+      INLINE_POPUP_NETWORK_ERROR: 'Network error'
     }[id] || id)
   })
 

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -1,0 +1,235 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import {JSDOM} from 'jsdom'
+
+import {
+  calculatePopupPosition,
+  createPopupAnchor,
+  getDocumentViewport
+} from '../src/content-position.mjs'
+import {createPopupController, POPUP_STATES} from '../src/content-popup.mjs'
+import {
+  createPopupRequestCoordinator,
+  POPUP_REQUEST_STATUSES
+} from '../src/content-request.mjs'
+
+const VIEWPORT = {
+  left: 0,
+  top: 0,
+  right: 1000,
+  bottom: 800,
+  width: 1000,
+  height: 800
+}
+
+const POPUP_SIZE = {width: 360, height: 200}
+
+test('positions the inline popup in all four viewport quadrants', () => {
+  const cases = [
+    {
+      name: 'below-right',
+      anchorRect: {left: 300, right: 360, top: 250, bottom: 270},
+      direction: 'below-right',
+      left: 300,
+      top: 282
+    },
+    {
+      name: 'below-left near the right edge',
+      anchorRect: {left: 850, right: 900, top: 250, bottom: 270},
+      direction: 'below-left',
+      left: 540,
+      top: 282
+    },
+    {
+      name: 'above-right near the bottom edge',
+      anchorRect: {left: 300, right: 360, top: 680, bottom: 700},
+      direction: 'above-right',
+      left: 300,
+      top: 468
+    },
+    {
+      name: 'above-left near the bottom-right corner',
+      anchorRect: {left: 850, right: 900, top: 680, bottom: 700},
+      direction: 'above-left',
+      left: 540,
+      top: 468
+    }
+  ]
+
+  for (const expected of cases) {
+    const result = calculatePopupPosition({
+      anchorRect: expected.anchorRect,
+      popupSize: POPUP_SIZE,
+      viewport: VIEWPORT
+    })
+
+    assert.equal(result.direction, expected.direction, expected.name)
+    assert.equal(result.left, expected.left, expected.name)
+    assert.equal(result.top, expected.top, expected.name)
+    assert.ok(result.left >= VIEWPORT.left + 10, expected.name)
+    assert.ok(result.left + result.width <= VIEWPORT.right - 10, expected.name)
+    assert.ok(result.top >= VIEWPORT.top + 10, expected.name)
+    assert.ok(result.top + POPUP_SIZE.height <= VIEWPORT.bottom - 10, expected.name)
+  }
+})
+
+test('accounts for scroll and the visual viewport when calculating document bounds', () => {
+  const fakeWindow = {
+    scrollX: 120,
+    scrollY: 240,
+    innerWidth: 1000,
+    innerHeight: 800,
+    visualViewport: {
+      offsetLeft: 15,
+      offsetTop: 25,
+      width: 600,
+      height: 500
+    }
+  }
+
+  assert.deepEqual(getDocumentViewport(fakeWindow), {
+    left: 135,
+    top: 265,
+    right: 735,
+    bottom: 765,
+    width: 600,
+    height: 500,
+    scrollX: 120,
+    scrollY: 240,
+    visualLeft: 15,
+    visualTop: 25
+  })
+
+  const position = calculatePopupPosition({
+    anchorRect: {left: 650, right: 690, top: 680, bottom: 700},
+    popupSize: POPUP_SIZE,
+    viewport: getDocumentViewport(fakeWindow)
+  })
+
+  assert.equal(position.direction, 'above-left')
+  assert.ok(position.left >= 145)
+  assert.ok(position.top >= 275)
+})
+
+test('limits tall results to the available side and returns a scroll budget', () => {
+  const result = calculatePopupPosition({
+    anchorRect: {left: 300, right: 360, top: 580, bottom: 600},
+    popupSize: {width: 360, height: 1000},
+    viewport: VIEWPORT
+  })
+
+  assert.equal(result.vertical, 'above')
+  assert.equal(result.maxHeight, 558)
+  assert.equal(result.top, 10)
+})
+
+test('keeps a live selection anchor and falls back to the triggering event', () => {
+  const selection = {
+    rangeCount: 1,
+    getRangeAt: () => ({
+      getBoundingClientRect: () => ({
+        left: 40,
+        right: 90,
+        top: 100,
+        bottom: 122,
+        width: 50,
+        height: 22
+      })
+    })
+  }
+  const anchor = createPopupAnchor({
+    selection,
+    event: {clientX: 10, clientY: 20}
+  })
+
+  assert.equal(anchor.getRect().left, 40)
+  const scrolledAnchor = createPopupAnchor({
+    selection,
+    event: {clientX: 10, clientY: 20},
+    window: {scrollX: 100, scrollY: 200}
+  })
+  assert.equal(scrolledAnchor.getRect().left, 140)
+  assert.equal(scrolledAnchor.getRect().top, 300)
+  selection.getRangeAt = () => {
+    throw new Error('selection disappeared')
+  }
+  assert.equal(anchor.getRect().left, 10)
+})
+
+test('ignores a late response after a newer selection starts', async () => {
+  const coordinator = createPopupRequestCoordinator()
+  let resolveFirst
+  let resolveSecond
+  let firstSignal
+
+  const first = coordinator.run(({signal}) => {
+    firstSignal = signal
+    return new Promise(resolve => {
+      resolveFirst = resolve
+    })
+  })
+  const second = coordinator.run(() => new Promise(resolve => {
+    resolveSecond = resolve
+  }))
+
+  assert.equal(firstSignal.aborted, true)
+  resolveFirst('old result')
+  resolveSecond('new result')
+
+  const [firstResult, secondResult] = await Promise.all([first, second])
+  assert.equal(firstResult.status, POPUP_REQUEST_STATUSES.STALE)
+  assert.equal(secondResult.status, POPUP_REQUEST_STATUSES.SUCCESS)
+  assert.equal(secondResult.data, 'new result')
+})
+
+test('renders common states inside an isolated shadow popup and closes on outside or Escape', () => {
+  const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
+  const {document, window} = dom.window
+  const controller = createPopupController({
+    document,
+    window,
+    loadStylesheet: () => Promise.resolve('.naverdic-popup { color: red; }'),
+    getText: id => ({
+      INLINE_POPUP_DICTIONARY_TITLE: 'Dictionary',
+      INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
+      INLINE_POPUP_LOADING: 'Loading',
+      INLINE_POPUP_NO_RESULT: 'No result',
+      INLINE_POPUP_NETWORK_ERROR: 'Network error',
+      INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio unavailable'
+    }[id] || id)
+  })
+
+  controller.open({
+    popupType: 'dictionary',
+    popupAnchor: {getRect: () => ({left: 100, right: 140, top: 100, bottom: 120})}
+  })
+
+  const host = document.getElementById('popupFrame')
+  assert.ok(host)
+  assert.ok(host.shadowRoot)
+  assert.equal(host.shadowRoot.querySelector('#popupShadow').dataset.state, POPUP_STATES.LOADING)
+  assert.ok(host.shadowRoot.querySelector('style'))
+
+  controller.update(POPUP_STATES.RESULT, [{
+    word: 'hello',
+    dictionaryUrl: 'https://en.dict.naver.com/#/search?query=hello',
+    partOfSpeech: 'noun',
+    phoneticSymbol: 'həˈloʊ',
+    audioUrl: 'https://example.com/hello.mp3',
+    meanings: [{order: '1', value: '안녕하세요'}]
+  }])
+  assert.equal(host.shadowRoot.querySelector('.naverdic-wordTitle a').textContent, 'hello')
+  assert.equal(host.shadowRoot.querySelector('audio').getAttribute('controlslist'), 'nodownload')
+  assert.equal(host.shadowRoot.querySelector('audio').id, '')
+
+  document.body.dispatchEvent(new window.Event('pointerdown', {bubbles: true}))
+  assert.equal(controller.isOpen(), false)
+
+  controller.open({
+    popupType: 'translation',
+    popupAnchor: {getRect: () => ({left: 100, right: 140, top: 100, bottom: 120})}
+  })
+  document.dispatchEvent(new window.KeyboardEvent('keydown', {key: 'Escape', bubbles: true}))
+  assert.equal(controller.isOpen(), false)
+  dom.window.close()
+})

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -295,6 +295,38 @@ test('keeps the loading shell hidden and reveals only the settled result', async
   dom.window.close()
 })
 
+test('mounts outside positioned or transformed body coordinate systems', async () => {
+  const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
+  const {document, window} = dom.window
+  document.body.style.cssText = [
+    'position: relative',
+    'transform: translate(40px, 20px)',
+    'overflow: hidden'
+  ].join(';')
+  const controller = createPopupController({
+    document,
+    window,
+    loadStylesheet: () => Promise.resolve('.naverdic-popup { display: block; }')
+  })
+
+  controller.open({
+    popupType: 'translation',
+    popupAnchor: {getRect: () => ({left: 100, right: 140, top: 100, bottom: 120})}
+  })
+  controller.update(POPUP_STATES.RESULT, 'result')
+  await new Promise(resolve => setImmediate(resolve))
+
+  const host = document.getElementById('popupFrame')
+  const popup = host.shadowRoot.querySelector('#popupShadow')
+  assert.equal(host.parentElement, document.documentElement)
+  assert.equal(host.style.position, 'fixed')
+  assert.equal(popup.style.left, '100px')
+  assert.equal(popup.style.top, '132px')
+
+  controller.close()
+  dom.window.close()
+})
+
 test('installs dictionary interaction while Chrome Translator availability is pending', async () => {
   const dom = new JSDOM(
     '<!doctype html><body><p id="word">hello</p></body>',

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -215,6 +215,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   assert.ok(host)
   assert.ok(host.shadowRoot)
   assert.equal(host.shadowRoot.querySelector('#popupShadow').dataset.state, POPUP_STATES.LOADING)
+  assert.equal(host.shadowRoot.querySelector('#popupShadow').style.visibility, 'hidden')
   assert.equal(host.shadowRoot.querySelector('.naverdic-popup__header').hidden, true)
   assert.ok(host.shadowRoot.querySelector('style'))
 
@@ -254,7 +255,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   dom.window.close()
 })
 
-test('keeps the popup hidden until its stylesheet has settled', async () => {
+test('keeps the loading shell hidden and reveals only the settled result', async () => {
   const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
   const {document, window} = dom.window
   let resolveStyles
@@ -283,6 +284,10 @@ test('keeps the popup hidden until its stylesheet has settled', async () => {
   assert.equal(popup.style.visibility, 'hidden')
 
   resolveStyles('.naverdic-popup { display: block; }')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(popup.style.visibility, 'hidden')
+
+  controller.update(POPUP_STATES.RESULT, 'loaded')
   await new Promise(resolve => setImmediate(resolve))
   assert.equal(popup.style.visibility, 'visible')
   controller.close()

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -244,7 +244,8 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   await new Promise(resolve => setImmediate(resolve))
   const translationPopup = document.getElementById('popupFrame').shadowRoot
     .querySelector('#popupShadow')
-  assert.equal(translationPopup.querySelector('.naverdic-popup__header').hidden, false)
+  assert.equal(translationPopup.querySelector('.naverdic-popup__header').hidden, true)
+  assert.equal(translationPopup.querySelector('.naverdic-popup__title').textContent, '')
   assert.equal(translationPopup.querySelector('.naverdic-popup__body').textContent, longTranslation)
   assert.match(
     document.getElementById('popupFrame').shadowRoot.querySelector('style').textContent,

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -124,7 +124,7 @@ test('limits tall results to the available side and returns a scroll budget', ()
   })
 
   assert.equal(result.vertical, 'above')
-  assert.equal(result.maxHeight, 558)
+  assert.equal(result.maxHeight, 780)
   assert.equal(result.top, 10)
 })
 
@@ -187,13 +187,15 @@ test('ignores a late response after a newer selection starts', async () => {
   assert.equal(secondResult.data, 'new result')
 })
 
-test('renders common states inside an isolated shadow popup and closes on outside or Escape', () => {
+test('renders common states inside an isolated shadow popup and closes on outside or Escape', async () => {
   const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
   const {document, window} = dom.window
   const controller = createPopupController({
     document,
     window,
-    loadStylesheet: () => Promise.resolve('.naverdic-popup { color: red; }'),
+    loadStylesheet: () => Promise.resolve(
+      '.naverdic-popup { color: red; } .naverdic-popup__body { overflow: auto; }'
+    ),
     getText: id => ({
       INLINE_POPUP_DICTIONARY_TITLE: 'Dictionary',
       INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
@@ -213,6 +215,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   assert.ok(host)
   assert.ok(host.shadowRoot)
   assert.equal(host.shadowRoot.querySelector('#popupShadow').dataset.state, POPUP_STATES.LOADING)
+  assert.equal(host.shadowRoot.querySelector('.naverdic-popup__header').hidden, true)
   assert.ok(host.shadowRoot.querySelector('style'))
 
   controller.update(POPUP_STATES.RESULT, [{
@@ -224,6 +227,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
     meanings: [{order: '1', value: '안녕하세요'}]
   }])
   assert.equal(host.shadowRoot.querySelector('.naverdic-wordTitle a').textContent, 'hello')
+  assert.equal(host.shadowRoot.querySelector('.naverdic-popup__header').hidden, true)
   assert.equal(host.shadowRoot.querySelector('audio').getAttribute('controlslist'), 'nodownload')
   assert.equal(host.shadowRoot.querySelector('audio').id, '')
 
@@ -234,8 +238,54 @@ test('renders common states inside an isolated shadow popup and closes on outsid
     popupType: 'translation',
     popupAnchor: {getRect: () => ({left: 100, right: 140, top: 100, bottom: 120})}
   })
+  const longTranslation = Array.from({length: 80}, () => '긴 번역 결과').join(' ')
+  controller.update(POPUP_STATES.RESULT, longTranslation)
+  await new Promise(resolve => setImmediate(resolve))
+  const translationPopup = document.getElementById('popupFrame').shadowRoot
+    .querySelector('#popupShadow')
+  assert.equal(translationPopup.querySelector('.naverdic-popup__header').hidden, false)
+  assert.equal(translationPopup.querySelector('.naverdic-popup__body').textContent, longTranslation)
+  assert.match(
+    document.getElementById('popupFrame').shadowRoot.querySelector('style').textContent,
+    /overflow: auto/
+  )
   document.dispatchEvent(new window.KeyboardEvent('keydown', {key: 'Escape', bubbles: true}))
   assert.equal(controller.isOpen(), false)
+  dom.window.close()
+})
+
+test('keeps the popup hidden until its stylesheet has settled', async () => {
+  const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
+  const {document, window} = dom.window
+  let resolveStyles
+  const styles = new Promise(resolve => {
+    resolveStyles = resolve
+  })
+  const controller = createPopupController({
+    document,
+    window,
+    loadStylesheet: () => styles,
+    getText: id => ({
+      INLINE_POPUP_DICTIONARY_TITLE: 'Dictionary',
+      INLINE_POPUP_TRANSLATION_TITLE: 'Translation',
+      INLINE_POPUP_LOADING: 'Loading',
+      INLINE_POPUP_NO_RESULT: 'No result',
+      INLINE_POPUP_NETWORK_ERROR: 'Network error',
+      INLINE_POPUP_AUDIO_UNAVAILABLE: 'Audio unavailable'
+    }[id] || id)
+  })
+
+  controller.open({
+    popupType: 'translation',
+    popupAnchor: {getRect: () => ({left: 100, right: 140, top: 100, bottom: 120})}
+  })
+  const popup = document.getElementById('popupFrame').shadowRoot.querySelector('#popupShadow')
+  assert.equal(popup.style.visibility, 'hidden')
+
+  resolveStyles('.naverdic-popup { display: block; }')
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(popup.style.visibility, 'visible')
+  controller.close()
   dom.window.close()
 })
 

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -301,6 +301,42 @@ test('keeps the loading shell hidden and reveals only the settled result', async
   dom.window.close()
 })
 
+test('repositions an above-anchor popup after failed audio is removed', async () => {
+  const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
+  const {document, window} = dom.window
+  Object.defineProperty(window, 'innerWidth', {configurable: true, value: 1000})
+  Object.defineProperty(window, 'innerHeight', {configurable: true, value: 800})
+  const controller = createPopupController({
+    document,
+    window,
+    loadStylesheet: () => Promise.resolve('')
+  })
+
+  controller.open({
+    popupType: 'dictionary',
+    popupAnchor: {getRect: () => ({left: 300, right: 340, top: 650, bottom: 670})}
+  })
+  const popup = document.getElementById('popupFrame').shadowRoot.querySelector('#popupShadow')
+  let popupHeight = 200
+  popup.getBoundingClientRect = () => ({width: 360, height: popupHeight})
+  controller.update(POPUP_STATES.RESULT, [{
+    word: 'hello',
+    dictionaryUrl: 'https://en.dict.naver.com/#/search?query=hello',
+    phoneticSymbol: 'həˈloʊ',
+    audioUrl: 'https://example.com/hello.mp3',
+    meanings: [{order: '1', value: '안녕하세요'}]
+  }])
+  assert.equal(popup.style.top, '438px')
+
+  popupHeight = 180
+  popup.querySelector('audio').dispatchEvent(new window.Event('error'))
+  await new Promise(resolve => setImmediate(resolve))
+  assert.equal(popup.style.top, '458px')
+
+  controller.close()
+  dom.window.close()
+})
+
 test('mounts outside positioned or transformed body coordinate systems', async () => {
   const dom = new JSDOM('<!doctype html><body></body>', {url: 'https://example.com/'})
   const {document, window} = dom.window

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -229,6 +229,7 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   }])
   assert.equal(host.shadowRoot.querySelector('.naverdic-wordTitle a').textContent, 'hello')
   assert.equal(host.shadowRoot.querySelector('.naverdic-popup__header').hidden, true)
+  assert.equal(host.shadowRoot.querySelector('#popupShadow').style.width, '360px')
   assert.equal(host.shadowRoot.querySelector('audio').getAttribute('controlslist'), 'nodownload')
   assert.equal(host.shadowRoot.querySelector('audio').id, '')
 

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -12,6 +12,11 @@ import {
   createPopupRequestCoordinator,
   POPUP_REQUEST_STATUSES
 } from '../src/content-request.mjs'
+import {
+  SETTINGS_STORAGE,
+  createDefaultSecretsV2,
+  createInitialSettingsV2
+} from '../src/settings-v2.mjs'
 
 const VIEWPORT = {
   left: 0,
@@ -232,4 +237,110 @@ test('renders common states inside an isolated shadow popup and closes on outsid
   document.dispatchEvent(new window.KeyboardEvent('keydown', {key: 'Escape', bubbles: true}))
   assert.equal(controller.isOpen(), false)
   dom.window.close()
+})
+
+test('installs dictionary interaction while Chrome Translator availability is pending', async () => {
+  const dom = new JSDOM(
+    '<!doctype html><body><p id="word">hello</p></body>',
+    {url: 'https://example.com/', pretendToBeVisual: true}
+  )
+  const {document, window} = dom.window
+  const settings = createInitialSettingsV2()
+  settings.dictionary.drag.enabled = false
+  const secrets = createDefaultSecretsV2()
+  const listeners = new Set()
+  const storage = {
+    sync: {
+      get: (_keys, callback) => callback({
+        [SETTINGS_STORAGE.settings.key]: settings
+      })
+    },
+    local: {
+      get: (_keys, callback) => callback({
+        [SETTINGS_STORAGE.secrets.key]: secrets
+      })
+    },
+    onChanged: {
+      addListener: listener => listeners.add(listener),
+      removeListener: listener => listeners.delete(listener)
+    }
+  }
+  let resolveAvailability
+  const availability = new Promise(resolve => {
+    resolveAvailability = resolve
+  })
+  const previousGlobals = {
+    chrome: globalThis.chrome,
+    document: globalThis.document,
+    fetch: globalThis.fetch,
+    navigator: globalThis.navigator,
+    self: globalThis.self,
+    window: globalThis.window
+  }
+
+  globalThis.window = window
+  globalThis.document = document
+  globalThis.navigator = window.navigator
+  globalThis.self = window
+  globalThis.fetch = async () => ({ok: false})
+  window.Translator = {
+    availability: () => availability,
+    create: () => Promise.resolve({translate: async () => '안녕'})
+  }
+  globalThis.chrome = {
+    storage,
+    runtime: {
+      getURL: name => `https://extension.test/${name}`,
+      sendMessage: (_request, callback) => callback({
+        ok: true,
+        data: {searchResult: {searchResultList: []}}
+      })
+    },
+    i18n: {getMessage: () => ''}
+  }
+
+  try {
+    const range = document.createRange()
+    const text = document.getElementById('word').firstChild
+    range.setStart(text, 0)
+    range.setEnd(text, text.length)
+    const selection = window.getSelection()
+    selection.removeAllRanges()
+    selection.addRange(range)
+    window.getSelection = () => selection
+
+    const content = await import(`../src/content.js?pending-availability=${Date.now()}`)
+    content.main()
+    await new Promise(resolve => setImmediate(resolve))
+
+    for (let index = 0; index < 2; index += 1) {
+      document.dispatchEvent(new window.MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        clientX: 100,
+        clientY: 100
+      }))
+      document.dispatchEvent(new window.MouseEvent('mouseup', {
+        bubbles: true,
+        button: 0,
+        clientX: 100,
+        clientY: 100
+      }))
+    }
+
+    assert.ok(document.getElementById('popupFrame'))
+    assert.equal(listeners.size, 1)
+
+    resolveAvailability('available')
+    await new Promise(resolve => setImmediate(resolve))
+    content.unregisterEventListener()
+  } finally {
+    globalThis.chrome = previousGlobals.chrome
+    globalThis.document = previousGlobals.document
+    globalThis.fetch = previousGlobals.fetch
+    globalThis.navigator = previousGlobals.navigator
+    globalThis.self = previousGlobals.self
+    globalThis.window = previousGlobals.window
+    dom.window.close()
+  }
 })

--- a/tests/naver-parser.test.mjs
+++ b/tests/naver-parser.test.mjs
@@ -13,7 +13,8 @@ import {
   normalizeHttpUrl,
   normalizeMeanings,
   normalizeString,
-  normalizeStringList
+  normalizeStringList,
+  stripInlineMarkup
 } from '../src/dictionary/normalizer.mjs'
 
 function response(items) {
@@ -199,6 +200,11 @@ test('normalizes scalar and array values consistently', () => {
     '12',
     'false'
   ])
+  assert.equal(
+    stripInlineMarkup('(↔<span class="related_word" lang="en">go out</span>)'),
+    '(↔go out)'
+  )
+  assert.equal(stripInlineMarkup('first<br>second'), 'first\nsecond')
 })
 
 test('normalizes missing and invalid entry fields to the stable contract', () => {
@@ -246,7 +252,7 @@ test('ignores invalid sibling entries while preserving valid response order', ()
   assert.deepEqual(result[1].meanings, [])
 })
 
-test('keeps HTML-looking response values as plain data', () => {
+test('keeps headwords as text and removes markup from dictionary meanings', () => {
   const word = '<img src=x onerror=alert(1)>'
   const meaning = '<script>alert(1)</script>'
   const result = parseNaverDictionaryResponse(response([{
@@ -255,8 +261,28 @@ test('keeps HTML-looking response values as plain data', () => {
   }]))
 
   assert.equal(result[0].word, word)
-  assert.equal(result[0].meanings[0].value, meaning)
+  assert.equal(result[0].meanings[0].value, 'alert(1)')
   assert.ok(!result[0].dictionaryUrl.includes('<'))
+})
+
+test('removes related-word span markup from the come dictionary response', () => {
+  const result = parseNaverDictionaryResponse(response([{
+    handleEntry: 'come',
+    meansCollector: [{
+      partOfSpeech: '동사',
+      means: [
+        {order: 1, value: '(밀물이) 밀려[들어]오다 (↔<span class="related_word" lang="en">go out</span>)'},
+        {order: 2, value: '(경주에서 몇 위로) 들어오다'},
+        {order: 3, value: '유행하다 (↔<span class="related_word" lang="en">go out</span>)'}
+      ]
+    }]
+  }]))
+
+  assert.deepEqual(result[0].meanings, [
+    {order: '1', value: '(밀물이) 밀려[들어]오다 (↔go out)'},
+    {order: '2', value: '(경주에서 몇 위로) 들어오다'},
+    {order: '3', value: '유행하다 (↔go out)'}
+  ])
 })
 
 test('encodes API and dictionary query values', () => {

--- a/tests/packaging.test.mjs
+++ b/tests/packaging.test.mjs
@@ -17,6 +17,12 @@ const manifest = JSON.parse(
 test('package validator covers manifest entry points and web resources', () => {
   const files = collectManifestFiles(manifest)
 
+  assert.equal(
+    (manifest.content_scripts || []).some(script => Array.isArray(script.css)),
+    false,
+    'popup CSS should stay inside its Shadow DOM'
+  )
+
   for (const file of [
     'manifest.json',
     'contentWrapper.js',
@@ -24,6 +30,10 @@ test('package validator covers manifest entry points and web resources', () => {
     'popup.html',
     'options.html',
     'content.css',
+    'content-data.mjs',
+    'content-position.mjs',
+    'content-popup.mjs',
+    'content-request.mjs',
     'messaging.mjs',
     'dictionary/parser.mjs',
     'dictionary/normalizer.mjs',

--- a/vite.config.js
+++ b/vite.config.js
@@ -47,6 +47,22 @@ export default defineConfig({
           dest: '.'
         },
         {
+          src: 'src/content-data.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/content-position.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/content-popup.mjs',
+          dest: '.'
+        },
+        {
+          src: 'src/content-request.mjs',
+          dest: '.'
+        },
+        {
           src: 'src/content-interaction.mjs',
           dest: '.'
         },


### PR DESCRIPTION
## Summary
- Split inline popup positioning, rendering, data transport, and request coordination out of `content.js`.
- Add four-quadrant viewport placement with document/visual viewport coordinates, live selection anchors, scroll/resize/zoom repositioning, and per-frame iframe behavior.
- Add a shared Shadow DOM popup shell with loading, empty, error, dictionary, and translation states; bounded internal scrolling; outside/Escape close; and safer audio controls.
- Ignore or abort superseded popup requests and add locale messages for popup states.
- Keep popup CSS isolated in Shadow DOM and update unpacked/release packaging resources.
- Keep dictionary interaction available while Chrome Translator availability is warming up, so the Translator readiness check cannot suppress double-click lookup.
- Keep the loading state hidden until a settled result is ready, so the popup does not visibly appear in two stages.
- Hide both dictionary and translation title rows so the inline popup shows content directly.
- Normalize Naver inline meaning markup such as related-word `<span>` tags to readable text.
- Mount the popup outside page body coordinate styles and convert document coordinates to the fixed visual viewport.
- Keep popup error text inherited from the user-configured font color.
- Keep the dictionary popup at 360px while widening only the translation popup to 440px; give translation bodies a `line-height: 1.45` while keeping dictionary spacing unchanged.
- Remove failed pronunciation controls without rendering an unavailable-audio message, then reposition the popup after the failed control changes its height.
- Confirm that Naver's pronunciation URL responds as `200 audio/mpeg`; the attached GitHub page's CSP omits `dict-dn.pstatic.net` from `media-src`, so page-injected audio is blocked there.
- Prevent stylesheet/result layout shifts and give long results the full viewport scroll budget.

## Verification
- `yarn lint`
- `yarn test` (152 passing)
- `yarn build`
- `NAVERDIC_ZIP_DIR=/tmp/naverdic-task7-audio-reposition-final-20260824 bash pack.sh` (package validator passed; 42 files in unpacked and ZIP outputs)

## Review focus
- Positioning behavior at viewport edges and under scroll/visual viewport changes.
- Request race handling when selections change quickly.
- Shadow DOM event boundaries and iframe-local content script behavior.
- Dictionary double-click behavior while the Chrome Translator availability promise is pending.
- One-stage popup reveal for loading-to-result transitions.
- No visible dictionary/translation title, readable related-word meanings, stable long-translation popup layout, and isolation from positioned/transformed body styles.
- Dictionary 360px versus translation 440px width behavior and translation line-height readability.
- Failed pronunciation controls disappear silently when the host page blocks the Naver audio CDN and the popup reflows to preserve the configured gap.