### PR TITLE
chore: prepare 7.1 release package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ yarn build
 yarn package
 ```
 
-The package command builds and validates `naverdic_<version>.zip`.
+The package command builds, minifies, and validates `naverdic_<version>.zip`.
+Run `./pack.sh` directly when a non-minified package is needed; pass
+`./pack.sh --minify` to enable minification explicitly.
 
 ### Run the webpage development server
 

--- a/pack.sh
+++ b/pack.sh
@@ -5,8 +5,22 @@ PROJECT_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 DIST_DIR="$PROJECT_ROOT/dist"
 VITE_BIN="$PROJECT_ROOT/node_modules/.bin/vite"
 ESBUILD_BIN="$PROJECT_ROOT/node_modules/.bin/esbuild"
+MINIFY=false
 
-if [[ ! -x "$VITE_BIN" || ! -x "$ESBUILD_BIN" ]]; then
+for argument in "$@"; do
+  case "$argument" in
+    --minify)
+      MINIFY=true
+      ;;
+    *)
+      echo "Unknown option: $argument" >&2
+      echo "Usage: $0 [--minify]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "$VITE_BIN" || ( "$MINIFY" == true && ! -x "$ESBUILD_BIN" ) ]]; then
   echo "Missing local build dependencies. Run yarn install first." >&2
   exit 1
 fi
@@ -14,12 +28,14 @@ fi
 cd "$PROJECT_ROOT"
 "$VITE_BIN" build
 
-# Vite copies the raw service/content modules for development. The release
-# package uses minified bundles while retaining the static modules declared by
-# the manifest for unpacked/content-script compatibility.
-"$ESBUILD_BIN" --bundle src/background.js --minify --format=esm --outfile="$DIST_DIR/background.js"
-"$ESBUILD_BIN" --bundle src/content.js --minify --format=esm --outfile="$DIST_DIR/content.js"
-"$ESBUILD_BIN" --bundle src/content.css --minify --outfile="$DIST_DIR/content.css"
+# Vite copies the raw service/content modules for development. The optional
+# release minification keeps the static modules declared by the manifest for
+# unpacked/content-script compatibility.
+if [[ "$MINIFY" == true ]]; then
+  "$ESBUILD_BIN" --bundle src/background.js --minify --format=esm --outfile="$DIST_DIR/background.js"
+  "$ESBUILD_BIN" --bundle src/content.js --minify --format=esm --outfile="$DIST_DIR/content.js"
+  "$ESBUILD_BIN" --bundle src/content.css --minify --outfile="$DIST_DIR/content.css"
+fi
 
 # index.html and its index-* chunks are the repository's development demo, not
 # extension entry points. The demo HTML and favicon are not needed by Chrome.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "naverdic",
   "private": true,
   "type": "module",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "scripts": {
     "dev": "vite",
     "lint": "node scripts/check-source.mjs",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "node --test tests/*.test.mjs",
     "typecheck": "node scripts/check-source.mjs",
     "build": "vite build",
-    "package": "bash pack.sh",
+    "package": "bash pack.sh --minify",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_APP_NAME__",
   "description": "__MSG_APP_DESCRIPTION__",
-  "version": "7.0",
+  "version": "7.1",
   "default_locale": "ko",
   "icons": {
     "16": "icon16.png",

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -7,8 +7,8 @@ const SOURCE_ENTRYPOINTS = [
   'src/content.js'
 ]
 
-export const RELEASE_MANIFEST_VERSION = '7.0'
-export const RELEASE_PACKAGE_VERSION = '7.0.0'
+export const RELEASE_MANIFEST_VERSION = '7.1'
+export const RELEASE_PACKAGE_VERSION = '7.1.0'
 export const PACKAGE_ASSETS = Object.freeze([
   'audio-play.svg'
 ])

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -120,7 +120,7 @@
     "message": "Naver English Dictionary · NaverDic"
   },
   "SETTINGS_PRODUCT_VERSION": {
-    "message": "7.0"
+    "message": "7.1"
   },
   "SETTINGS_SIDEBAR_HEADING": {
     "message": "Settings"

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -120,7 +120,7 @@
     "message": "네이버 영어사전 · NaverDic"
   },
   "SETTINGS_PRODUCT_VERSION": {
-    "message": "7.0"
+    "message": "7.1"
   },
   "SETTINGS_SIDEBAR_HEADING": {
     "message": "설정"

--- a/src/components/DictionaryResult.vue
+++ b/src/components/DictionaryResult.vue
@@ -231,6 +231,8 @@ onBeforeUnmount(() => stopAudio())
   width: 40px;
   height: 28px;
   padding: 0 8px;
+  /* The result inset leaves the control 6px right of the search action center. */
+  margin-right: 6px;
   border: 0;
   border-radius: 8px;
   background: #E8F2FF;

--- a/tests/content-interaction.test.mjs
+++ b/tests/content-interaction.test.mjs
@@ -148,7 +148,10 @@ test('distinguishes vertical/horizontal drags from a double click', () => {
   }, {
     target,
     openPopup: (...args) => opened.push(args),
-    removePopup: () => { removed += 1 }
+    removePopup: () => { removed += 1 },
+    // Keep this interaction sequence deterministic on hosts whose Node
+    // navigator reports macOS (where the ctrl setting maps to Meta).
+    checkTrigger: (event, key) => checkTrigger(event, key, 'Win32')
   })
 
   target.dispatch('mousedown', mouseEvent({clientX: 10, clientY: 10}))

--- a/tests/content-popup.test.mjs
+++ b/tests/content-popup.test.mjs
@@ -399,14 +399,18 @@ test('installs dictionary interaction while Chrome Translator availability is pe
     chrome: globalThis.chrome,
     document: globalThis.document,
     fetch: globalThis.fetch,
-    navigator: globalThis.navigator,
+    navigatorDescriptor: Object.getOwnPropertyDescriptor(globalThis, 'navigator'),
     self: globalThis.self,
     window: globalThis.window
   }
 
   globalThis.window = window
   globalThis.document = document
-  globalThis.navigator = window.navigator
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: window.navigator
+  })
   globalThis.self = window
   globalThis.fetch = async () => ({ok: false})
   window.Translator = {
@@ -464,7 +468,11 @@ test('installs dictionary interaction while Chrome Translator availability is pe
     globalThis.chrome = previousGlobals.chrome
     globalThis.document = previousGlobals.document
     globalThis.fetch = previousGlobals.fetch
-    globalThis.navigator = previousGlobals.navigator
+    if (previousGlobals.navigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', previousGlobals.navigatorDescriptor)
+    } else {
+      delete globalThis.navigator
+    }
     globalThis.self = previousGlobals.self
     globalThis.window = previousGlobals.window
     dom.window.close()

--- a/tests/packaging.test.mjs
+++ b/tests/packaging.test.mjs
@@ -13,15 +13,26 @@ import {
 } from '../scripts/validate-package.mjs'
 
 const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')
+)
+const packScript = fs.readFileSync(path.join(projectRoot, 'pack.sh'), 'utf8')
 const manifest = JSON.parse(
   fs.readFileSync(path.join(projectRoot, 'public/manifest.json'), 'utf8')
 )
+
+test('release packaging opts into minification while direct pack.sh stays raw by default', () => {
+  assert.equal(packageJson.scripts.package, 'bash pack.sh --minify')
+  assert.match(packScript, /MINIFY=false/)
+  assert.match(packScript, /--minify\)/)
+  assert.match(packScript, /if \[\[ "\$MINIFY" == true \]\]; then/)
+})
 
 test('package validator covers manifest entry points and web resources', () => {
   const files = collectManifestFiles(manifest)
 
   assert.equal(manifest.version, RELEASE_MANIFEST_VERSION)
-  assert.equal(JSON.parse(fs.readFileSync(path.join(projectRoot, 'package.json'), 'utf8')).version, RELEASE_PACKAGE_VERSION)
+  assert.equal(packageJson.version, RELEASE_PACKAGE_VERSION)
   assert.equal(manifest.options_ui?.open_in_tab, true)
 
   assert.equal(

--- a/tests/stage2-contracts.test.mjs
+++ b/tests/stage2-contracts.test.mjs
@@ -484,6 +484,7 @@ test('keeps the official Chrome Translator display name and translation panel bo
   assert.match(dictionaryResult, /\.dictionary-result \{[\s\S]*min-height: 216px;[\s\S]*padding: 12px 4px;[\s\S]*overflow: visible/)
   assert.equal(dictionaryResult.includes('dictionary-result--scrollable'), false)
   assert.match(dictionaryResult, /\.dictionary-result__audio-button img \{[\s\S]*width: 18px;[\s\S]*height: 18px/)
+  assert.match(dictionaryResult, /\.dictionary-result__audio-button \{[\s\S]*margin-right: 6px;/)
   assert.match(dictionaryResult, /POPUP_AUDIO_PAUSE_LABEL/)
 
   const preview = fs.readFileSync(path.join(projectRoot, 'src/components/SettingsPreview.vue'), 'utf8')


### PR DESCRIPTION
## Summary
- keep the compact Korean dictionary result layout from master
- align the pronunciation button center with the top search action by moving it 6px left
- make `yarn package` run `bash pack.sh --minify`, while direct `./pack.sh` stays unminified
- bump package, manifest, validator, and localized product versions to 7.1
- stabilize platform-dependent interaction and popup test setup

## Validation
- `npm test` (161 passed)
- `node --test tests/stage2-contracts.test.mjs tests/toolbar-popup.test.mjs tests/packaging.test.mjs tests/locales.test.mjs` (30 passed)
- `npm run lint`
- `npm run build`
- `corepack yarn package` (validated `naverdic_7.1.zip`, manifest version 7.1)
- Chrome popup visual validation is blocked because the Codex Chrome browser-control extension is unavailable; the 6px offset is derived from the fixed production layout dimensions and covered by the CSS contract test.