### PR TITLE
[NaverDic] refine extension metadata

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -1,9 +1,9 @@
 {
   "APP_NAME": {
-    "message": "Naver English Dictionary - NaverDic"
+    "message": "Naver English Dictionary · NaverDic"
   },
   "APP_DESCRIPTION": {
-    "message": "Enter your own words or select an English word from a webpage to show the definition of the English word. Drag a sentence from a webpage to translate it with Chrome built-in translation, DeepL, or Gemini."
+    "message": "Enter a word directly, or double-click or select an English word on a webpage to look up its meaning. Select a sentence or paragraph to translate it with Chrome's built-in Translator, DeepL, or Gemini."
   },
   "SEARCH": {
     "message": "Search"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -1,9 +1,9 @@
 {
   "APP_NAME": {
-    "message": "네이버 영어사전 - NaverDic"
+    "message": "네이버 영어사전 · NaverDic"
   },
   "APP_DESCRIPTION": {
-    "message": "직접 단어를 입력하거나 웹페이지의 영어 단어를 선택해 영단어의 뜻을 보여줍니다. 웹페이지의 문장을 드래그하면 Chrome 내장 번역, DeepL 또는 Gemini로 번역합니다."
+    "message": "단어를 직접 입력하거나 웹페이지의 영어 단어를 더블클릭·선택해 뜻을 확인합니다. 문장이나 단락을 드래그하면 Chrome 내장 번역, DeepL 또는 Gemini로 번역합니다."
   },
   "SEARCH": {
     "message": "검색"


### PR DESCRIPTION
## Summary
- Update the Korean extension name to `네이버 영어사전 · NaverDic` and the English name to `Naver English Dictionary · NaverDic`.
- Clarify the Korean and English descriptions for direct lookup, double-click/selection lookup, and sentence/paragraph translation.

## Validation
- `yarn lint` — passed
- `yarn test` — 159 passed
- `yarn build` — passed
- `bash pack.sh` — `naverdic_7.0.zip`
- Package validator — 44 unpacked files and ZIP files passed
- `git diff --check` — passed

Manifest i18n wiring remains unchanged.